### PR TITLE
Fix wind direction in the current conditions component

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherDataService.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php.test
@@ -81,18 +81,20 @@ final class WeatherDataServiceTest extends TestCase {
         "long" => "Snow",
         "short" => "Snow",
       ],
-      "feels_like" => 45.0,
-      "humidity" => 88.0,
+      "feels_like" => 45,
+      "humidity" => 88,
       "icon" => "snow.svg",
       "location" => "National Weather Service",
-      "temperature" => 45.0,
+      "temperature" => 45,
       "timestamp" => [
         "formatted" => "Thursday 8:00 PM GMT+0000",
         "utc" => "1697140800",
       ],
       "wind" => [
         "speed" => 13,
-        "direction" => 310,
+        "angle" => 310,
+        "direction" => "northwest",
+        "shortDirection" => "NW",
       ],
     ];
   }
@@ -102,7 +104,6 @@ final class WeatherDataServiceTest extends TestCase {
    */
   public function testHappyPathWithNoFeelsLike(): void {
     $expected = $this->setupHappyPath("observation.good-no-feelslike.json");
-    $expected["feels_like"] = 45.0;
 
     $actual = $this->weatherDataService->getCurrentConditions();
 
@@ -114,7 +115,7 @@ final class WeatherDataServiceTest extends TestCase {
    */
   public function testHappyPathWithHeatIndex(): void {
     $expected = $this->setupHappyPath("observation.good-heatindex.json");
-    $expected["feels_like"] = 117.0;
+    $expected["feels_like"] = 117;
 
     $actual = $this->weatherDataService->getCurrentConditions();
 
@@ -126,7 +127,7 @@ final class WeatherDataServiceTest extends TestCase {
    */
   public function testHappyPathWithWindChill(): void {
     $expected = $this->setupHappyPath("observation.good-windchill.json");
-    $expected["feels_like"] = 16.0;
+    $expected["feels_like"] = 16;
 
     $actual = $this->weatherDataService->getCurrentConditions();
 
@@ -138,11 +139,85 @@ final class WeatherDataServiceTest extends TestCase {
    */
   public function testHappyPathWithHeatIndexAndWindChill(): void {
     $expected = $this->setupHappyPath("observation.good-both.json");
-    $expected["feels_like"] = 194.0;
+    $expected["feels_like"] = 194;
 
     $actual = $this->weatherDataService->getCurrentConditions();
 
     $this->assertEquals((object) $expected, (object) $actual);
+  }
+
+  /**
+   * Tests that the wind direction is populated correctly.
+   *
+   * This tests the 8 cardinal and ordinal directions.
+   */
+  public function testWindDirections(): void {
+    $scenarios = [
+      [0, "north", "N"],
+      [45, "northeast", "NE"],
+      [90, "east", "E"],
+      [135, "southeast", "SE"],
+      [180, "south", "S"],
+      [225, "southwest", "SW"],
+      [270, "west", "W"],
+      [315, "northwest", "NW"],
+      [360, "north", "N"],
+    ];
+
+    $observationResponse = json_decode(file_get_contents(__DIR__ . "/test_data/observation.good-no-feelslike.json"));
+
+    $expected = [
+      "conditions" => [
+        "long" => "Snow",
+        "short" => "Snow",
+      ],
+      "feels_like" => 45,
+      "humidity" => 88,
+      "icon" => "snow.svg",
+      "location" => "National Weather Service",
+      "temperature" => 45,
+      "timestamp" => [
+        "formatted" => "Thursday 8:00 PM GMT+0000",
+        "utc" => "1697140800",
+      ],
+      "wind" => [
+        "speed" => 13,
+        "angle" => 310,
+        "direction" => "northwest",
+        "shortDirection" => "NW",
+      ],
+    ];
+
+    foreach ($scenarios as $scenario) {
+      $observationResponse->features[0]->properties->windDirection->value = $scenario[0];
+
+      $expected["wind"]["angle"] = $scenario[0];
+      $expected["wind"]["direction"] = $scenario[1];
+      $expected["wind"]["shortDirection"] = $scenario[2];
+
+      $this->httpClientMock->append(
+        new Response(200,
+          ['Content-type' => 'application/geo+json'],
+          file_get_contents(__DIR__ . "/test_data/points.good.json")
+        )
+      );
+      $this->httpClientMock->append(
+        new Response(200,
+          ['Content-type' => 'application/geo+json'],
+          file_get_contents(__DIR__ . "/test_data/observation-stations.good.json")
+        )
+      );
+      $this->httpClientMock->append(
+        new Response(200,
+          ['Content-type' => 'application/geo+json'],
+          json_encode($observationResponse)
+        ),
+      );
+
+      $actual = $this->weatherDataService->getCurrentConditions();
+
+      $this->assertEquals((object) $expected, (object) $actual);
+    }
   }
 
 }

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -39,10 +39,9 @@
             {{ source(directory ~ "/assets/images/weather/icons/humidity.svg") }}
             {{ "Humidity: @humidity%" | t({ "@humidity": content["#data"]["humidity"] }) }}
           </p>
-          <p class="margin-0 item">
-            {#  #}
+          <p class="item">
             {{ source(directory ~ "/assets/images/weather/icons/wind.svg") }}
-            {{ "Wind: @windSpeed mph" | t({ "@windSpeed": content["#data"]["wind"]["speed"] }) }}
+            {{ "Wind: @windSpeed mph @windDirection" | t({ "@windSpeed": content["#data"]["wind"]["speed"], "@windDirection": content["#data"]["wind"]["shortDirection"] }) }}
           </p>
         </div>
       </div>
@@ -64,8 +63,8 @@
         "with <strong>@windSpeed mph winds</strong> from the @windDirection"
         |
         t({
-          "@windSpeed": content["#data"]["speed"],
-          "@windDirection": content["#data"]["direction"]
+          "@windSpeed": content["#data"]["wind"]["speed"],
+          "@windDirection": content["#data"]["wind"]["direction"]
         })
       }}{% endif %}.
     </p>


### PR DESCRIPTION
## What's wrong?

The wind direction is displayed as degrees from north instead of the useful cardinal and ordinal names (north, northeast, etc.). See #301.

## How does this PR fix it? 

Sets the `direction` to a cardinal or ordinal name, adds `shortDirection` for the short version of the name, and moves the angle to an `angle` property.

Fixes #301.

## Screenshots (if appropriate):

<img width="511" alt="image" src="https://github.com/weather-gov/weather.gov/assets/142943695/91fbeffe-6347-47c5-b110-b38281a73d39">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
