### PR TITLE
move from using deprecated cg deploy to using the cloud-gov supported action

### DIFF
--- a/.github/workflows/deploy-beta.yaml
+++ b/.github/workflows/deploy-beta.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Deploy to cloud.gov sandbox
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         env:
           DEPLOY_NOW: thanks
         with:
@@ -23,13 +23,13 @@ jobs:
           cf_password: ${{ secrets.CF_BETA_PASSWORD }}
           cf_org: nws-weathergov
           cf_space: prod
-          push_arguments: "-f manifests/manifest-beta.yaml"
+          cf_manifest: "manifests/manifest-beta.yaml"
 
       - name: Run post-deploy steps in beta
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         with:
           cf_username: ${{ secrets.CF_BETA_USERNAME }}
           cf_password: ${{ secrets.CF_BETA_PASSWORD }}
           cf_org: nws-weathergov
           cf_space: prod
-          full_command: "cf run-task weathergov-beta --command './scripts/post-deploy.sh' --name 'weathergov-beta-deploy' -k '2G' -m '256M'"
+          cf_command: "run-task weathergov-beta --command './scripts/post-deploy.sh' --name 'weathergov-beta-deploy' -k '2G' -m '256M'"

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -23,19 +23,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Deploy application in ${{ github.event.inputs.environment }} space
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         with:
           cf_username: ${{ secrets[env.CF_USERNAME] }}
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: nws-weathergov
           cf_space: ${{ github.event.inputs.environment }}
-          push_arguments: "-f manifests/manifest-${{ github.event.inputs.environment }}.yaml"
+          cf_manifest: "manifests/manifest-${{ github.event.inputs.environment }}.yaml"
 
       - name: Run post-deploy steps in ${{ github.event.inputs.environment }} space
-        uses: 18f/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         with:
           cf_username: ${{ secrets[env.CF_USERNAME] }}
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: nws-weathergov
           cf_space: ${{ github.event.inputs.environment }}
-          full_command: "cf run-task weathergov-${{ github.event.inputs.environment }} --command './scripts/post-deploy.sh' --name 'weathergov-${{ github.event.inputs.environment }}-deploy' -k '2G' -m '256M'"
+          cf_command: "run-task weathergov-${{ github.event.inputs.environment }} --command './scripts/post-deploy.sh' --name 'weathergov-${{ github.event.inputs.environment }}-deploy' -k '2G' -m '256M'"

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
         - uses: actions/checkout@v3
         - name: Deploy to cloud.gov weathergov-staging space
-          uses: 18f/cg-deploy-action@main
+          uses: cloud-gov/cg-cli-tools@main
           env:
             DEPLOY_NOW: thanks
           with:
@@ -23,12 +23,12 @@ jobs:
             cf_password: ${{ secrets.CF_STAGING_PASSWORD }}
             cf_org: nws-weathergov
             cf_space: staging
-            push_arguments: "-f manifests/manifest-staging.yaml"
+            cf_manifest: "manifests/manifest-staging.yaml"
         - name: Run post deploy steps
-          uses: 18f/cg-deploy-action@main
+          uses: cloud-gov/cg-cli-tools@main
           with:
             cf_username: ${{ secrets.CF_STAGING_USERNAME }}
             cf_password: ${{ secrets.CF_STAGING_PASSWORD }}
             cf_org: nws-weathergov
             cf_space: staging
-            full_command: "cf run-task weathergov-staging --command './scripts/post-deploy.sh' --name 'weathergov-staging-deploy' -k '2G' -m '256M'"
+            cf_command: "run-task weathergov-staging --command './scripts/post-deploy.sh' --name 'weathergov-staging-deploy' -k '2G' -m '256M'"


### PR DESCRIPTION
## What does this PR do? 🛠️
Moves to using the [cloud-gov supported action](https://github.com/cloud-gov/cg-cli-tools) instead of the deprecated action. 

## What does the reviewer need to know? 🤔
Will conduct a test of the sandbox script before merging. 
