### PR TITLE
Add screenshots to our end-to-end tests

### DIFF
--- a/.github/workflows/code-standards.yaml
+++ b/.github/workflows/code-standards.yaml
@@ -262,6 +262,13 @@ jobs:
           project: tests/e2e
           cache-key: cypress-e2e-${{ hashFiles('package-lock.json') }}
 
+      - name: save screenshots
+        if: needs.should-test.outputs.yes == 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: screenshots
+          path: tests/e2e/cypress/screenshots/screenshots.cy.js/
+
   accessibility-tests:
     name: accessibility tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ node_modules
 
 # Code coverage
 /.coverage
+
+# Test screenshots
+/tests/**/screenshots/**

--- a/tests/e2e/cypress/e2e/screenshots.cy.js
+++ b/tests/e2e/cypress/e2e/screenshots.cy.js
@@ -1,0 +1,24 @@
+describe("collect screenshots", () => {
+  it("is not a test, is just a utility", () => {
+    const pages = [
+      { name: "front page", url: "/" },
+      { name: "location page", url: "/local/OHX/50/57/Nashville" },
+      { name: "login page", url: "/user/login" },
+    ];
+
+    for (const { name, url } of pages) {
+      cy.visit(url);
+      cy.get("html").invoke("css", "height", "initial");
+      cy.get("body").invoke("css", "height", "initial");
+
+      cy.viewport(480, 500);
+      cy.screenshot(`phone/${name}`, { capture: "fullPage" });
+
+      cy.viewport(640, 500);
+      cy.screenshot(`tablet/${name}`, { capture: "fullPage" });
+
+      cy.viewport(1024, 500);
+      cy.screenshot(`desktop/${name}`, { capture: "fullPage" });
+    }
+  });
+});


### PR DESCRIPTION
# Hold

I don't think this is useful unless we can integrate the newly-captured screenshots into our review process. Ideally I think we'd want the screenshots to be added to a comment that gets updated on each push (instead of new comments each time). GitHub doesn't provide an API for uploading images into comments, so we'll have to dance around that a little bit. There are existing actions that do it, but they add new comments each time, so that'd be noisy.

## What does this PR do? 🛠️

Adds an additional test to our end-to-end tests that iterates over a list of pages we want to screen shot and gets screen shots of all of those pages at phone, table, and desktop viewport widths.

## What does the reviewer need to know? 🤔

Nothing much. Running end-to-end tests will create screenshots (in the git-ignored) `tests/e2e/cypress/screenshots/screenshots.cy.js/` directory.