### PR TITLE
add a github action that automatically posts our code review template

### DIFF
--- a/.github/workflows/code-review-templates/code-review-generic.md
+++ b/.github/workflows/code-review-templates/code-review-generic.md
@@ -1,0 +1,9 @@
+## Code Review Checklist - Generic (no changes in web or docs detected)
+
+This is an automated comment on every pull request requiring a review. A checked item is either an assertion that I have tested this item or an indication that I have verified it does not apply to this pull request.
+
+## Checklist
+- [ ] Checks are passing
+- [ ] I read the pull request
+- [ ] Documentation added if necessary
+- [ ] Relevant audiences are aware of changes (eng for /architecture, product for /product)

--- a/.github/workflows/code-review-templates/code-review-web.md
+++ b/.github/workflows/code-review-templates/code-review-web.md
@@ -31,7 +31,7 @@ This is an automated comment on every pull request requiring a review. A checked
 
 ## Accessibility
 - [ ] New pages have been added to cypress-axe file so that they will be tested with our automated accessibility testing
-- Meets WCAG 2.0 AA or 2.1 AA for Section 508 compliance
+- [ ] Meets WCAG 2.0 AA or 2.1 AA for Section 508 compliance
     - [ ] Site is keyboard accessible. All interactions can be accessed with a keyboard
     - [ ] Site is free of keyboard traps. The keyboard focus is never trapped in a loop
     - [ ] All form inputs have explicit labels
@@ -52,6 +52,6 @@ This is an automated comment on every pull request requiring a review. A checked
 ## Device Matrix
 - [ ] firefox (renders correctly and user interactions work)
 - [ ] chrome/chromium/edge (renders correctly and user interactions work)
-- web page is readable and usable 
+- [ ] web page is readable and usable 
     - [ ] at 480px
     - [ ] at 1024px

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -1,0 +1,54 @@
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - main
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Github Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Check modified files
+        id: check_files
+        run: |
+          echo "=============== list modified files ==============="
+          git diff --name-only -r HEAD^1 HEAD
+          
+          echo "========== check paths of modified files =========="
+          git diff --name-only -r HEAD^1 HEAD > files.txt
+          # Start with generic CR template
+          template_name='.github/workflows/code-review-templates/code-review-generic.md'
+          while read -r file; do
+            # If any of the files are in web, do a full CR
+            if [[ $file == web/* ]]; then
+              template_name='.github/workflows/code-review-templates/code-review-web.md'
+              break
+            # Change the file from generic to document if any docs changes
+            elif [[ $file == docs/* ]]; then
+              template_name='.github/workflows/code-review-templates/code-review-docs.md'
+            fi
+          done < "files.txt"
+          echo $template_name
+          echo "filename=$template_name" >> "$GITHUB_OUTPUT"
+      - name: Read template file
+        id: get_template_content
+        run: |
+          {
+            echo 'template<<EOF'
+            cat ${{ steps.check_files.outputs.filename }}
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Comment on pull request
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${{ steps.get_template_content.outputs.template }}`
+            })


### PR DESCRIPTION
## What's wrong?

We want to use our code review checklists. This automatically posts the code review checklist on opened pull requests.

## How does this PR fix it? 

There are currently three PR checklists: 
* Generic (posted on every PR if conditions not met - no docs or web files were changed)
* Docs (posted if any docs files are changed but no web files are changed)
* Web, a full CR checklist (posted if any web files are changed)

Should we add documentation for this and if so where? 
 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
