### PR TITLE
Pair down pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,9 @@
-## What's wrong?
+## What does this PR do? 🛠️
+<!--- Describe what to expect after this change is implemented -->
 
-## How does this PR fix it? 
+## What does the reviewer need to know? 🤔
+<!--- Include any local deployment instructions, navigation instructions, etc -->
 
-## Screenshots (if appropriate):
+## Screenshots (if appropriate): 📸
 
-## Types of changes
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-- [ ] 🆕 New feature (non-breaking change which adds functionality)
-- [ ] ⚒️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
-
-## Checklist:
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] My code follows the code style of this project.
-- [ ] My change requires a change to the documentation.
-- [ ] I have updated the documentation accordingly.
+<!--- Make sure you add a subject matter expert to the Reviewers list -->


### PR DESCRIPTION
## What's wrong?
<!--- Describe what to expect after this change is implemented -->
Current PR asks for more info than a requester needs.

## How does this PR fix it? 
This PR remove change type and checklist sections. It also adds instructional comments.

Compare this PR with new one https://github.com/weather-gov/weather.gov/blob/effea79ae1852b3b0baa92d7cfe11f88a65009fa/.github/pull_request_template.md

## Screenshots (if appropriate): 
**before:**
![image](https://github.com/weather-gov/weather.gov/assets/144830694/d44738d7-91b5-4cbe-859c-596cdaaa5b31)

**after:** 
![image](https://github.com/weather-gov/weather.gov/assets/144830694/0bee962e-c9f8-4a98-bfcb-bc6c019a828c)

