### PR TITLE
Make the current conditions component translation-ready

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\weather_data\Service;
 
+use Drupal\Core\StringTranslation\TranslationInterface;
 use GuzzleHttp\ClientInterface;
 
 /**
@@ -210,10 +211,18 @@ class WeatherDataService {
   private $client;
 
   /**
+   * Translation provider.
+   *
+   * @var \Drupal\Core\StringTranslation\TranslationInterface t
+   */
+  private $t;
+
+  /**
    * Constructor.
    */
-  public function __construct(ClientInterface $httpClient) {
+  public function __construct(ClientInterface $httpClient, TranslationInterface $t) {
     $this->client = $httpClient;
+    $this->t = $t;
   }
 
   /**
@@ -256,12 +265,12 @@ class WeatherDataService {
 
     return [
       'conditions' => [
-        'long' => $description,
-        'short' => $description,
+        'long' => $this->t->translate($description),
+        'short' => $this->t->translate($description),
       ],
       // C to F.
       'feels_like' => round($feelsLike),
-      'humidity' => round($obs->relativeHumidity->value),
+      'humidity' => round($obs->relativeHumidity->value ?? 0),
       'icon' => get_noaa_icon($obs) ,
       'location' => $location,
       // C to F.

--- a/web/modules/weather_data/src/Service/WeatherDataService.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php.test
@@ -4,6 +4,7 @@ namespace Drupal\weather_data\Service;
 
 include_once "WeatherDataService.php";
 
+use Drupal\Core\StringTranslation\TranslationInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -38,7 +39,18 @@ final class WeatherDataServiceTest extends TestCase {
     $stack = HandlerStack::create($this->httpClientMock);
     $client = new Client(['handler' => $stack]);
 
-    $this->weatherDataService = new WeatherDataService($client);
+    // Just return the input string. The translation manager is tested by Drupal
+    // so we don't need to.
+    $translationManager = $this->createStub(TranslationInterface::class);
+    $translationManager->method('translate')->will(
+      $this->returnCallback(
+        function ($str) {
+          return $str;
+        }
+      )
+    );
+
+    $this->weatherDataService = new WeatherDataService($client, $translationManager);
   }
 
   /**

--- a/web/modules/weather_data/weather_data.services.yml
+++ b/web/modules/weather_data/weather_data.services.yml
@@ -1,4 +1,4 @@
 services:
   weather_data:
     class: Drupal\weather_data\Service\WeatherDataService
-    arguments: ['@http_client']
+    arguments: ['@http_client', '@string_translation']

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -7,7 +7,8 @@
     <h1>{{ content["#data"]["location"] }}</h1>
 
     <p class="margin-0 font-body-3xs text-gray-50">
-      Weather as of
+      {{ 'Weather as of' | t }}
+      {# Datetimes are localized in client-side Javascript. #}
       <weather-timestamp data-utc="{{ content["#data"]["timestamp"]["utc"] }}">
         {{ content["#data"]["timestamp"]["formatted"] }}
       </weather-timestamp>
@@ -33,25 +34,40 @@
             {{ content["#data"]["feels_like" ]}}
             <span class="font-body-3xs">&deg;F</span>
           </p>
-          <p class="margin-0 font-body-3xs text-gray-50">Feels like</p>
+          <p class="margin-0 font-body-3xs text-gray-50">{{ "Feels like" | t }}</p>
           <p class="margin-0 item">
-            {{ source(directory ~ "/assets/images/weather/icons/humidity.svg") }} Humidity: {{ content["#data"]["humidity"] }}%
+            {{ source(directory ~ "/assets/images/weather/icons/humidity.svg") }}
+            {{ "Humidity: @humidity%" | t({ "@humidity": content["#data"]["humidity"] }) }}
           </p>
           <p class="margin-0 item">
-            {{ source(directory ~ "/assets/images/weather/icons/wind.svg") }}Wind: {{ content["#data"]["wind"]["speed"] }} mph {{ content["#data"]["wind"]["direction"] }}
+            {#  #}
+            {{ source(directory ~ "/assets/images/weather/icons/wind.svg") }}
+            {{ "Wind: @windSpeed mph" | t({ "@windSpeed": content["#data"]["wind"]["speed"] }) }}
           </p>
         </div>
       </div>
     </div>
 
     <p class="conditions-narrative long">
-      The weather in <strong>{{ content["#data"]["location"] }}</strong> is
-      <strong>{{ content["#data"]["conditions"]["long"] | lower }}</strong>.
-      Temperature is <strong>{{ content["#data"]["temperature"] }}
-      &deg;F</strong>. Humidity is <strong>
-      {{ content["#data"]["humidity"] }}%</strong>{% if content["#data"]["wind"]["speed"] > 0  %} with
-      <strong>{{ content["#data"]["wind"]["speed"] }}mph winds</strong> from
-      the {{ content["#data"]["wind"]["direction"] }}{% endif %}.
+      {{ "The weather in <strong>@place</strong> is <strong>@conditions</strong>.
+          Temperature is <strong>@temperature&deg;F</strong>.
+          Humidity is <strong>@humidity%</strong>"
+          |
+          t({
+            "@place": content["#data"]["location"],
+            "@conditions": content["#data"]["conditions"]["long"] | lower,
+            "@temperature": content["#data"]["temperature"],
+            "@humidity": content["#data"]["humidity"]
+          })
+      }}{% if content["#data"]["wind"]["speed"] > 0 %}
+      {{
+        "with <strong>@windSpeed mph winds</strong> from the @windDirection"
+        |
+        t({
+          "@windSpeed": content["#data"]["speed"],
+          "@windDirection": content["#data"]["direction"]
+        })
+      }}{% endif %}.
     </p>
   </section>
 </weather-gov-current-conditions>


### PR DESCRIPTION
## What does this PR do? 🛠️

- In the Twig template, runs translatable strings through the `t` filter.
- In the WeatherDataService, sends the current conditions text (e.g., "mostly sunny") through the translation manager
   - I did this translation in the service because it is data from the API. Doing the translation in Twig would be funky because the current conditions text is a variable, so it would have to be double-translated, and that seemed dirty:
   ```php
   {{ "The weather in @place is {{ $data["condition"] | t }}" | t }}
   ``` 
  Also, ☝️ that doesn't work.
- Updates tests to inject a mock translation manager.

Closes #204

## What does the reviewer need to know? 🤔

None, I guess. We don't actually have translations setup, so we can't be sure that this works as expected yet. But that'll come. I reckon for now we're just making sure the code makes sense.