### PR TITLE
Adds a new issue template for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-template.md
@@ -1,0 +1,26 @@
+---
+name: Bug template
+about: Use this template for describing a bug that needs to be addressed
+title: ""
+labels: Bug
+assignees: ""
+---
+
+### Description
+
+<!--
+  Describe the bug here. If you know when it was introduced, you can include a
+  link to the relevant pull request for more context. You can also include a
+  link to the original implementation issue if you know it.
+-->
+
+### Acceptance criteria
+
+<!--
+  Describe how we'll know the bug is fixed. All standard acceptance criteria
+  should also apply (e.g., tested for accessibility; meets coding standards;
+  etc.).
+-->
+
+- [ ] Tests have been implemented or modified to capture the bug
+- [ ] Changes have been tested for accessibility


### PR DESCRIPTION
## What's wrong?

Documenting bugs is a little different from documenting other work tasks.

## How does this PR fix it? 

This PR adds an issue template for documenting bugs.