### PR TITLE
Make the max_items configuration for hourly forecast settable in the Drupal UI

### DIFF
--- a/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
@@ -3,6 +3,7 @@
 namespace Drupal\weather_blocks\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Provides a block of the hourly (short term) weather conditions.
@@ -18,11 +19,39 @@ class HourlyForecastBlock extends BlockBase {
   /**
    * {@inheritdoc}
    */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+    $config = $this->getConfiguration();
+    $max = $config["max_items"] ?? "4";
+
+    $form["max_items"] = [
+      "#type" => "textfield",
+      "#title" => "Maximum items to display",
+      "#default_value" => $max,
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $this->setConfigurationValue(
+      "max_items",
+      $form_state->getValue("max_items")
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function build() {
+    $config = $this->getConfiguration();
+    $max = $config["max_items"] ?? "4";
+
     return [
       '#theme' => "weather_blocks_hourly_forecast",
-    // @todo Capture max_items value from block config. Hard code an integer for now.
-      '#data' => ['max_items' => '4'],
+      '#data' => ['max_items' => $max],
     ];
   }
 

--- a/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php.test
@@ -4,6 +4,7 @@ namespace Drupal\weather_blocks\Plugin\Block;
 
 include_once "HourlyForecastBlock.php";
 
+use Drupal\Core\Form\FormStateInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,14 +29,74 @@ final class HourlyForecastBlockTest extends TestCase {
       "provider" => "weather_blocks",
     ];
 
-    $this->hourlyForecastBlock = new HourlyForecastBlock([], '', $definition);
+    $this->hourlyForecastBlock = new HourlyForecastBlock(
+      [],
+      '',
+      $definition
+    );
 
   }
 
   /**
-   * Test that the block returns hardcoded data for now.
+   * Tests that the block returns the correct form with default configuration.
    */
-  public function testBuild() : void {
+  public function testDefaultForm() : void {
+    $expected = [
+      "max_items" => [
+        "#type" => "textfield",
+        "#title" => "Maximum items to display",
+        "#default_value" => "4",
+      ],
+    ];
+
+    $formState = $this->createStub(FormStateInterface::class);
+
+    $actual = $this->hourlyForecastBlock->blockForm([], $formState);
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Test that the block returns the correct form based on prior configuration.
+   */
+  public function testFormUsingExistingConfig() : void {
+    $this->hourlyForecastBlock->setConfigurationValue("max_items", "17");
+
+    $expected = [
+      "max_items" => [
+        "#type" => "textfield",
+        "#title" => "Maximum items to display",
+        "#default_value" => "17",
+      ],
+    ];
+
+    $formState = $this->createStub(FormStateInterface::class);
+
+    $actual = $this->hourlyForecastBlock->blockForm([], $formState);
+
+    $this->assertEquals($expected, $actual);
+
+  }
+
+  /**
+   * Test that the block properly persists configuration changes.
+   */
+  public function testBlockSubmit() : void {
+    $expected = '9';
+
+    $formState = $this->createStub(FormStateInterface::class);
+    $formState->method('getValue')->willReturn($expected);
+    $this->hourlyForecastBlock->blockSubmit([], $formState);
+
+    $actual = $this->hourlyForecastBlock->getConfiguration()["max_items"];
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Test that the block returns default data if unconfigured.
+   */
+  public function testBuildWithDefaultConfiguration() : void {
     $expected = [
       "#theme" => "weather_blocks_hourly_forecast",
       "#data" => ['max_items' => '4'],
@@ -43,6 +104,22 @@ final class HourlyForecastBlockTest extends TestCase {
     $actual = $this->hourlyForecastBlock->build();
 
     $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Test that the block returns data according to saved configuration.
+   */
+  public function testBuildWithModifiedConfigured() : void {
+    $this->hourlyForecastBlock->setConfigurationValue("max_items", "57");
+
+    $expected = [
+      "#theme" => "weather_blocks_hourly_forecast",
+      "#data" => ['max_items' => '57'],
+    ];
+    $actual = $this->hourlyForecastBlock->build();
+
+    $this->assertEquals($expected, $actual);
+
   }
 
 }


### PR DESCRIPTION
## What does this PR do? 🛠️

Adding a first coat of polish to #395, this PR makes the `max_items` configuration something that admins can set in the Drupal UI instead of having to bonk around in code. This configuration is then pulled at build time and pushed down to the template.

## What does the reviewer need to know? 🤔

1. View the site. Note that there are 4 hours of forecast displayed.
2. [Log in](http://localhost:8080/user/login) as an admin
3. Navigate to the [hourly forecast block configuration](http://localhost:8080/admin/structure/block/manage/new_weather_theme_hourlyforecastblock)
  - Or click to it. It's under Home > Administration > Structure > Block layout, then find the Hourly Forecast block, and click the "Configure" button 
5. Note that there is a form element that says "*Maximum items to display*" and it is set to 4
6. Change this value to another number and click the "Save block" button at the bottom of the page
7. View the site again. Note that there are now a different number of hours of forecast display.

## Screenshots (if appropriate): 📸

<!--- Make sure you add a subject matter expert to the Reviewers list -->
