### PR TITLE
Create a weather block base class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,11 @@
         },
         "sort-packages": true
     },
+    "autoload": {
+        "psr-4": {
+            "Drupal\\weather_blocks\\": "web/modules/weather_blocks/src/"
+        }
+    },
     "extra": {
         "drupal-scaffold": {
             "locations": {

--- a/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php
@@ -2,12 +2,6 @@
 
 namespace Drupal\weather_blocks\Plugin\Block;
 
-use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\weather_data\Service\WeatherDataService;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
 /**
  * Provides a block of the current weather conditions.
  *
@@ -17,58 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   category = @Translation("weather.gov"),
  * )
  */
-class CurrentConditionsBlock extends BlockBase implements ContainerFactoryPluginInterface {
-
-  /**
-   * A service for fetching weather data.
-   *
-   * @var \Drupal\weather_data\Service\WeatherDataService weatherData
-   */
-  private $weatherData;
-
-  /**
-   * The current route.
-   *
-   * @var \Drupal\Core\Routing\RouteMatchInterface route
-   */
-  private $route;
-
-  /**
-   * Constructor for dependency injection.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, WeatherDataService $weatherDataService, RouteMatchInterface $route) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->weatherData = $weatherDataService;
-    $this->route = $route;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('weather_data'),
-      $container->get('current_route_match')
-    );
-  }
-
-  /**
-   * Disable cacheing on this block.
-   *
-   * Because this is displayed to anonymous users and it is location-based (or
-   * will be), we can't really rely on any cacheing here right now.
-   *
-   * Once we hook up location data, it may be the case that Drupal can cache
-   * responses based on that location, in which case a short cache could work
-   * fine. Not 100% convinced we should do it, though, because we'd just be
-   * trading one kind of complexity for another (time vs. space).
-   */
-  public function getCacheMaxAge() {
-    return 0;
-  }
+class CurrentConditionsBlock extends WeatherBlockBase {
 
   /**
    * {@inheritdoc}

--- a/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
@@ -2,12 +2,6 @@
 
 namespace Drupal\weather_blocks\Plugin\Block;
 
-use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\weather_data\Service\WeatherDataService;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
 /**
  * Provides a block of the hourly (short term) weather conditions.
  *
@@ -17,59 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   category = @Translation("weather.gov"),
  * )
  */
-class HourlyForecastBlock extends BlockBase implements ContainerFactoryPluginInterface {
-
-  /**
-   * A service for fetching weather data.
-   *
-   * @var \Drupal\weather_data\Service\WeatherDataService weatherData
-   */
-  private $weatherData;
-
-  /**
-   * The current route.
-   *
-   * @var \Drupal\Core\Routing\RouteMatchInterface route
-   */
-  private $route;
-
-  /**
-   * Constructor for dependency injection.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, WeatherDataService $weatherDataService, RouteMatchInterface $route) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->weatherData = $weatherDataService;
-    $this->route = $route;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('weather_data'),
-      $container->get('current_route_match')
-    );
-  }
-
-  /**
-   * Disable cacheing on this block.
-   *
-   * Because this is displayed to anonymous
-   * users and it is location-based (or will be), we can't really rely on any
-   * cacheing here right now.
-   *
-   * Once we hook up location data, it may be the case that Drupal can cache
-   * responses based on that location, in which case a short cache could work
-   * fine. Not 100% convinced we should do it, though, because we'd just be
-   * trading one kind of complexity for another (time vs. space).
-   */
-  public function getCacheMaxAge() {
-    return 0;
-  }
+class HourlyForecastBlock extends WeatherBlockBase {
 
   /**
    * {@inheritdoc}

--- a/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php.test
@@ -2,12 +2,9 @@
 
 namespace Drupal\weather_blocks\Plugin\Block;
 
-include_once "HourlyForecastBlock.php";
-
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\weather_data\Service\WeatherDataService;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Tests for the HourlyForecast block.
@@ -55,39 +52,6 @@ final class HourlyForecastBlockTest extends TestCase {
 
     $this->hourlyForecastBlock = new HourlyForecastBlock([], '', $definition, $this->weatherData, $this->routeMock);
 
-  }
-
-  /**
-   * Test that the create() static method gives us back a block object.
-   */
-  public function testCreation() : void {
-    $container = $this->createStub(ContainerInterface::class);
-    $container->method('get')->will($this->returnCallback(function () {
-      $args = func_get_args();
-      switch ($args[0]) {
-        case 'weather_data':
-          return $this->weatherData;
-
-        case 'current_route_match':
-          return $this->routeMock;
-
-        default:
-          return NULL;
-      }
-    }));
-
-    $actual = HourlyForecastBlock::create($container, [], '', ["provider" => "weather_blocks"]);
-    $this->assertEquals(HourlyForecastBlock::class, $actual::class);
-  }
-
-  /**
-   * Test that block cacheing is disabled.
-   */
-  public function testCache() : void {
-    $expected = 0;
-    $actual = $this->hourlyForecastBlock->getCacheMaxAge();
-
-    $this->assertEquals($expected, $actual);
   }
 
   /**

--- a/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php
@@ -2,12 +2,6 @@
 
 namespace Drupal\weather_blocks\Plugin\Block;
 
-use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\weather_data\Service\WeatherDataService;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
 /**
  * Provides a block for searching for locations.
  *
@@ -17,58 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   category = @Translation("weather.gov"),
  * )
  */
-class LocationSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
-
-  /**
-   * A service for fetching weather data.
-   *
-   * @var \Drupal\weather_data\Service\WeatherDataService weatherData
-   */
-  private $weatherData;
-
-  /**
-   * The current route.
-   *
-   * @var \Drupal\Core\Routing\RouteMatchInterface route
-   */
-  private $route;
-
-  /**
-   * Constructor for dependency injection.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, WeatherDataService $weatherDataService, RouteMatchInterface $route) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->weatherData = $weatherDataService;
-    $this->route = $route;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('weather_data'),
-      $container->get('current_route_match')
-    );
-  }
-
-  /**
-   * Disable cacheing on this block.
-   *
-   * Because this is displayed to anonymous users and it is location-based (or
-   * will be), we can't really rely on any cacheing here right now.
-   *
-   * Once we hook up location data, it may be the case that Drupal can cache
-   * responses based on that location, in which case a short cache could work
-   * fine. Not 100% convinced we should do it, though, because we'd just be
-   * trading one kind of complexity for another (time vs. space).
-   */
-  public function getCacheMaxAge() {
-    return 0;
-  }
+class LocationSearchBlock extends WeatherBlockBase {
 
   /**
    * {@inheritdoc}

--- a/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php.test
@@ -2,12 +2,9 @@
 
 namespace Drupal\weather_blocks\Plugin\Block;
 
-include_once "LocationSearchBlock.php";
-
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\weather_data\Service\WeatherDataService;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Tests for the LocationSearch block.
@@ -53,39 +50,6 @@ final class LocationSearchBlockTest extends TestCase {
     $this->routeMock->method('getRouteName')->willReturn("weather_routes.grid");
 
     $this->locationSearchBlock = new LocationSearchBlock([], '', $definition, $this->weatherData, $this->routeMock);
-  }
-
-  /**
-   * Test that the create() static method gives us back a block object.
-   */
-  public function testCreation() : void {
-    $container = $this->createStub(ContainerInterface::class);
-    $container->method('get')->will($this->returnCallback(function () {
-      $args = func_get_args();
-      switch ($args[0]) {
-        case 'weather_data':
-          return $this->weatherData;
-
-        case 'current_route_match':
-          return $this->routeMock;
-
-        default:
-          return NULL;
-      }
-    }));
-
-    $actual = LocationSearchBlock::create($container, [], '', ["provider" => "weather_blocks"]);
-    $this->assertEquals(LocationSearchBlock::class, $actual::class);
-  }
-
-  /**
-   * Test that block cacheing is disabled.
-   */
-  public function testCache() : void {
-    $expected = 0;
-    $actual = $this->locationSearchBlock->getCacheMaxAge();
-
-    $this->assertEquals($expected, $actual);
   }
 
   /**

--- a/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\weather_blocks\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\weather_data\Service\WeatherDataService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for weather.gov custom blocks.
+ *
+ * This class handles the dependency injection to get access to a
+ * RouteMatchInterface object and a WeatherDataService object.
+ */
+abstract class WeatherBlockBase extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * A service for fetching weather data.
+   *
+   * @var \Drupal\weather_data\Service\WeatherDataService weatherData
+   */
+  protected $weatherData;
+
+  /**
+   * The current route.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface route
+   */
+  protected $route;
+
+  /**
+   * Constructor for dependency injection.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, WeatherDataService $weatherDataService, RouteMatchInterface $route) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->weatherData = $weatherDataService;
+    $this->route = $route;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('weather_data'),
+      $container->get('current_route_match')
+    );
+  }
+
+  /**
+   * Disable cacheing on this block.
+   *
+   * Because this is displayed to anonymous users and it is location-based (or
+   * will be), we can't really rely on any cacheing here right now.
+   *
+   * Once we hook up location data, it may be the case that Drupal can cache
+   * responses based on that location, in which case a short cache could work
+   * fine. Not 100% convinced we should do it, though, because we'd just be
+   * trading one kind of complexity for another (time vs. space).
+   */
+  public function getCacheMaxAge() {
+    return 0;
+  }
+
+}

--- a/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php.test
@@ -5,13 +5,17 @@ namespace Drupal\weather_blocks\Plugin\Block;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\weather_data\Service\WeatherDataService;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Tests for the CurrentConditions block.
+ * Tests for the WeatherBlockBaseTest block.
  */
-final class CurrentConditionsBlockTest extends TestCase {
+final class WeatherBlockBaseTest extends TestCase {
   /**
    * A ready-to-use current conditions block object.
+   *
+   * We use this block for our tests because the WeatherBlockBase class is
+   * abstract and cannot be directly instantiated. So, we'll test by proxy.
    *
    * @var currentConditionsBlock
    */
@@ -55,38 +59,36 @@ final class CurrentConditionsBlockTest extends TestCase {
   }
 
   /**
-   * Test that the block returns the expected data if we're on a grid route.
+   * Test that the create() static method gives us back a block object.
    */
-  public function testBuild() : void {
-    $this->weatherData->method('getCurrentConditions')->willReturn('this is weather data');
+  public function testCreation() : void {
+    $container = $this->createStub(ContainerInterface::class);
+    $container->method('get')->will($this->returnCallback(function () {
+      $args = func_get_args();
+      switch ($args[0]) {
+        case 'weather_data':
+          return $this->weatherData;
 
-    $expected = [
-      "#theme" => "weather_blocks_current_conditions",
-      "#data" => "this is weather data",
-    ];
-    $actual = $this->currentConditionsBlock->build();
+        case 'current_route_match':
+          return $this->routeMock;
 
-    $this->assertEquals($expected, $actual);
+        default:
+          return NULL;
+      }
+    }));
+
+    $actual = CurrentConditionsBlock::create($container, [], '', ["provider" => "weather_blocks"]);
+    $this->assertEquals(CurrentConditionsBlock::class, $actual::class);
   }
 
   /**
-   * Test that the block returns null if we're not on a grid route.
+   * Test that block cacheing is disabled.
    */
-  public function testBuildNotGridRoute(): void {
-    $definition = [
-      "provider" => "weather_blocks",
-    ];
+  public function testCache() : void {
+    $expected = 0;
+    $actual = $this->currentConditionsBlock->getCacheMaxAge();
 
-    $this->weatherData = $this->createStub(WeatherDataService::class);
-
-    $this->routeMock = $this->createStub(RouteMatchInterface::class);
-    $this->routeMock->method('getRouteName')->willReturn("weather_routes.not-grid");
-
-    $this->currentConditionsBlock = new CurrentConditionsBlock([], '', $definition, $this->weatherData, $this->routeMock);
-
-    $actual = $this->currentConditionsBlock->build();
-
-    $this->assertEquals(NULL, $actual);
+    $this->assertEquals($expected, $actual);
   }
 
 }


### PR DESCRIPTION
# Hold for #439

This PR builds on #439, so after that one is merged, this one should be rebased on top of `main` and then it will be ready for review.

## What does this PR do? 🛠️

Inspired by @eric-gade, this PR pulls the common boilerplate code out of our custom module blocks and puts it into a base class. It also configures autoloading of our blocks so we can reference them by namespace instead of having to `include()` them in tests.

## What does the reviewer need to know? 🤔

Behaviorally, nothing should change. If everything works, then I guess this is good?