### PR TITLE
Refactor: Update remaining weather data service methods to accept grid parameters

### DIFF
--- a/web/modules/weather_blocks/src/Plugin/Block/DailyForecastBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/DailyForecastBlock.php
@@ -17,10 +17,16 @@ class DailyForecastBlock extends WeatherBlockBase {
    * {@inheritdoc}
    */
   public function build() {
-    $routeName = $this->route->getRouteName();
+    $location = $this->getLocation();
 
-    if ($routeName == "weather_routes.grid") {
-      $data = $this->weatherData->getDailyForecast($this->route);
+    if ($location->grid) {
+      $grid = $location->grid;
+
+      $data = $this->weatherData->getDailyForecastFromGrid(
+        $grid->wfo,
+        $grid->x,
+        $grid->y
+      );
       return ["days" => $data];
     }
     return NULL;

--- a/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
@@ -45,12 +45,18 @@ class HourlyForecastBlock extends WeatherBlockBase {
    * {@inheritdoc}
    */
   public function build() {
-    $routeName = $this->route->getRouteName();
+    $location = $this->getLocation();
 
-    if ($routeName == "weather_routes.grid") {
+    if ($location->grid) {
+      $grid = $location->grid;
+
       $config = $this->getConfiguration();
       $max = $config["max_items"] ?? "12";
-      $data = $this->weatherData->getHourlyForecast($this->route);
+      $data = $this->weatherData->getHourlyForecastFromGrid(
+        $grid->wfo,
+        $grid->x,
+        $grid->y
+      );
       $data = array_slice($data, 0, $max);
 
       return ["hours" => $data];

--- a/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php.test
@@ -116,7 +116,7 @@ final class HourlyForecastBlockTest extends TestCase {
    */
   public function testBuildWithDefaultConfiguration() : void {
     $this->weatherData
-      ->method('getHourlyForecast')
+      ->method('getHourlyForecastFromGrid')
       ->willReturn([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 
     $expected = [
@@ -134,7 +134,7 @@ final class HourlyForecastBlockTest extends TestCase {
     $this->hourlyForecastBlock->setConfigurationValue("max_items", "7");
 
     $this->weatherData
-      ->method('getHourlyForecast')
+      ->method('getHourlyForecastFromGrid')
       ->willReturn([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 
     $expected = [

--- a/web/modules/weather_data/src/Service/WeatherDataService.getDailyForecast.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.getDailyForecast.php.test
@@ -4,7 +4,6 @@ namespace Drupal\weather_data\Service;
 
 include_once "WeatherDataService.php";
 
-use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -22,13 +21,6 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
    * @var httpClientMock
    */
   protected $httpClientMock;
-
-  /**
-   * The mocked route object.
-   *
-   * @var routeMock
-   */
-  protected $routeMock;
 
   /**
    * The WeatherDataService object under test.
@@ -72,15 +64,6 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
     );
 
     $this->weatherDataService = new WeatherDataService($client, $translationManager);
-
-    $this->routeMock = $this->createStub(RouteMatchInterface::class);
-    $this->routeMock->method('getRouteName')->willReturn('weather_routes.grid');
-    $this->routeMock->method('getParameter')->WillReturnMap([
-      ['wfo', 'BOU'],
-      ['gridX', 63],
-      ['gridY', 62],
-      ['location', 'Boulder'],
-    ]);
   }
 
   /**
@@ -111,8 +94,8 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
     $this->setupHappyPath();
     $expected = 5;
 
-    $forecastDays = $this->weatherDataService->getDailyForecast(
-      $this->routeMock,
+    $forecastDays = $this->weatherDataService->getDailyForecastFromGrid(
+      'wfo', 'x', 'y',
       $this->now
     );
     $actual = count($forecastDays);
@@ -127,8 +110,8 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
     $this->setupHappyPath();
     $expected = 2;
 
-    $forecastDays = $this->weatherDataService->getDailyForecast(
-      $this->routeMock,
+    $forecastDays = $this->weatherDataService->getDailyForecastFromGrid(
+      'wfo', 'x', 'y',
       $this->now,
       2
     );
@@ -149,8 +132,8 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
       'Fri',
       'Sat',
     ];
-    $forecastDays = $this->weatherDataService->getDailyForecast(
-      $this->routeMock,
+    $forecastDays = $this->weatherDataService->getDailyForecastFromGrid(
+      'wfo', 'x', 'y',
       $this->now
     );
     $actual = array_map(function ($day) {
@@ -172,8 +155,8 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
       "2023-12-01T06:00:00-07:00",
       "2023-12-02T06:00:00-07:00",
     ];
-    $forecastDays = $this->weatherDataService->getDailyForecast(
-      $this->routeMock,
+    $forecastDays = $this->weatherDataService->getDailyForecastFromGrid(
+      'wfo', 'x', 'y',
       $this->now
     );
 
@@ -197,8 +180,8 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
       42,
       48,
     ];
-    $forecastDays = $this->weatherDataService->getDailyForecast(
-      $this->routeMock,
+    $forecastDays = $this->weatherDataService->getDailyForecastFromGrid(
+      'wfo', 'x', 'y',
       $this->now
     );
     $actual = array_map(function ($forecast) {
@@ -220,8 +203,8 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
       22,
       23,
     ];
-    $forecastDays = $this->weatherDataService->getDailyForecast(
-      $this->routeMock,
+    $forecastDays = $this->weatherDataService->getDailyForecastFromGrid(
+      'wfo', 'x', 'y',
       $this->now
     );
     $actual = array_map(function ($forecast) {
@@ -246,8 +229,8 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
       'Partly cloudy',
       'Partly cloudy',
     ];
-    $forecastDays = $this->weatherDataService->getDailyForecast(
-      $this->routeMock,
+    $forecastDays = $this->weatherDataService->getDailyForecastFromGrid(
+      'wfo', 'x', 'y',
       $this->now
     );
     $actual = array_map(function ($forecast) {
@@ -270,8 +253,8 @@ final class WeatherDataServiceGetDailyForecastTest extends TestCase {
       NULL,
       NULL,
     ];
-    $forecastDays = $this->weatherDataService->getDailyForecast(
-      $this->routeMock,
+    $forecastDays = $this->weatherDataService->getDailyForecastFromGrid(
+      'wfo', 'x', 'y',
       $this->now
     );
     $actual = array_map(function ($forecast) {

--- a/web/modules/weather_data/src/Service/WeatherDataService.getHourlyForecast.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.getHourlyForecast.php.test
@@ -4,7 +4,6 @@ namespace Drupal\weather_data\Service;
 
 include_once "WeatherDataService.php";
 
-use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -22,13 +21,6 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
    * @var httpClientMock
    */
   protected $httpClientMock;
-
-  /**
-   * The mocked route object.
-   *
-   * @var routeMock
-   */
-  protected $routeMock;
 
   /**
    * The WeatherDataService object under test.
@@ -75,15 +67,6 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
     );
 
     $this->weatherDataService = new WeatherDataService($client, $translationManager);
-
-    $this->routeMock = $this->createStub(RouteMatchInterface::class);
-    $this->routeMock->method('getRouteName')->willReturn('weather_routes.grid');
-    $this->routeMock->method('getParameter')->WillReturnMap([
-      ['wfo', 'NWS'],
-      ['gridX', 10],
-      ['gridY', 10],
-      ['location', 'National Weather Service'],
-    ]);
   }
 
   /**
@@ -159,7 +142,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
     $this->setupHappyPath($response);
 
     $expected = [];
-    $actual = $this->weatherDataService->getHourlyForecast($this->routeMock, $this->now);
+    $actual = $this->weatherDataService->getHourlyForecastFromGrid('wfo', 'x', 'y', $this->now);
     $this->assertEquals((object) $expected, (object) $actual);
   }
 
@@ -204,7 +187,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
       ],
     ];
 
-    $actual = $this->weatherDataService->getHourlyForecast($this->routeMock, $this->now);
+    $actual = $this->weatherDataService->getHourlyForecastFromGrid('wfo', 'x', 'y', $this->now);
 
     $this->assertEquals((object) $expected, (object) $actual);
   }
@@ -259,7 +242,7 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
       ],
     ];
 
-    $actual = $this->weatherDataService->getHourlyForecast($this->routeMock, $this->now);
+    $actual = $this->weatherDataService->getHourlyForecastFromGrid('wfo', 'x', 'y', $this->now);
 
     $this->assertEquals((object) $expected, (object) $actual);
   }
@@ -282,25 +265,8 @@ final class WeatherDataServiceGetHourlyForecastTest extends TestCase {
     $this->setupHappyPath($response);
 
     $expected = [];
-    $actual = $this->weatherDataService->getHourlyForecast($this->routeMock);
+    $actual = $this->weatherDataService->getHourlyForecastFromGrid('wfo', 'x', 'y');
     $this->assertEquals((object) $expected, (object) $actual);
-  }
-
-  /**
-   * Tests asking for current conditions when not on a grid route.
-   */
-  public function testNotGridRoute(): void {
-    // Create a one-off stub because phpunit doesn't allow overriding a return
-    // value from a stub once it's set. It's just set forever. And rather than
-    // changing the setup() method that works for most of these tests, we'll
-    // just work around it.
-    // https://github.com/sebastianbergmann/phpunit-mock-objects/issues/260
-    $routeMock = $this->createStub(RouteMatchInterface::class);
-    $routeMock->method('getRouteName')->willReturn('weather_routes.not-grid');
-
-    $actual = $this->weatherDataService->getHourlyForecast($routeMock);
-
-    $this->assertEquals(NULL, $actual);
   }
 
 }

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -291,29 +291,16 @@ class WeatherDataService {
   /**
    * Get the hourly forecast for a location.
    *
-   * The location is taken from the provided route. Note that the $now object
-   * should *NOT* be set. It's a dependency injection hack so we can mock the
-   * current date/time.
+   * Note that the $now object should *NOT* be set. It's a dependency injection
+   * hack so we can mock the current date/time.
    *
    * @return array
-   *   The hourly forecast as an associative array, or NULL if no route is
-   *   provided, or the provided route is not on the grid.
+   *   The hourly forecast as an associative array.
    */
-  public function getHourlyForecast($route, $now = FALSE) {
-    // If this isn't a grid route, don't do anything. We can only respond to
-    // requests on the grid.
-    if ($route->getRouteName() != "weather_routes.grid") {
-      return NULL;
-    }
-
+  public function getHourlyForecastFromGrid($wfo, $gridX, $gridY, $now = FALSE) {
     if (!($now instanceof \DateTimeImmutable)) {
       $now = new \DateTimeImmutable();
     }
-
-    // Since we're on the right kind of route, pull out the data we need.
-    $wfo = $route->getParameter("wfo");
-    $gridX = $route->getParameter("gridX");
-    $gridY = $route->getParameter("gridY");
 
     date_default_timezone_set('America/New_York');
 
@@ -370,27 +357,13 @@ class WeatherDataService {
   /**
    * Get the daily forecast for a location.
    *
-   * The location is taken from the provided route. Note that the $now object
-   * should *NOT* be set. It's a dependency injection hack so we can mock the
-   * current date/time.
+   * Note that the $now object should *NOT* be set. It's a dependency injection
+   * hack so we can mock the current date/time.
    *
    * @return array
-   *   The daily forecast as an associative array, or NULL if no route is
-   *   provided, or the provided route is not on the grid.
+   *   The daily forecast as an associative array.
    */
-  public function getDailyForecast($route, $now = FALSE, $defaultDays = 5) {
-    // If this isn't a grid route, don't do anything. We can only respond to
-    // requests on the grid.
-    if ($route->getRouteName() != "weather_routes.grid") {
-      return NULL;
-    }
-
-    // We pull the grid information from the
-    // route URI.
-    $wfo = $route->getParameter("wfo");
-    $gridX = $route->getParameter("gridX");
-    $gridY = $route->getParameter("gridY");
-
+  public function getDailyForecastFromGrid($wfo, $gridX, $gridY, $now = FALSE, $defaultDays = 5) {
     $forecast = $this->getFromWeatherAPI("https://api.weather.gov/gridpoints/$wfo/$gridX,$gridY/forecast");
 
     $periods = $forecast->properties->periods;


### PR DESCRIPTION
## What does this PR do? 🛠️

Builds on #481 by making the rest of the weather data service behave the same as `getCurrentConditionsFromGrid`.