### PR TITLE
Ignore more composer files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,21 @@
 /drush/Commands/contrib/
 /web/profiles/contrib/
 /web/libraries/
+/web/.csslintrc
+/web/.eslintignore
+/web/.eslintrc.json
+/web/.ht.router.php
+/web/.htaccess
+/web/INSTALL.txt
+/web/README.md
+/web/autoload.php
+/web/example.gitignore
+/web/index.php
+/web/robots.txt
+/web/sites/default.settings.php
+/web/sites/default/.gitignore
+/web/update.php
+/web/web.config
 
 # Ignore configuration files that may contain sensitive information.
 /web/sites/*/settings*.php


### PR DESCRIPTION
## What's wrong?
When running `composer install` or `composer require`, there are additional drupal files loads. Those should come from the composer package.

## How does this PR fix it?
Adds those files to our .gitignore.

## Types of changes
- [x] 🆕 New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
