### PR TITLE
Bug fix: catch when the icon is empty or null

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -23,7 +23,7 @@ function get_api_condition_key($observation) {
    */
   $icon = $observation->icon;
 
-  if($icon == NULL or strlen($icon) == 0) {
+  if ($icon == NULL or strlen($icon) == 0) {
     return "no data";
   }
 

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -21,6 +21,11 @@ function get_api_condition_key($observation) {
   The last two path segments are the ones we need to identify the current
   conditions.
    */
+  $icon = $observation->icon;
+
+  if($icon == NULL or strlen($icon) == 0) {
+    return "no data";
+  }
 
   $url = parse_url($observation->icon);
   $apiConditionKey = implode("/", array_slice(explode("/", $url["path"]), -2));

--- a/web/modules/weather_data/src/Service/WeatherDataService.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php.test
@@ -145,7 +145,7 @@ final class WeatherDataServiceTest extends TestCase {
     $this->assertEquals((object) $expected, (object) $actual);
   }
 
-    /**
+  /**
    * Tests the case where the icon is null.
    */
   public function testIconIsNull(): void {

--- a/web/modules/weather_data/src/Service/WeatherDataService.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php.test
@@ -174,7 +174,8 @@ final class WeatherDataServiceTest extends TestCase {
     $this->assertEquals((object) $expected, (object) $actual);
   }
 
-  /* Tests that the wind direction is populated correctly.
+  /**
+   * Tests that the wind direction is populated correctly.
    *
    * This tests the 8 cardinal and ordinal directions.
    */

--- a/web/modules/weather_data/src/Service/WeatherDataService.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php.test
@@ -145,4 +145,32 @@ final class WeatherDataServiceTest extends TestCase {
     $this->assertEquals((object) $expected, (object) $actual);
   }
 
+    /**
+   * Tests the case where the icon is null.
+   */
+  public function testIconIsNull(): void {
+    $expected = $this->setupHappyPath("observation.bad-null-icon.json");
+    $expected["icon"] = "nodata.svg";
+    $expected["conditions"]["short"] = "No data";
+    $expected["conditions"]["long"] = "No data";
+
+    $actual = $this->weatherDataService->getCurrentConditions();
+
+    $this->assertEquals((object) $expected, (object) $actual);
+  }
+
+  /**
+   * Tests the case where the icon is an empty string.
+   */
+  public function testIconIsEmptyString(): void {
+    $expected = $this->setupHappyPath("observation.bad-empty-icon.json");
+    $expected["icon"] = "nodata.svg";
+    $expected["conditions"]["short"] = "No data";
+    $expected["conditions"]["long"] = "No data";
+
+    $actual = $this->weatherDataService->getCurrentConditions();
+
+    $this->assertEquals((object) $expected, (object) $actual);
+  }
+
 }

--- a/web/modules/weather_data/src/Service/test_data/observation.bad-empty-icon.json
+++ b/web/modules/weather_data/src/Service/test_data/observation.bad-empty-icon.json
@@ -1,0 +1,170 @@
+{
+  "@context": [
+    "https://geojson.org/geojson-ld/geojson-context.jsonld",
+    {
+      "@version": "1.1",
+      "wx": "https://api.weather.gov/ontology#",
+      "s": "https://schema.org/",
+      "geo": "http://www.opengis.net/ont/geosparql#",
+      "unit": "http://codes.wmo.int/common/unit/",
+      "@vocab": "https://api.weather.gov/ontology#",
+      "geometry": {
+        "@id": "s:GeoCoordinates",
+        "@type": "geo:wktLiteral"
+      },
+      "city": "s:addressLocality",
+      "state": "s:addressRegion",
+      "distance": {
+        "@id": "s:Distance",
+        "@type": "s:QuantitativeValue"
+      },
+      "bearing": {
+        "@type": "s:QuantitativeValue"
+      },
+      "value": {
+        "@id": "s:value"
+      },
+      "unitCode": {
+        "@id": "s:unitCode",
+        "@type": "@id"
+      },
+      "forecastOffice": {
+        "@type": "@id"
+      },
+      "forecastGridData": {
+        "@type": "@id"
+      },
+      "publicZone": {
+        "@type": "@id"
+      },
+      "county": {
+        "@type": "@id"
+      }
+    }
+  ],
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "id": "https://observation",
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0, 0]
+      },
+      "properties": {
+        "@id": "https://observation",
+        "@type": "wx:ObservationStation",
+        "elevation": {
+          "unitCode": "wmoUnit:m",
+          "value": 0
+        },
+        "station": "https://observation-station-1",
+        "timestamp": "2023-10-12T20:00:00+00:00",
+        "rawMessage": "ARGLE BARGLE FLARGLE FLARGLE",
+        "textDescription": "It's really coming down out there",
+        "icon": "",
+        "presentWeather": [
+          {
+            "intensity": "light",
+            "modifier": null,
+            "weather": "snow",
+            "rawString": "-SN"
+          },
+          {
+            "intensity": null,
+            "modifier": null,
+            "weather": "fog_mist",
+            "rawString": "BR"
+          }
+        ],
+        "temperature": {
+          "unitCode": "wmoUnit:degC",
+          "value": 7,
+          "qualityControl": "V"
+        },
+        "dewpoint": {
+          "unitCode": "wmoUnit:degC",
+          "value": 0,
+          "qualityControl": "V"
+        },
+        "windDirection": {
+          "unitCode": "wmoUnit:degree_(angle)",
+          "value": 310,
+          "qualityControl": "V"
+        },
+        "windSpeed": {
+          "unitCode": "wmoUnit:km_h-1",
+          "value": 21,
+          "qualityControl": "V"
+        },
+        "windGust": {
+          "unitCode": "wmoUnit:km_h-1",
+          "value": null,
+          "qualityControl": "Z"
+        },
+        "barometricPressure": {
+          "unitCode": "wmoUnit:Pa",
+          "value": 100920,
+          "qualityControl": "V"
+        },
+        "seaLevelPressure": {
+          "unitCode": "wmoUnit:Pa",
+          "value": 100780,
+          "qualityControl": "V"
+        },
+        "visibility": {
+          "unitCode": "wmoUnit:m",
+          "value": 1610,
+          "qualityControl": "C"
+        },
+        "maxTemperatureLast24Hours": {
+          "unitCode": "wmoUnit:degC",
+          "value": null
+        },
+        "minTemperatureLast24Hours": {
+          "unitCode": "wmoUnit:degC",
+          "value": null
+        },
+        "precipitationLastHour": {
+          "unitCode": "wmoUnit:mm",
+          "value": 3,
+          "qualityControl": "C"
+        },
+        "precipitationLast3Hours": {
+          "unitCode": "wmoUnit:mm",
+          "value": 6,
+          "qualityControl": "C"
+        },
+        "precipitationLast6Hours": {
+          "unitCode": "wmoUnit:mm",
+          "value": 9,
+          "qualityControl": "Z"
+        },
+        "relativeHumidity": {
+          "unitCode": "wmoUnit:percent",
+          "value": 88,
+          "qualityControl": "V"
+        },
+        "windChill": {
+          "unitCode": "wmoUnit:degC",
+          "value": null,
+          "qualityControl": "V"
+        },
+        "heatIndex": {
+          "unitCode": "wmoUnit:degC",
+          "value": null,
+          "qualityControl": "V"
+        },
+        "cloudLayers": [
+          {
+            "base": {
+              "unitCode": "wmoUnit:m",
+              "value": 370
+            },
+            "amount": "VV"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/web/modules/weather_data/src/Service/test_data/observation.bad-null-icon.json
+++ b/web/modules/weather_data/src/Service/test_data/observation.bad-null-icon.json
@@ -1,0 +1,170 @@
+{
+  "@context": [
+    "https://geojson.org/geojson-ld/geojson-context.jsonld",
+    {
+      "@version": "1.1",
+      "wx": "https://api.weather.gov/ontology#",
+      "s": "https://schema.org/",
+      "geo": "http://www.opengis.net/ont/geosparql#",
+      "unit": "http://codes.wmo.int/common/unit/",
+      "@vocab": "https://api.weather.gov/ontology#",
+      "geometry": {
+        "@id": "s:GeoCoordinates",
+        "@type": "geo:wktLiteral"
+      },
+      "city": "s:addressLocality",
+      "state": "s:addressRegion",
+      "distance": {
+        "@id": "s:Distance",
+        "@type": "s:QuantitativeValue"
+      },
+      "bearing": {
+        "@type": "s:QuantitativeValue"
+      },
+      "value": {
+        "@id": "s:value"
+      },
+      "unitCode": {
+        "@id": "s:unitCode",
+        "@type": "@id"
+      },
+      "forecastOffice": {
+        "@type": "@id"
+      },
+      "forecastGridData": {
+        "@type": "@id"
+      },
+      "publicZone": {
+        "@type": "@id"
+      },
+      "county": {
+        "@type": "@id"
+      }
+    }
+  ],
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "id": "https://observation",
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0, 0]
+      },
+      "properties": {
+        "@id": "https://observation",
+        "@type": "wx:ObservationStation",
+        "elevation": {
+          "unitCode": "wmoUnit:m",
+          "value": 0
+        },
+        "station": "https://observation-station-1",
+        "timestamp": "2023-10-12T20:00:00+00:00",
+        "rawMessage": "ARGLE BARGLE FLARGLE FLARGLE",
+        "textDescription": "It's really coming down out there",
+        "icon": null,
+        "presentWeather": [
+          {
+            "intensity": "light",
+            "modifier": null,
+            "weather": "snow",
+            "rawString": "-SN"
+          },
+          {
+            "intensity": null,
+            "modifier": null,
+            "weather": "fog_mist",
+            "rawString": "BR"
+          }
+        ],
+        "temperature": {
+          "unitCode": "wmoUnit:degC",
+          "value": 7,
+          "qualityControl": "V"
+        },
+        "dewpoint": {
+          "unitCode": "wmoUnit:degC",
+          "value": 0,
+          "qualityControl": "V"
+        },
+        "windDirection": {
+          "unitCode": "wmoUnit:degree_(angle)",
+          "value": 310,
+          "qualityControl": "V"
+        },
+        "windSpeed": {
+          "unitCode": "wmoUnit:km_h-1",
+          "value": 21,
+          "qualityControl": "V"
+        },
+        "windGust": {
+          "unitCode": "wmoUnit:km_h-1",
+          "value": null,
+          "qualityControl": "Z"
+        },
+        "barometricPressure": {
+          "unitCode": "wmoUnit:Pa",
+          "value": 100920,
+          "qualityControl": "V"
+        },
+        "seaLevelPressure": {
+          "unitCode": "wmoUnit:Pa",
+          "value": 100780,
+          "qualityControl": "V"
+        },
+        "visibility": {
+          "unitCode": "wmoUnit:m",
+          "value": 1610,
+          "qualityControl": "C"
+        },
+        "maxTemperatureLast24Hours": {
+          "unitCode": "wmoUnit:degC",
+          "value": null
+        },
+        "minTemperatureLast24Hours": {
+          "unitCode": "wmoUnit:degC",
+          "value": null
+        },
+        "precipitationLastHour": {
+          "unitCode": "wmoUnit:mm",
+          "value": 3,
+          "qualityControl": "C"
+        },
+        "precipitationLast3Hours": {
+          "unitCode": "wmoUnit:mm",
+          "value": 6,
+          "qualityControl": "C"
+        },
+        "precipitationLast6Hours": {
+          "unitCode": "wmoUnit:mm",
+          "value": 9,
+          "qualityControl": "Z"
+        },
+        "relativeHumidity": {
+          "unitCode": "wmoUnit:percent",
+          "value": 88,
+          "qualityControl": "V"
+        },
+        "windChill": {
+          "unitCode": "wmoUnit:degC",
+          "value": null,
+          "qualityControl": "V"
+        },
+        "heatIndex": {
+          "unitCode": "wmoUnit:degC",
+          "value": null,
+          "qualityControl": "V"
+        },
+        "cloudLayers": [
+          {
+            "base": {
+              "unitCode": "wmoUnit:m",
+              "value": 370
+            },
+            "amount": "VV"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do? 🛠️

- Adds tests to cover the cases where the API returns null or an empty string for the icon of an observation
- Updates the weather data service to properly handle those cases.

Closes #333.

## What does the reviewer need to know? 🤔

This one's pretty straightforward, I think.