### PR TITLE
Push URL on to the history stack before navigating away

### DIFF
--- a/tests/e2e/cypress/e2e/location-pages-preserve-browser-history.cy.js
+++ b/tests/e2e/cypress/e2e/location-pages-preserve-browser-history.cy.js
@@ -1,0 +1,13 @@
+describe("location search", () => {
+  it("properly handles browser history", () => {
+    const start = "/local/OHX/50/57/Nashville";
+
+    cy.visit(start);
+    cy.get("form[data-location-search] input").type("Atlanta", { delay: 200 });
+    cy.get("form[data-location-search] ul li").first().click();
+    cy.location("pathname").should("not.equal", start);
+
+    cy.go("back");
+    cy.location("pathname").should("equal", start);
+  });
+});

--- a/web/themes/new_weather_theme/assets/js/components/locationSearch.js
+++ b/web/themes/new_weather_theme/assets/js/components/locationSearch.js
@@ -58,6 +58,9 @@ class LocationSearch {
       const lat = Math.round(geometry.y * 1_000) / 1_000;
       const long = Math.round(geometry.x * 1_000) / 1_000;
 
+      // Push the next URL into the history to preserve the current URL in the
+      // browser history stack.
+      window.history.pushState(null, null, `/point/${lat}/${long}`);
       window.location.href = `/point/${lat}/${long}`;
     }
   }


### PR DESCRIPTION
## What does this PR do? 🛠️

When Javascript sets `window.location` as a result of a direct user action, it results in pushing a new history state to the stack. When Javascript sets `window.location` without user interaction, it results in a history state *replacement* of the current state instead.

Our location search works kinda like this:
1. User types some stuff
2. We query ESRI geocoding API for list of matching place names
3. User selects an option
4. We query ESRI geocoding API for lat/long of the selected place
5. We change the `window.location` to `/point/{lat}/{long}`

Because step 5 is triggered by step 4 (ie, code rather than user interaction), we are replacing the current history state rather than pushing a new one.

This PR modifies the location search handler to explicitly push a new history state using the new URL. This way, the browser's back button will work as expected.

Closes #416

## What does the reviewer need to know? 🤔

You can test it by going to [/prototype-location-search](http://localhost:8080/prototype-location-search), choosing a place, waiting for that place page to load, using the search to choose a different place, wait for that second place page to load, then clicking the browser's back button and confirming that you return to the first place page.