### PR TITLE
Add Make targets for importing/exporting content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,21 +10,28 @@ clear-cache: ## Clear and rebuild all Drupal caches (alias cc)
 export-config: ## Export your current Drupal site's configuration to the config directory
 	docker compose exec drupal drush config:export -y
 
+export-content: ## Export all content to web/scs-export
+	docker compose exec drupal drush content:export node scs-export --all-content
+
 format: ## Format your code according to the Drupal PHP language standard
 	docker compose exec drupal phpcbf
 
 import-config: ## Import the Drupal configuration from the config directory into your site
 	docker compose exec drupal drush config:import -y
 
-install-site: ## Install a minimal Drupal site using the configuration in the config directory
+import-content: web/scs-export/* ## Import content from web/scs-export
+	for file in $^; do \
+		file="$${file#*/}"; \
+		docker compose exec drupal drush content:import "$$file"; \
+	done
+
+install-site: install-site-config import-content ## Install a minimal Drupal site using the configuration in the config directory and exported content
+install-site-config:
+	sleep 5
 	docker compose exec drupal drush site:install minimal --existing-config --account-pass=root -y
 
 lint: ## Run PHP_CodeSniffer on our custom modules and themes
 	docker compose exec drupal phpcs
-
-own-settings: ## Make the settings.php file writable
-	chmod -R 775 web/sites/default/settings.dev.php
-	chmod -R 775 web/sites/default/settings.prod.php
 
 rebuild: ## Delete the Drupal container and rebuild. Does *NOT* delete the site
 	docker compose stop drupal
@@ -32,12 +39,16 @@ rebuild: ## Delete the Drupal container and rebuild. Does *NOT* delete the site
 	docker compose build drupal
 	docker compose up -d
 
+reset-site: reset-site-database install-site ## Delete the database and rebuild it from configuration and exported content
+reset-site-database:
+	docker compose stop database
+	docker compose rm database -f
+	docker compose up -d
+
 shell: ## Get a shell inside the Drupal container
 	docker compose exec drupal bash
 
-zap: ## Delete the entire Docker environment and start from scratch.
+zap: zap-containers rebuild install-site ## Delete the entire Docker environment and start from scratch.
+zap-containers:
 	docker compose stop
 	docker compose rm -f
-	docker compose build
-	docker compose up -d
-	

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -1,0 +1,60 @@
+# Development
+
+## Getting started
+
+We use Docker to take care of all the heavy lifting for setup and configuration.
+To get up and running quickly with Docker, ensure you have Docker installed and
+then:
+
+1. Clone this repository into a new directory and `cd` into it.
+2. Run `docker compose up` from the command line.
+3. Install our site configuration by running `make install-site`.
+4. Browse to [http://localhost:8080](http://localhost:8080) in your broswer. You
+   should see our front page! Congrats!
+5. Browse to [http://localhost:8080/user/login](http://localhost:8080/user/login)
+   to log in. Your username is `admin` and your password is `root`. Then you can
+   do stuff!
+
+## Managing Drupal in the container
+
+We have a Makefile that scripts some of the routine development tasks we have
+with Drupal or Drush. That Makefile takes care of making sure your commands are
+run inside the correct container. To get the full list of self-documented Make
+targets, just run
+
+```sh
+make
+```
+
+from the root of this project. (A target is essentially what Make calls its
+scripts. You run a target by running `make [target name]`.) The self-documented
+target list should always be the most up-to-date, but the list of targets here
+should also be maintained:
+
+| target                | description                                                                                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `help`                | Shows the list of make targets                                                                                                                                                 |
+| `clear-cache or `cc`  | Runs `drush cache:rebuild`                                                                                                                                                     |
+| `export-config`       | Exports the current Drupal configuration to Yaml files                                                                                                                         |
+| `export-content`      | Exports all current content using the single_content_sync module. Produces either a bunch of Yaml files or a single zip file, depending on the available content.              |
+| `format`              | Runs `phpcbf` to format all of our PHP code according to the style guide                                                                                                       |
+| `import-config`       | Imports configuration from Yaml files into Drupal                                                                                                                              |
+| `import-content`      | Imports content using the single_content_sync module, from a bunch of Yaml or zip files produced in a previous export                                                          |
+| `install-site`        | Installs a new minimal Drupal site using our previously-exported configuration and populated with previously-exported content                                                  |
+| `lint`                | Runs `phpcs` to scan all of our PHP code for conformance to our code style guide                                                                                               |
+| `rebuild`             | Destroy and rebuild the Drupal container, but leaves the database intact                                                                                                       |
+| `reset-site`          | Destroys and rebuilds the database but leaves Drupal intact                                                                                                                    |
+| `shell`               | Get a shell inside the Drupal container. This allows running `drush` commands.                                                                                                 |
+| `zap`                 | Destroys all containers and rebuilds, including re-populating the database. This can be helpful if you've made a bunch of changes and suddenly everything has stopped working. |
+| `install-site-config` | **[HIDDEN]** Installs a new minimal site using our previously-exported configuration, but does not import content                                                              |
+| `reset-site-database` | **[HIDDEN]** Destroys and recreates the database, but does not repopulate it with anything                                                                                     |
+| `zap-containers`      | **[HIDDEN]** Destroys and recreates all containers, but does not repopulate anything.                                                                                          |
+
+> [!NOTE]  
+> The hidden targets are valid and can be used, but they mostly just exist as
+> reusable components for other targets. For example, the `zap` target is just
+> alias to call:
+>
+> - `zap-containers`
+> - `rebuild`
+> - `install-site`


### PR DESCRIPTION
## What's wrong?

We have content exported with the single_content_sync (scs) module, but we don't have tools to make it easier to reimport (or even re-export).

## How does this PR fix it? 

This PR adds some Makefile targets:
- `export-content` will export all content using scs
- `import-content` will import content previously exported by scs
- `reset-site` will wipe the database and start over with a clean site install, configuration, and scs content, but does not touch the Drupal container

Additionally, the following Makefile targets were updated:
- `install-site` and `zap` will both now load scs content in addition to loading configuration

Lastly, this PR adds a new `docs/dev/index.md` document that contains getting-started info and a list of Makefile targets and what they do. This serves as the initial movement towards developer documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🆕 New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
