### PR TITLE
Add a missing step to the developer docs

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -10,18 +10,22 @@ To get up and running quickly with Docker, ensure you have Docker installed and
 then:
 
 1. Clone this repository into a new directory and `cd` into it.
-2. Run `make zap` from the command line.  
+2. Copy the file at `web/sites/example.settings.dev.php` to
+   `web/sites/settings.dev.php` and make any necessary changes.
+   > [!NOTE]  
+   > As of this writing, no changes are necessary.
+3. Run `make zap` from the command line.  
    This command will first attempt to destroy any weather.gov 2.0 containers you
    have, so you may notice some warnings on the command line. It is safe to
    ignore those warnings. After the warnings, it will build all of the necessary
    containers, create a Drupal site with our configuration, and populate the
    site with our content.
-3. Run `npm ci` from the command line.  
+4. Run `npm ci` from the command line.  
    This installs our Javascript and Sass code linters and formatters, as well as
    Cypress, which is necessary for end-to-end and accessibility testing.
-4. Browse to [http://localhost:8080](http://localhost:8080) in your broswer. You
+5. Browse to [http://localhost:8080](http://localhost:8080) in your broswer. You
    should see our front page! Congrats!
-5. Browse to [http://localhost:8080/user/login](http://localhost:8080/user/login)
+6. Browse to [http://localhost:8080/user/login](http://localhost:8080/user/login)
    to log in. Your username is `admin` and your password is `root`. Then you can
    do stuff!
 


### PR DESCRIPTION
## What does this PR do? 🛠️

The "getting started" part of the dev docs is missing the step for setting up the `settings.dev.php` file.

## What does the reviewer need to know? 🤔

Adds that step!