### PR TITLE
Update .stylelintrc.js

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: "stylelint-config-standard-scss",
+	"rules": {
+		"selector-class-pattern": null,
+  }
 };


### PR DESCRIPTION
## What's wrong?
When Stylelint checks sass files, it throws an error on any classes with a double underscore (__). This is because the default settings is expecting kebab-case classes only. We're using USWDS, which uses a combo of double underscores and hyphens (aka kebabs). 

## How does this PR fix it? 
Adds a rule to stylelintrc.js to ignore selector class patterns, since we should only be using USWDS utility classes. Reference: https://github.com/WordPress/gutenberg/issues/28616

## Screenshots (if appropriate):
error:
![image](https://github.com/weather-gov/weather.gov/assets/144830694/0a697940-4d29-44f1-847a-0b7d565016c6)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

