### PR TITLE
For demo purposes, swtich to Nashville

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -123,9 +123,11 @@ class WeatherDataService {
   public function getCurrentConditions() {
     date_default_timezone_set('America/New_York');
 
-    // Roughly Minneapolis.
-    $lat = 44.98;
-    $lon = -93.27;
+    // 36°09′44″N 86°46′28″W
+
+    // Roughly Nashville.
+    $lat = 36.16;
+    $lon = -86.77;
 
     $locationResponse = $this->client->get("https://api.weather.gov/points/$lat,$lon");
     $locationMetadata = json_decode($locationResponse->getBody());

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -123,8 +123,6 @@ class WeatherDataService {
   public function getCurrentConditions() {
     date_default_timezone_set('America/New_York');
 
-    // 36°09′44″N 86°46′28″W
-
     // Roughly Nashville.
     $lat = 36.16;
     $lon = -86.77;

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -97,9 +97,9 @@
       <strong>{{ content["#data"]["conditions"]["long"] | lower }}</strong>.
       Temperature is <strong>{{ content["#data"]["temperature"] }}
       &deg;F</strong>. Humidity is <strong>
-      {{ content["#data"]["humidity"] }}%</strong> with
+      {{ content["#data"]["humidity"] }}%</strong>{% if content["#data"]["wind"]["speed"] > 0  %} with
       <strong>{{ content["#data"]["wind"]["speed"] }}mph winds</strong> from
-      the {{ content["#data"]["wind"]["direction"] }}.
+      the {{ content["#data"]["wind"]["direction"] }}{% endif %}.
     </p>
   </section>
 </weather-gov-current-conditions>


### PR DESCRIPTION
## What's wrong?

The location we display in the current conditions is static for now. It currently points to Minneapolis. We want to switch it to Nashville.

## How does this PR fix it? 

- Changes the coordinates from downtown Minneapolis to downtown Nashville
- Modifies the Twig template to make wind speed/direction in the narrative text conditional, based on whether there is any wind.

## Screenshots (if appropriate):

<img width="447" alt="image" src="https://github.com/weather-gov/weather.gov/assets/142943695/55e9e397-4af8-4bf2-80bd-82bf3c50cabb">
