### PR TITLE
Remove test coverage reporter

### DIFF
--- a/.github/workflows/code-standards.yaml
+++ b/.github/workflows/code-standards.yaml
@@ -191,25 +191,6 @@ jobs:
           path: coverage.xml
           retention-days: 1
 
-  report-code-coverage:
-    name: report code coverage
-    runs-on: ubuntu-latest
-    needs: [php-unit-tests, should-test]
-
-    steps:
-      - name: get coverage output
-        if: needs.should-test.outputs.yes == 'true'
-        uses: actions/download-artifact@v3
-        with:
-          name: coverage-report
-
-      - name: report coverage
-        if: needs.should-test.outputs.yes == 'true'
-        uses: lucassabreu/comment-coverage-clover@v0.10.2
-        with:
-          file: coverage.xml
-          signature: "code coverage report"
-
   min-code-coverage:
     name: "90% code coverage"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do? 🛠️

Disables the test coverage reporter step of our code standards automated tests. This step is the one responsible for the extra comment on all our pull requests with the funky coverage histogram, which is a really odd way of presenting that data. It's not very useful and it creates extra notifications. Since we already have a step for enforcing a 90% lower-bound on code coverage, we don't really need this.