### PR TITLE
Refactor: Have a single method for fetching API data and cache it

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherDataService.getFromAPI.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.getFromAPI.php.test
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\weather_data\Service;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the WeatherDataService getCurrentConditions method.
+ */
+final class WeatherDataServiceGetFromApiTest extends TestCase {
+  /**
+   * The mocked HTTP client.
+   *
+   * @var httpClientMock
+   */
+  protected $httpClientMock;
+
+  /**
+   * The WeatherDataService object under test.
+   *
+   * @var weatherDataService
+   */
+  protected $weatherDataService;
+
+  /**
+   * Common setup for all component tests.
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    $this->httpClientMock = new MockHandler([]);
+    $stack = HandlerStack::create($this->httpClientMock);
+    $client = new Client(['handler' => $stack]);
+
+    // Just return the input string. The translation manager is tested by Drupal
+    // so we don't need to.
+    $translationManager = $this->createStub(TranslationInterface::class);
+    $translationManager->method('translate')->will(
+      $this->returnCallback(
+        function ($str) {
+          return $str;
+        }
+      )
+    );
+
+    $this->weatherDataService = new WeatherDataService($client, $translationManager);
+  }
+
+  public function testGetsApiData(): void {
+    $expected = (object)[ "response" => "here"];
+    $this->httpClientMock->append(new Response(200,['Content-type'=>'application/json'], '{"response":"here"}'));
+
+    $actual = $this->weatherDataService->getFromWeatherAPI("my url");
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  public function testCachesApiData(): void {
+    $this->httpClientMock->append(new Response(200,['Content-type'=>'application/json'], '{"response":"here"}'));
+    $first = $this->weatherDataService->getFromWeatherAPI("my url");
+
+    $this->httpClientMock->append(new Response(200,['Content-type'=>'application/json'], '{"here":"response"}'));
+    $second = $this->weatherDataService->getFromWeatherAPI("my url");
+
+    $this->assertEquals($second, $first);
+  }
+
+}

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -52,6 +52,13 @@ class WeatherDataService {
   private $currentConditions;
 
   /**
+   * Cache of API calls for this request.
+   *
+   * @var apiCache
+   */
+  private $apiCache;
+
+  /**
    * Constructor.
    */
   public function __construct(ClientInterface $httpClient, TranslationInterface $t) {
@@ -62,11 +69,32 @@ class WeatherDataService {
 
     $this->currentConditions = FALSE;
 
+    $this->apiCache = [];
+
     $this->legacyMapping = json_decode(
       file_get_contents(
         __DIR__ . "/legacyMapping.json"
       )
     );
+  }
+
+  /**
+   * Get data from the weather API.
+   *
+   * The results for any given URL are cached for the duration of the current
+   * response. The cache is not persisted across responses.
+   *
+   * Disable phpcs on the next line because it does not like method names with
+   * sequential uppercase characters, but... I'm not camel-casing "API".
+   */
+  public function getFromWeatherAPI($url) { // phpcs:ignore
+    if (!array_key_exists($url, $this->apiCache)) {
+      $response = $this->client->get($url);
+      $response = json_decode($response->getBody());
+      $this->apiCache[$url] = $response;
+    }
+
+    return $this->apiCache[$url];
   }
 
   /**
@@ -175,8 +203,7 @@ class WeatherDataService {
    */
   public function getGridFromLatLon($lat, $lon) {
     try {
-      $locationResponse = $this->client->get("https://api.weather.gov/points/$lat,$lon");
-      $locationMetadata = json_decode($locationResponse->getBody());
+      $locationMetadata = $this->getFromWeatherAPI("https://api.weather.gov/points/$lat,$lon");
 
       return [
         "wfo" => $locationMetadata->properties->gridId,
@@ -210,82 +237,73 @@ class WeatherDataService {
       return NULL;
     }
 
-    // This object is only created once per request, so we can store the
-    // results of the API call in a member variable. If the variable is false,
-    // we haven't fetched data yet so do that. Otherwise, just return what's in
-    // the variable already.
-    if ($this->currentConditions == FALSE) {
-      // Since we're on the right kind of route, pull out the data we need.
-      $wfo = $route->getParameter("wfo");
-      $gridX = $route->getParameter("gridX");
-      $gridY = $route->getParameter("gridY");
-      $location = $route->getParameter("location");
+    // Since we're on the right kind of route, pull out the data we need.
+    $wfo = $route->getParameter("wfo");
+    $gridX = $route->getParameter("gridX");
+    $gridY = $route->getParameter("gridY");
+    $location = $route->getParameter("location");
 
-      date_default_timezone_set('America/New_York');
+    date_default_timezone_set('America/New_York');
 
-      $obsStationsResponse = $this->client->get("https://api.weather.gov/gridpoints/$wfo/$gridX,$gridY/stations");
-      $obsStationsMetadata = json_decode($obsStationsResponse->getBody());
+    $obsStationsMetadata = $this->getFromWeatherAPI("https://api.weather.gov/gridpoints/$wfo/$gridX,$gridY/stations");
 
-      $observationStation = $obsStationsMetadata->features[0];
+    $observationStation = $obsStationsMetadata->features[0];
 
-      $obsResponse = $this->client->get($observationStation->id . "/observations?limit=1");
-      $obs = json_decode($obsResponse->getBody())->features[0]->properties;
+    $obs = $this->getFromWeatherAPI($observationStation->id . "/observations?limit=1")->features[0]->properties;
 
-      $timestamp = \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $obs->timestamp);
+    $timestamp = \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $obs->timestamp);
 
-      $feelsLike = $obs->heatIndex->value;
-      if ($feelsLike == NULL) {
-        $feelsLike = $obs->windChill->value;
-      }
-      if ($feelsLike == NULL) {
-        $feelsLike = $obs->temperature->value;
-      }
-      $feelsLike = 32 + (9 * $feelsLike / 5);
-
-      $obsKey = $this->getApiObservationKey($obs);
-
-      $description = $this->legacyMapping->$obsKey->conditions;
-
-      // The cardinal and ordinal directions. North goes in twice because it
-      // sits in two "segments": -22.5° to 22.5°, and 337.5° to 382.5°.
-      $directions = ["north", "northeast", "east", "southeast", "south",
-        "southwest", "west", "northwest", "north",
-      ];
-      $shortDirections = ["N", "NE", "E", "SE", "S", "SW", "W", "NW", "N"];
-
-      // 1. Whatever degrees we got from the API, constrain it to 0°-360°.
-      // 2. Add 22.5° to it. This accounts for north starting at -22.5°
-      // 3. Use integer division by 45° to see which direction index this is.
-      // This indexes into the two direction name arrays above.
-      $directionIndex = intdiv(intval(($obs->windDirection->value % 360) + 22.5, 10), 45);
-
-      $this->currentConditions = [
-        'conditions' => [
-          'long' => $this->t->translate($description),
-          'short' => $this->t->translate($description),
-        ],
-        // C to F.
-        'feels_like' => (int) round($feelsLike),
-        'humidity' => (int) round($obs->relativeHumidity->value ?? 0),
-        'icon' => $this->legacyMapping->$obsKey->icon,
-        'location' => $location,
-        // C to F.
-        'temperature' => (int) round(32 + (9 * $obs->temperature->value / 5)),
-        'timestamp' => [
-          'formatted' => $timestamp->format("l g:i A T"),
-          'utc' => (int) $timestamp->format("U"),
-        ],
-        'wind' => [
-          // Kph to mph.
-          'speed' => (int) round($obs->windSpeed->value * 0.6213712),
-          'angle' => $obs->windDirection->value,
-          'direction' => $directions[$directionIndex],
-          'shortDirection' => $shortDirections[$directionIndex],
-        ],
-      ];
+    $feelsLike = $obs->heatIndex->value;
+    if ($feelsLike == NULL) {
+      $feelsLike = $obs->windChill->value;
     }
+    if ($feelsLike == NULL) {
+      $feelsLike = $obs->temperature->value;
+    }
+    $feelsLike = 32 + (9 * $feelsLike / 5);
 
-    return $this->currentConditions;
+    $obsKey = $this->getApiObservationKey($obs);
+
+    $description = $this->legacyMapping->$obsKey->conditions;
+
+    // The cardinal and ordinal directions. North goes in twice because it
+    // sits in two "segments": -22.5° to 22.5°, and 337.5° to 382.5°.
+    $directions = ["north", "northeast", "east", "southeast", "south",
+      "southwest", "west", "northwest", "north",
+    ];
+    $shortDirections = ["N", "NE", "E", "SE", "S", "SW", "W", "NW", "N"];
+
+    // 1. Whatever degrees we got from the API, constrain it to 0°-360°.
+    // 2. Add 22.5° to it. This accounts for north starting at -22.5°
+    // 3. Use integer division by 45° to see which direction index this is.
+    // This indexes into the two direction name arrays above.
+    $directionIndex = intdiv(intval(($obs->windDirection->value % 360) + 22.5, 10), 45);
+
+    return [
+      'conditions' => [
+        'long' => $this->t->translate($description),
+        'short' => $this->t->translate($description),
+      ],
+      // C to F.
+      'feels_like' => (int) round($feelsLike),
+      'humidity' => (int) round($obs->relativeHumidity->value ?? 0),
+      'icon' => $this->legacyMapping->$obsKey->icon,
+      'location' => $location,
+      // C to F.
+      'temperature' => (int) round(32 + (9 * $obs->temperature->value / 5)),
+      'timestamp' => [
+        'formatted' => $timestamp->format("l g:i A T"),
+        'utc' => (int) $timestamp->format("U"),
+      ],
+      'wind' => [
+        // Kph to mph.
+        'speed' => (int) round($obs->windSpeed->value * 0.6213712),
+        'angle' => $obs->windDirection->value,
+        'direction' => $directions[$directionIndex],
+        'shortDirection' => $shortDirections[$directionIndex],
+      ],
+    ];
+
   }
 
   /**
@@ -317,14 +335,12 @@ class WeatherDataService {
 
     date_default_timezone_set('America/New_York');
 
-    $forecast = $this->client->get("https://api.weather.gov/gridpoints/$wfo/$gridX,$gridY/forecast/hourly");
-    $forecast = json_decode($forecast->getBody());
+    $forecast = $this->getFromWeatherAPI("https://api.weather.gov/gridpoints/$wfo/$gridX,$gridY/forecast/hourly");
 
     // Get a point from the WFO grid. Any will do. We will use that to fetch the
     // appropriate timezone from the /points API endpoint.
     $point = $forecast->geometry->coordinates[0][0];
-    $timezone = $this->client->get("https://api.weather.gov/points/$point[1],$point[0]");
-    $timezone = json_decode($timezone->getBody());
+    $timezone = $this->getFromWeatherAPI("https://api.weather.gov/points/$point[1],$point[0]");
     $timezone = $timezone->properties->timeZone;
 
     $forecast = $forecast->properties->periods;
@@ -393,8 +409,7 @@ class WeatherDataService {
     $gridX = $route->getParameter("gridX");
     $gridY = $route->getParameter("gridY");
 
-    $forecast = $this->client->get("https://api.weather.gov/gridpoints/$wfo/$gridX,$gridY/forecast");
-    $forecast = json_decode($forecast->getBody());
+    $forecast = $this->getFromWeatherAPI("https://api.weather.gov/gridpoints/$wfo/$gridX,$gridY/forecast");
 
     $periods = $forecast->properties->periods;
 

--- a/web/modules/weather_data/src/Service/WeatherDataService.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php.test
@@ -260,26 +260,6 @@ final class WeatherDataServiceGetCurrentConditionsTest extends TestCase {
   }
 
   /**
-   * Tests that curent conditions results are cached.
-   */
-  public function testCaching(): void {
-    // First setup the API to return no feels-like temperature and get the
-    // conditions accordingly.
-    $expected = $this->setupHappyPath("observation.good-no-feelslike.json");
-    $this->weatherDataService->getCurrentConditions($this->routeMock);
-
-    // Now setup the API to return both heat index and wind chill and get the
-    // conditions again.
-    $this->setupHappyPath("observation.good-both.json");
-    $actual = $this->weatherDataService->getCurrentConditions($this->routeMock);
-
-    // The output from the second call should be the based on the no-feels-like
-    // setup because the results should be cached. The API should not be called
-    // again.
-    $this->assertEquals((object) $expected, (object) $actual);
-  }
-
-  /**
    * Tests asking for current conditions when not on a grid route.
    */
   public function testNotGridRoute(): void {


### PR DESCRIPTION
## What does this PR do? 🛠️

- Adds a public `getFromWeatherAPI` method to the weather data service, and modifies the other methods to use it
- The new method caches data from any given URL for the duration of the response
- Removes independent caching from `getCurrentConditions`
- Adds tests for the new method, and removes caching test for `getCurrentConditions`

## What does the reviewer need to know? 🤔

Main this probably to disable whitespace in the review, because `getCurrentConditions` gets unindented, undoing (but generalizing!) a change from #439.