### PR TITLE
Add helpers for dumping and restoring the database

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,6 +20,7 @@ RUN set -eux; \
   \
   apt-get update; \
   apt-get install -y --no-install-recommends \
+  default-mysql-client \
   libfreetype6-dev \
   libjpeg-dev \
   libpng-dev \

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,25 @@ cc: clear-cache
 clear-cache: ## Clear and rebuild all Drupal caches (alias cc)
 	docker compose exec drupal drush cache:rebuild
 
+dd: database-dump
+database-dump: ## Dump the current Drupal database to a the dump.sql file. (alias dd)
+	mkdir -p web/config/database
+	docker compose exec drupal bash -c '\
+	  mysqldump \
+	    -h $$DRUPAL_DB_HOST \
+	    -u $$DRUPAL_DB_USERNAME \
+	    -p$$DRUPAL_DB_PASSWORD \
+	    $$DRUPAL_DB_NAME ' > web/config/database/dump.sql
+
+dr: database-restore
+database-restore: ## Restore the Drupal database from the dump.sql file (alias dr)
+	docker compose exec -it drupal bash -c '\
+	  mysql \
+	    -h $$DRUPAL_DB_HOST \
+	    -u $$DRUPAL_DB_USERNAME \
+			-p$$DRUPAL_DB_PASSWORD \
+			$$DRUPAL_DB_NAME < web/config/database/dump.sql'
+
 export-config: ## Export your current Drupal site's configuration to the config directory
 	docker compose exec drupal drush config:export -y
 


### PR DESCRIPTION
## What's wrong?

Sometimes we need to be able to dump and/or restore the database wholesale. Right now we have to do it by hand and it's difficult so we don't do it.

## How does this PR fix it? 

This PR adds Makefile commands for dumping and restoring the database. 

### `make database-dump` or `make dd`
Dumps your current Drupal database to `web/config/database/dump.sql`. It is included in our `.gitignore` so it's not in this PR. Guess we'll share it privately if we need to.

### `make database-restore` or `make dr`
Restores your `web/config/database/dump.sql` file to your Drupal database, replacing anything that is already there. You'll have to provide this file yourself, it's not in our git repo. 😛 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🆕 New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
