### PR TITLE
Run tests in merge groups

### DIFF
--- a/.github/workflows/code-standards.yaml
+++ b/.github/workflows/code-standards.yaml
@@ -1,5 +1,7 @@
 name: code standards
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   php-lint:
@@ -29,6 +31,3 @@ jobs:
           composer global config allow-plugins true
           composer global require drupal/coder
           phpcs
-
-      # - name: run phpcs
-      #   uses: guix77/phpcs-drupal-action@v1.0.1


### PR DESCRIPTION
## What's wrong?

Our tests currently do not run when added to a merge group, meaning they can never report success and will never successfully merge using merge queues.

## How does this PR fix it? 

This PR updates our tests to run when added to a merge group, enabling us to use merge queues.