### PR TITLE
Wait for USWDS if necessary

### DIFF
--- a/web/themes/new_weather_theme/assets/js/components/locationSearch.js
+++ b/web/themes/new_weather_theme/assets/js/components/locationSearch.js
@@ -28,11 +28,33 @@ class LocationSearch {
   #select;
 
   constructor(node) {
-    this.#input = node.querySelector("input");
-    this.#select = node.querySelector("select");
+    // USWDS adds the input element for us. We can't be certain about when it
+    // will do that, so we need to check if the input element exists before we
+    // start hooking up event listeners to it. If it doesn't exist yet, wait a
+    // bit and try again. Only do it a few times, though, because if it doesn't
+    // show up within a second or so, there's likely another issue preventing it
+    // from getting added to the DOM and we don't want to just sit and waste
+    // CPU cycles forever.
+    let attempts = 0;
+    const addListeners = () => {
+      attempts += 1;
+      this.#input = node.querySelector("input");
+      this.#select = node.querySelector("select");
 
-    this.#input.addEventListener("input", this.searchChanged.bind(this));
-    this.#select.addEventListener("change", this.locationSelected.bind(this));
+      if (!this.#input || !this.#select) {
+        if (attempts < 20) {
+          setTimeout(addListeners, 50);
+        }
+      } else {
+        this.#input.addEventListener("input", this.searchChanged.bind(this));
+        this.#select.addEventListener(
+          "change",
+          this.locationSelected.bind(this),
+        );
+      }
+    };
+
+    addListeners();
   }
 
   async locationSelected() {


### PR DESCRIPTION
## What does this PR do? 🛠️

We're using the USWDS combobox component. Under the hood, it inserts an `<input>` element into the DOM for us, but we can't be sure when that will happen. #425 is caused basically by a race condition. This PR adds some logic to our search box to essentially ask the DOM periodically if the input element is present yet and once it shows up, then it hooks up the event listeners.

The new logic only does the wait-and-see thing 20 times before giving up entirely. The reason for this is that if there's anything outside of our control that interferes with the element being added to the DOM, we don't want to just keep running a poll forever and ever and chewing up users' CPUs and/or batteries.

Closes #425.