### PR TITLE
Get weather description from icons description instead of current observations

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -109,7 +109,7 @@ function get_noaa_icon($observation) {
   ];
 
   $conditionKey = get_api_condition_key($observation);
-  return $apiIconToNoaaMapping[$conditionKey];
+  return $apiKeyToNoaaIconMapping[$conditionKey];
 }
 
 /**

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -98,6 +98,95 @@ function get_noaa_icon($apiIconPath) {
 }
 
 /**
+ * Converts an api.weather.gov icon path to a NOAA weather icon filename.
+ *
+ * @param string $apiIconPath
+ *   The path returned by api.weather.gov.
+ *
+ * @return string
+ *   The filename for the associated NOAA weather icon.
+ */
+function get_noaa_icon($apiIconPath) {
+  $apiIconToNoaaMapping = [
+    "bkn_day" => "mostly_cloudy-day.svg",
+    "bkn_night" => "mostly_cloudy-night.svg",
+    "blizzard_day" => "blizzard_winter_storm.svg",
+    "blizzard_night" => "blizzard_winter_storm.svg",
+    "cold_day" => "cold.svg",
+    "cold_night" => "cold.svg",
+    "dust_day" => "new_dust.svg",
+    "dust_night" => "new_dust.svg",
+    "few_day" => "mostly_clear-day.svg",
+    "few_night" => "mostly_clear-night.svg",
+    "fog_day" => "fog.svg",
+    "fog_night" => "fog.svg",
+    "fzra_day" => "cold.svg",
+    "fzra_night" => "cold.svg",
+    "haze_day" => "hazy_smoke-day.svg",
+    "haze_night" => "fog.svg",
+    "hot_day" => "hot.svg",
+    "hot_night" => "hot.svg",
+    "hurricane_day" => "hurricane.svg",
+    "hurricane_night" => "hurricane.svg",
+    "no data" => "nodata.svg",
+    "ovc_day" => "cloud_overcast.svg",
+    "ovc_night" => "cloud_overcast.svg",
+    "rain_day" => "rain.svg",
+    "rain_fzra_day" => "freezing_rain_sleet.svg",
+    "rain_fzra_night" => "freezing_rain_sleet.svg",
+    "rain_night" => "rain.svg",
+    "rain_showers_day" => "showers_scattered_rain.svg",
+    "rain_showers_hi_day" => "showers_scattered_rain.svg",
+    "rain_showers_hi_night" => "showers_scattered_rain.svg",
+    "rain_showers_night" => "rain_showers.svg",
+    "rain_sleet_day" => "freezing_rain_sleet.svg",
+    "rain_sleet_night" => "freezing_rain_sleet.svg",
+    "rain_snow_day" => "mixed_precip.svg",
+    "rain_snow_night" => "mixed_precip.svg",
+    "sct_day" => "mosty_cleary-day.svg",
+    "sct_night" => "mosty_cleary-night.svg",
+    "skc_day" => "clear_day.svg",
+    "skc_night" => "clear_night.svg",
+    "sleet_day" => "freezing_rain_sleet.svg",
+    "sleet_night" => "freezing_rain_sleet.svg",
+    "smoke_day" => "hazy_smoke-day.svg",
+    "smoke_night" => "hazy_smoke-day.svg",
+    "snow_day" => "snow.svg",
+    "snow_fzra_day" => "mixed_precip.svg",
+    "snow_fzra_night" => "mixed_precip.svg",
+    "snow_night" => "snow.svg",
+    "snow_sleet_day" => "new_snow_sleet.svg",
+    "snow_sleet_night" => "new_snow_sleet.svg",
+    "tornado_day" => "tornado.svg",
+    "tornado_night" => "tornado.svg",
+    "tropical_storm_day" => "hurricane.svg",
+    "tropical_storm_night" => "hurricane.svg",
+    "tsra_day" => "thunderstorm.svg",
+    "tsra_hi_day" => "thunderstorm.svg",
+    "tsra_hi_night" => "thunderstorm.svg",
+    "tsra_night" => "thunderstorm.svg",
+    "tsra_sct_day" => "thunderstorm.svg",
+    "tsra_sct_night" => "thunderstorm.svg",
+    "wind_bkn_day" => "new_windy_cloudy.svg",
+    "wind_bkn_night" => "new_windy_cloudy.svg",
+    "wind_few_day" => "new_windy_cloudy.svg",
+    "wind_few_night" => "new_windy_cloudy.svg",
+    "wind_ovc_day" => "new_windy_cloudy.svg",
+    "wind_ovc_night" => "new_windy_cloudy.svg",
+    "wind_sct_day" => "new_windy_cloudy.svg",
+    "wind_sct_night" => "new_windy_cloudy.svg",
+    "wind_skc_day" => "windy.svg",
+    "wind_skc_night" => "windy.svg",
+  ];
+
+  $url = parse_url($apiIconPath);
+  $apiIconBits = array_slice(explode("/", $url["path"]), -2);
+  $apiIconName = $apiIconBits[1] . "_" . $apiIconBits[0];
+
+  return $apiIconToNoaaMapping[$apiIconName];
+}
+
+/**
  * A service class for fetching weather data.
  */
 class WeatherDataService {


### PR DESCRIPTION
## What's wrong?

As described in #210, the short weather description should come from the descriptions in the API `/icons` endpoint, not from the text in the `/stations/[id]/observations` endpoint.

Closes #210

## How does this PR fix it? 

This PR builds on #208. It adds an additional mapping from the observation API icon name to condition text. It also creates a utility function to derive a conditions key from an observation rather than duplicating that code again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
