### PR TITLE
Defer USWDS to prevent flash of unstyled content

### DIFF
--- a/web/themes/new_weather_theme/templates/layout/html.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/html.html.twig
@@ -40,7 +40,7 @@
     <js-placeholder token="{{ placeholder_token }}">
     <link rel="stylesheet" href="/{{ directory }}/assets/css/styles.css" />
     <link rel="icon" type="image/png" href="/{{ directory }}/assets/images/weather/favicons/noaa-favicon.ico" />
-    <script type="text/javascript" async="" src="/{{ directory }}/assets/js/uswds-init.min.js"></script>
+    <script type="text/javascript" src="/{{ directory }}/assets/js/uswds-init.min.js"></script>
   </head>
   <body{{ attributes.addClass(body_classes) }}>
     {#
@@ -54,11 +54,8 @@
     {{ page }}
     {{ page_bottom }}
     <js-bottom-placeholder token="{{ placeholder_token }}">
-     <script type="text/javascript" async="" src="/{{ directory }}/assets/js/uswds.min.js"></script>
-     <script
-      type="module"
-      async=""
-      src="/{{ directory }}/assets/js/main.js"
+     <script type="text/javascript" defer src="/{{ directory }}/assets/js/uswds.min.js"></script>
+     <script type="module" async src="/{{ directory }}/assets/js/main.js"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
## What does this PR do? 🛠️

USWDS does some DOM manipulation immediately when it loads, which disrupts the page loading order and forces the browser to start rendering prematurely. This PR adds the `defer` attribute to the USWDS Javascript so it doesn't run until after everything is ready so the browser isn't forced into a premature layout.

Closes #260

## What does the reviewer need to know? 🤔

Compare:
- [Broken](https://weathergov-staging.app.cloud.gov/local/OHX/50/57/Nashville): The flash is very noticeable in Firefox, a little less so in Chrome. If you're using Firefox, it outputs a message to the console indicating that layout started prematurely.
- [Fixed](https://weathergov-greg.app.cloud.gov/local/OHX/50/57/Nashville): No flash, and in Firefox, no console message about premature layout.
