### PR TITLE
Use API text for conditions descriptions

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherDataService.getDailyForecast.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.getDailyForecast.php.test
@@ -223,11 +223,11 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
     // legacy condition values here for now,
     // rather than the shortForecast values.
     $expected = [
-      'A few clouds',
-      'Partly cloudy',
-      'Snow',
-      'Partly cloudy',
-      'Partly cloudy',
+      'Sunny',
+      'Mostly sunny',
+      'Slight snow',
+      'Mostly sunny',
+      'Cats and dogs!',
     ];
     $forecastDays = $this->weatherDataService->getDailyForecastFromGrid(
       'wfo', 'x', 'y',

--- a/web/modules/weather_data/src/Service/WeatherDataService.getHourlyForecast.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.getHourlyForecast.php.test
@@ -177,7 +177,8 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
 
     $expected = [
       [
-        "conditions" => "Thunderbolt", // Conditions should be sentence-cased
+        // Conditions should be sentence-cased.
+        "conditions" => "Thunderbolt",
         "icon" => "nodata.svg",
         "probabilityOfPrecipitation" => 11,
         "time" => "12 PM",

--- a/web/modules/weather_data/src/Service/WeatherDataService.getHourlyForecast.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.getHourlyForecast.php.test
@@ -115,6 +115,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
         // One minute before noon UTC, but not using UTC or America/Denver tz.
         "startTime" => "2023-11-16T03:59:59-08:00",
         "temperature" => 1,
+        "shortForecast" => "blah",
         "probabilityOfPrecipitation" => [
           "value" => 11,
         ],
@@ -124,6 +125,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
         // One hour before noon UTC, and in America/Denver tz.
         "startTime" => "2023-11-16T03:00:00-07:00",
         "temperature" => 2,
+        "shortForecast" => "bleh",
         "probabilityOfPrecipitation" => [
           "value" => 22,
         ],
@@ -133,6 +135,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
         // One hour before noon UTC.
         "startTime" => "2023-11-16T11:00:00Z",
         "temperature" => 3,
+        "shortForecast" => "bluh",
         "probabilityOfPrecipitation" => [
           "value" => 33,
         ],
@@ -154,6 +157,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
       [
         "startTime" => "2023-11-16T12:00:00-07:00",
         "temperature" => 1,
+        "shortForecast" => "thunderBOLT",
         "probabilityOfPrecipitation" => [
           "value" => 11,
         ],
@@ -162,6 +166,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
       [
         "startTime" => "2023-11-16T13:00:00-07:00",
         "temperature" => 2,
+        "shortForecast" => "lightning",
         "probabilityOfPrecipitation" => [
           "value" => 22,
         ],
@@ -172,14 +177,14 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
 
     $expected = [
       [
-        "conditions" => "No data",
+        "conditions" => "Thunderbolt", // Conditions should be sentence-cased
         "icon" => "nodata.svg",
         "probabilityOfPrecipitation" => 11,
         "time" => "12 PM",
         "temperature" => 1,
       ],
       [
-        "conditions" => "No data",
+        "conditions" => "Lightning",
         "icon" => "nodata.svg",
         "probabilityOfPrecipitation" => 22,
         "time" => "1 PM",
@@ -201,6 +206,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
         // One minute before noon UTC. This should be filtered out.
         "startTime" => "2023-11-16T03:59:59-08:00",
         "temperature" => 1,
+        "shortForecast" => "Very Very",
         "probabilityOfPrecipitation" => [
           "value" => 11,
         ],
@@ -209,6 +215,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
       [
         "startTime" => "2023-11-16T12:00:00-07:00",
         "temperature" => 2,
+        "shortForecast" => "FRIGHTENING",
         "probabilityOfPrecipitation" => [
           "value" => 22,
         ],
@@ -217,6 +224,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
       [
         "startTime" => "2023-11-16T13:00:00-07:00",
         "temperature" => 3,
+        "shortForecast" => "Mama mia!",
         "probabilityOfPrecipitation" => [
           "value" => 33,
         ],
@@ -227,14 +235,14 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
 
     $expected = [
       [
-        "conditions" => "Rain",
+        "conditions" => "Frightening",
         "icon" => "rain.svg",
         "probabilityOfPrecipitation" => 22,
         "time" => "12 PM",
         "temperature" => 2,
       ],
       [
-        "conditions" => "Snow",
+        "conditions" => "Mama mia!",
         "icon" => "snow.svg",
         "probabilityOfPrecipitation" => 33,
         "time" => "1 PM",

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -438,10 +438,8 @@ class WeatherDataService {
       // Get any mapped condition and/or icon values.
       $obsKey = $this->getApiObservationKey($daytime);
 
-      // The short forecast name should be mapped to
-      // the legacyMapping and translated.
-      $shortForecast = $this->legacyMapping->$obsKey->conditions;
-      $shortForecast = $this->removeParenthetical($shortForecast);
+      // Sentence-case the forecast description
+      $shortForecast = ucfirst(strtolower($daytime->shortForecast));
 
       $daytimeForecast = [
         'shortDayName' => $shortDayName,

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -79,7 +79,6 @@ class WeatherDataService {
   }
 
   /**
-<<<<<<< HEAD
    * Get data from the weather API.
    *
    * The results for any given URL are cached for the duration of the current
@@ -99,20 +98,6 @@ class WeatherDataService {
   }
 
   /**
-   * Return a condition stripped of any parentheticals.
-   *
-   * @return string
-   *   A condition text with any parenthetical
-   *    statements removed
-   */
-  private function removeParenthetical($str) {
-    $parts = explode("(", $str);
-    return $parts[0];
-  }
-
-  /**
-=======
->>>>>>> 925a7fc (lint fixes)
    * Return only the periods that are after today.
    *
    * This private method will filter the forecast periods
@@ -290,7 +275,7 @@ class WeatherDataService {
 
     $obsKey = $this->getApiObservationKey($obs);
 
-    $description = $this->legacyMapping->$obsKey->conditions;
+    $description = ucfirst(strtolower($obs->textDescription));
 
     // The cardinal and ordinal directions. North goes in twice because it
     // sits in two "segments": -22.5° to 22.5°, and 337.5° to 382.5°.

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -381,7 +381,7 @@ class WeatherDataService {
       $obsKey = $this->getApiObservationKey($period);
 
       return [
-        "conditions" => $this->legacyMapping->$obsKey->conditions,
+        "conditions" => $this->t->translate(ucfirst(strtolower($period->shortForecast))),
         "icon" => $this->legacyMapping->$obsKey->icon,
         "probabilityOfPrecipitation" => $period->probabilityOfPrecipitation->value,
         "time" => $timestamp,

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -79,6 +79,7 @@ class WeatherDataService {
   }
 
   /**
+<<<<<<< HEAD
    * Get data from the weather API.
    *
    * The results for any given URL are cached for the duration of the current
@@ -110,6 +111,8 @@ class WeatherDataService {
   }
 
   /**
+=======
+>>>>>>> 925a7fc (lint fixes)
    * Return only the periods that are after today.
    *
    * This private method will filter the forecast periods
@@ -438,7 +441,7 @@ class WeatherDataService {
       // Get any mapped condition and/or icon values.
       $obsKey = $this->getApiObservationKey($daytime);
 
-      // Sentence-case the forecast description
+      // Sentence-case the forecast description.
       $shortForecast = ucfirst(strtolower($daytime->shortForecast));
 
       $daytimeForecast = [

--- a/web/modules/weather_data/src/Service/WeatherDataService.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php.test
@@ -75,8 +75,8 @@ final class WeatherDataServiceGetCurrentConditionsTest extends TestCase {
 
     return [
       "conditions" => [
-        "long" => "Snow",
-        "short" => "Snow",
+        "long" => "Not snow",
+        "short" => "Not snow",
       ],
       "feels_like" => 45,
       "humidity" => 88,
@@ -148,8 +148,6 @@ final class WeatherDataServiceGetCurrentConditionsTest extends TestCase {
   public function testIconIsNull(): void {
     $expected = $this->setupHappyPath("observation.bad-null-icon.json");
     $expected["icon"] = "nodata.svg";
-    $expected["conditions"]["short"] = "No data";
-    $expected["conditions"]["long"] = "No data";
 
     $actual = $this->weatherDataService->getCurrentConditionsFromGrid("wfo", 1, 2);
 
@@ -162,8 +160,6 @@ final class WeatherDataServiceGetCurrentConditionsTest extends TestCase {
   public function testIconIsEmptyString(): void {
     $expected = $this->setupHappyPath("observation.bad-empty-icon.json");
     $expected["icon"] = "nodata.svg";
-    $expected["conditions"]["short"] = "No data";
-    $expected["conditions"]["long"] = "No data";
 
     $actual = $this->weatherDataService->getCurrentConditionsFromGrid("wfo", 1, 2);
 
@@ -192,8 +188,8 @@ final class WeatherDataServiceGetCurrentConditionsTest extends TestCase {
 
     $expected = [
       "conditions" => [
-        "long" => "Snow",
-        "short" => "Snow",
+        "long" => "Not snow",
+        "short" => "Not snow",
       ],
       "feels_like" => 45,
       "humidity" => 88,

--- a/web/modules/weather_data/src/Service/legacyMapping.json
+++ b/web/modules/weather_data/src/Service/legacyMapping.json
@@ -1,278 +1,209 @@
 {
   "day/bkn": {
-    "icon": "mostly_cloudy-day.svg",
-    "conditions": "Mostly cloudy"
+    "icon": "mostly_cloudy-day.svg"
   },
   "night/bkn": {
-    "icon": "mostly_cloudy-night.svg",
-    "conditions": "Mostly cloudy"
+    "icon": "mostly_cloudy-night.svg"
   },
   "day/blizzard": {
-    "icon": "blizzard_winter_storm.svg",
-    "conditions": "Blizzard"
+    "icon": "blizzard_winter_storm.svg"
   },
   "night/blizzard": {
-    "icon": "blizzard_winter_storm.svg",
-    "conditions": "Blizzard"
+    "icon": "blizzard_winter_storm.svg"
   },
   "day/cold": {
-    "icon": "cold.svg",
-    "conditions": "Cold"
+    "icon": "cold.svg"
   },
   "night/cold": {
-    "icon": "cold.svg",
-    "conditions": "Cold"
+    "icon": "cold.svg"
   },
   "day/dust": {
-    "icon": "new_dust.svg",
-    "conditions": "Dust"
+    "icon": "new_dust.svg"
   },
   "night/dust": {
-    "icon": "new_dust.svg",
-    "conditions": "Dust"
+    "icon": "new_dust.svg"
   },
   "day/few": {
-    "icon": "mostly_clear-day.svg",
-    "conditions": "A few clouds"
+    "icon": "mostly_clear-day.svg"
   },
   "night/few": {
-    "icon": "mostly_clear-night.svg",
-    "conditions": "A few clouds"
+    "icon": "mostly_clear-night.svg"
   },
   "day/fog": {
-    "icon": "fog.svg",
-    "conditions": "Fog/mist"
+    "icon": "fog.svg"
   },
   "night/fog": {
-    "icon": "fog.svg",
-    "conditions": "Fog/mist"
+    "icon": "fog.svg"
   },
   "day/fzra": {
-    "icon": "cold.svg",
-    "conditions": "Freezing rain"
+    "icon": "cold.svg"
   },
   "night/fzra": {
-    "icon": "cold.svg",
-    "conditions": "Freezing rain"
+    "icon": "cold.svg"
   },
   "day/haze": {
-    "icon": "hazy_smoke-day.svg",
-    "conditions": "Haze"
+    "icon": "hazy_smoke-day.svg"
   },
   "night/haze": {
-    "icon": "fog.svg",
-    "conditions": "Haze"
+    "icon": "fog.svg"
   },
   "day/hot": {
-    "icon": "hot.svg",
-    "conditions": "Hot"
+    "icon": "hot.svg"
   },
   "night/hot": {
-    "icon": "hot.svg",
-    "conditions": "Hot"
+    "icon": "hot.svg"
   },
   "day/hurricane": {
-    "icon": "hurricane.svg",
-    "conditions": "Hurricane conditions"
+    "icon": "hurricane.svg"
   },
   "night/hurricane": {
-    "icon": "hurricane.svg",
-    "conditions": "Hurricane conditions"
+    "icon": "hurricane.svg"
   },
   "no data": {
-    "icon": "nodata.svg",
-    "conditions": "No data"
+    "icon": "nodata.svg"
   },
   "day/ovc": {
-    "icon": "cloudy_overcast.svg",
-    "conditions": "Overcast"
+    "icon": "cloudy_overcast.svg"
   },
   "night/ovc": {
-    "icon": "cloudy_overcast.svg",
-    "conditions": "Overcast"
+    "icon": "cloudy_overcast.svg"
   },
   "day/rain": {
-    "icon": "rain.svg",
-    "conditions": "Rain"
+    "icon": "rain.svg"
   },
   "day/rain_fzra": {
-    "icon": "freezing_rain_sleet.svg",
-    "conditions": "Rain/freezing rain"
+    "icon": "freezing_rain_sleet.svg"
   },
   "night/rain_fzra": {
-    "icon": "freezing_rain_sleet.svg",
-    "conditions": "Rain/freezing rain"
+    "icon": "freezing_rain_sleet.svg"
   },
   "night/rain": {
-    "icon": "rain.svg",
-    "conditions": "Rain"
+    "icon": "rain.svg"
   },
   "day/rain_showers": {
-    "icon": "showers_scattered_rain.svg",
-    "conditions": "Rain showers (high cloud cover)"
+    "icon": "showers_scattered_rain.svg"
   },
   "day/rain_showers_hi": {
-    "icon": "showers_scattered_rain.svg",
-    "conditions": "Rain showers (low cloud cover)"
+    "icon": "showers_scattered_rain.svg"
   },
   "night/rain_showers_hi": {
-    "icon": "showers_scattered_rain.svg",
-    "conditions": "Rain showers (low cloud cover)"
+    "icon": "showers_scattered_rain.svg"
   },
   "night/rain_showers": {
-    "icon": "showers_scattered_rain.svg",
-    "conditions": "Rain showers (high cloud cover)"
+    "icon": "showers_scattered_rain.svg"
   },
   "day/rain_sleet": {
-    "icon": "freezing_rain_sleet.svg",
-    "conditions": "Rain/sleet"
+    "icon": "freezing_rain_sleet.svg"
   },
   "night/rain_sleet": {
-    "icon": "freezing_rain_sleet.svg",
-    "conditions": "Rain/sleet"
+    "icon": "freezing_rain_sleet.svg"
   },
   "day/rain_snow": {
-    "icon": "mixed_precip.svg",
-    "conditions": "Rain/snow"
+    "icon": "mixed_precip.svg"
   },
   "night/rain_snow": {
-    "icon": "mixed_precip.svg",
-    "conditions": "Rain/sleet"
+    "icon": "mixed_precip.svg"
   },
   "day/sct": {
-    "icon": "mostly_clear-day.svg",
-    "conditions": "Partly cloudy"
+    "icon": "mostly_clear-day.svg"
   },
   "night/sct": {
-    "icon": "mostly_clear-night.svg",
-    "conditions": "Partly cloudy"
+    "icon": "mostly_clear-night.svg"
   },
   "day/skc": {
-    "icon": "clear-day.svg",
-    "conditions": "Fair/clear"
+    "icon": "clear-day.svg"
   },
   "night/skc": {
-    "icon": "clear-night.svg",
-    "conditions": "Fair/clear"
+    "icon": "clear-night.svg"
   },
   "day/sleet": {
-    "icon": "freezing_rain_sleet.svg",
-    "conditions": "Sleet"
+    "icon": "freezing_rain_sleet.svg"
   },
   "night/sleet": {
-    "icon": "freezing_rain_sleet.svg",
-    "conditions": "Sleet"
+    "icon": "freezing_rain_sleet.svg"
   },
   "day/smoke": {
-    "icon": "hazy_smoke-day.svg",
-    "conditions": "Smoke"
+    "icon": "hazy_smoke-day.svg"
   },
   "night/smoke": {
-    "icon": "hazy_smoke-day.svg",
-    "conditions": "Smoke"
+    "icon": "hazy_smoke-day.svg"
   },
   "day/snow": {
-    "icon": "snow.svg",
-    "conditions": "Snow"
+    "icon": "snow.svg"
   },
   "day/snow_fzra": {
-    "icon": "mixed_precip.svg",
-    "conditions": "Freezing rain/snow"
+    "icon": "mixed_precip.svg"
   },
   "night/snow_fzra": {
-    "icon": "mixed_precip.svg",
-    "conditions": "Freezing rain/snow"
+    "icon": "mixed_precip.svg"
   },
   "night/snow": {
-    "icon": "snow.svg",
-    "conditions": "Snow"
+    "icon": "snow.svg"
   },
   "day/snow_sleet": {
-    "icon": "new_snow_sleet.svg",
-    "conditions": "Snow/sleet"
+    "icon": "new_snow_sleet.svg"
   },
   "night/snow_sleet": {
-    "icon": "new_snow_sleet.svg",
-    "conditions": "Snow/sleet"
+    "icon": "new_snow_sleet.svg"
   },
   "day/tornado": {
-    "icon": "tornado.svg",
-    "conditions": "Tornado"
+    "icon": "tornado.svg"
   },
   "night/tornado": {
-    "icon": "tornado.svg",
-    "conditions": "Tornado"
+    "icon": "tornado.svg"
   },
   "day/tropical_storm": {
-    "icon": "hurricane.svg",
-    "conditions": "Tropical storm conditions"
+    "icon": "hurricane.svg"
   },
   "night/tropical_storm": {
-    "icon": "hurricane.svg",
-    "conditions": "Tropical storm conditions"
+    "icon": "hurricane.svg"
   },
   "day/tsra": {
-    "icon": "thunderstorm.svg",
-    "conditions": "Thunderstorm (high cloud cover)"
+    "icon": "thunderstorm.svg"
   },
   "day/tsra_hi": {
-    "icon": "thunderstorm.svg",
-    "conditions": "Thunderstorm (low cloud cover)"
+    "icon": "thunderstorm.svg"
   },
   "night/tsra_hi": {
-    "icon": "thunderstorm.svg",
-    "conditions": "Thunderstorm (low cloud cover)"
+    "icon": "thunderstorm.svg"
   },
   "night/tsra": {
-    "icon": "thunderstorm.svg",
-    "conditions": "Thunderstorm (high cloud cover)"
+    "icon": "thunderstorm.svg"
   },
   "day/tsra_sct": {
-    "icon": "thunderstorm.svg",
-    "conditions": "Thunderstorm (medium cloud cover)"
+    "icon": "thunderstorm.svg"
   },
   "night/tsra_sct": {
-    "icon": "thunderstorm.svg",
-    "conditions": "Thunderstorm (medium cloud cover)"
+    "icon": "thunderstorm.svg"
   },
   "day/wind_bkn": {
-    "icon": "new_windy_cloudy.svg",
-    "conditions": "Mostly cloudy and windy"
+    "icon": "new_windy_cloudy.svg"
   },
   "night/wind_bkn": {
-    "icon": "new_windy_cloudy.svg",
-    "conditions": "Mostly cloudy and windy"
+    "icon": "new_windy_cloudy.svg"
   },
   "day/wind_few": {
-    "icon": "new_windy_cloudy.svg",
-    "conditions": "A few clouds and windy"
+    "icon": "new_windy_cloudy.svg"
   },
   "night/wind_few": {
-    "icon": "new_windy_cloudy.svg",
-    "conditions": "A few clouds and windy"
+    "icon": "new_windy_cloudy.svg"
   },
   "day/wind_ovc": {
-    "icon": "new_windy_cloudy.svg",
-    "conditions": "Overcast and windy"
+    "icon": "new_windy_cloudy.svg"
   },
   "night/wind_ovc": {
-    "icon": "new_windy_cloudy.svg",
-    "conditions": "Overcast and windy"
+    "icon": "new_windy_cloudy.svg"
   },
   "day/wind_sct": {
-    "icon": "new_windy_cloudy.svg",
-    "conditions": "Partly cloudy and windy"
+    "icon": "new_windy_cloudy.svg"
   },
   "night/wind_sct": {
-    "icon": "new_windy_cloudy.svg",
-    "conditions": "Partly cloudy and windy"
+    "icon": "new_windy_cloudy.svg"
   },
   "day/wind_skc": {
-    "icon": "windy.svg",
-    "conditions": "Fair/clear and windy"
+    "icon": "windy.svg"
   },
   "night/wind_skc": {
-    "icon": "windy.svg",
-    "conditions": "Fair/clear and windy"
+    "icon": "windy.svg"
   }
 }

--- a/web/modules/weather_data/src/Service/test_data/daily.forecast.good.json
+++ b/web/modules/weather_data/src/Service/test_data/daily.forecast.good.json
@@ -14,26 +14,11 @@
     "type": "Polygon",
     "coordinates": [
       [
-        [
-          -105.0066349,
-          39.7603119
-        ],
-        [
-          -105.00451969999999,
-          39.738315799999995
-        ],
-        [
-          -104.97595569999999,
-          39.739937299999994
-        ],
-        [
-          -104.97806499999999,
-          39.76193359999999
-        ],
-        [
-          -105.0066349,
-          39.7603119
-        ]
+        [-105.0066349, 39.7603119],
+        [-105.00451969999999, 39.738315799999995],
+        [-104.97595569999999, 39.739937299999994],
+        [-104.97806499999999, 39.76193359999999],
+        [-105.0066349, 39.7603119]
       ]
     ]
   },
@@ -235,7 +220,7 @@
         "windSpeed": "6 to 9 mph",
         "windDirection": "NE",
         "icon": "https://api.weather.gov/icons/land/day/snow,20?size=medium",
-        "shortForecast": "Slight Chance Snow Showers (Low Cloud Cover)",
+        "shortForecast": "SLIGHT SNOW",
         "detailedForecast": "A slight chance of snow showers between 11am and 5pm. Mostly cloudy, with a high near 38. Chance of precipitation is 20%."
       },
       {
@@ -343,7 +328,7 @@
         "windSpeed": "9 mph",
         "windDirection": "W",
         "icon": "https://api.weather.gov/icons/land/day/sct?size=medium",
-        "shortForecast": "Mostly Sunny",
+        "shortForecast": "Cats And Dogs!",
         "detailedForecast": "Mostly sunny, with a high near 48."
       },
       {

--- a/web/modules/weather_data/src/Service/test_data/observation.bad-empty-icon.json
+++ b/web/modules/weather_data/src/Service/test_data/observation.bad-empty-icon.json
@@ -61,7 +61,7 @@
         "station": "https://observation-station-1",
         "timestamp": "2023-10-12T20:00:00+00:00",
         "rawMessage": "ARGLE BARGLE FLARGLE FLARGLE",
-        "textDescription": "It's really coming down out there",
+        "textDescription": "Not snow",
         "icon": "",
         "presentWeather": [
           {

--- a/web/modules/weather_data/src/Service/test_data/observation.bad-null-icon.json
+++ b/web/modules/weather_data/src/Service/test_data/observation.bad-null-icon.json
@@ -61,7 +61,7 @@
         "station": "https://observation-station-1",
         "timestamp": "2023-10-12T20:00:00+00:00",
         "rawMessage": "ARGLE BARGLE FLARGLE FLARGLE",
-        "textDescription": "It's really coming down out there",
+        "textDescription": "Not snow",
         "icon": null,
         "presentWeather": [
           {

--- a/web/modules/weather_data/src/Service/test_data/observation.good-both.json
+++ b/web/modules/weather_data/src/Service/test_data/observation.good-both.json
@@ -61,7 +61,7 @@
         "station": "https://observation-station-1",
         "timestamp": "2023-10-12T20:00:00+00:00",
         "rawMessage": "ARGLE BARGLE FLARGLE FLARGLE",
-        "textDescription": "It's really coming down out there",
+        "textDescription": "Not snow",
         "icon": "https://api.weather.gov/icons/land/day/snow?size=medium",
         "presentWeather": [
           {

--- a/web/modules/weather_data/src/Service/test_data/observation.good-heatindex.json
+++ b/web/modules/weather_data/src/Service/test_data/observation.good-heatindex.json
@@ -61,7 +61,7 @@
         "station": "https://observation-station-1",
         "timestamp": "2023-10-12T20:00:00+00:00",
         "rawMessage": "ARGLE BARGLE FLARGLE FLARGLE",
-        "textDescription": "It's really coming down out there",
+        "textDescription": "Not snow",
         "icon": "https://api.weather.gov/icons/land/day/snow?size=medium",
         "presentWeather": [
           {

--- a/web/modules/weather_data/src/Service/test_data/observation.good-no-feelslike.json
+++ b/web/modules/weather_data/src/Service/test_data/observation.good-no-feelslike.json
@@ -61,7 +61,7 @@
         "station": "https://observation-station-1",
         "timestamp": "2023-10-12T20:00:00+00:00",
         "rawMessage": "ARGLE BARGLE FLARGLE FLARGLE",
-        "textDescription": "It's really coming down out there",
+        "textDescription": "Not snow",
         "icon": "https://api.weather.gov/icons/land/day/snow?size=medium",
         "presentWeather": [
           {

--- a/web/modules/weather_data/src/Service/test_data/observation.good-windchill.json
+++ b/web/modules/weather_data/src/Service/test_data/observation.good-windchill.json
@@ -61,7 +61,7 @@
         "station": "https://observation-station-1",
         "timestamp": "2023-10-12T20:00:00+00:00",
         "rawMessage": "ARGLE BARGLE FLARGLE FLARGLE",
-        "textDescription": "It's really coming down out there",
+        "textDescription": "Not snow",
         "icon": "https://api.weather.gov/icons/land/day/snow?size=medium",
         "presentWeather": [
           {


### PR DESCRIPTION
## What does this PR do? 🛠️

We currently key off the icon returned by the API to map into a condition description. However, (we think) we should be using the text from the API. This PR updates the current conditions, hourly forecast, and daily forecast components to use the text provided by the API.

Addresses #455 

## What does the reviewer need to know? 🤔

A simple cache clear should have this ready to run locally.

I think it would be good to do a design/eng huddle to look at this together. It would also still be super helpful to have a complete and definitive list of text values the API may return so we know what kind of text lengths we need to accommodate.