### PR TITLE
Setup plantuml-server in Docker

### DIFF
--- a/Dockerfile.plantuml
+++ b/Dockerfile.plantuml
@@ -1,0 +1,19 @@
+FROM plantuml/plantuml-server:jetty
+
+# Copy the zscaler root CA into the container and add it to the list of OpenSSL
+# root certificates.
+COPY zscaler-root.pem /etc/ssl/certs/zscaler-root.pem
+
+# Put it in the Java keytool. Gotta be root for this.
+USER root
+RUN keytool -import \
+  -noprompt \
+  -trustcacerts \
+  -file /etc/ssl/certs/zscaler-root.pem \
+  -cacerts \
+  -keypass changeit \
+  -storepass changeit\ 
+  -alias zscaler
+
+# Switch back to the jetty user before we leave
+USER jetty

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,5 +61,15 @@ services:
       # Map in our test coverage directory so we can have those pretty outputs.
       - ./.coverage:/coverage
 
+  plantuml:
+    build:
+      context: ./
+      dockerfile: Dockerfile.plantuml
+    image: 18f-zscaler-plantum:jetty
+    ports:
+      - 8180:8080
+    profiles: ["utilities"]
+    
+
 networks:
   weather.gov:


### PR DESCRIPTION
## What does this PR do? 🛠️

1. Creates a custom Dockerfile for plantuml-server so we can put zscaler roots in the Java keytool
2. Adds a plantuml service to our Docker Compose. It's in a separate profile, so it doesn't start with everything else. To start it, run:
   ```
   docker compose run plantuml
   ```

## What does the reviewer need to know? 🤔

Try it out, I guess? But thank you for saying a couple times how useful it is to you to have a local server.