### PR TITLE
fetch location from API

### DIFF
--- a/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php
@@ -21,7 +21,7 @@ class LocationSearchBlock extends WeatherBlockBase {
 
     if ($location->grid) {
       $grid = $location->grid;
-      $data = $this->weatherData->getCurrentConditionsFromGrid(
+      $data = $this->weatherData->getPlaceFromGrid(
         $grid->wfo,
         $grid->x,
         $grid->y
@@ -29,13 +29,13 @@ class LocationSearchBlock extends WeatherBlockBase {
 
       if ($data) {
         return [
-          'location' => $data["location"],
+          'place' => $data,
         ];
       }
     }
 
     return [
-      'location' => NULL,
+      'place' => NULL,
     ];
   }
 

--- a/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php.test
@@ -58,11 +58,29 @@ final class LocationSearchBlockTest extends TestCase {
   public function testBuild() : void {
 
     $this->weatherData
-      ->method('getCurrentConditionsFromGrid')
-      ->willReturn(["location" => "The Place We Are"]);
+      ->method('getPlaceFromGrid')
+      ->willReturn("hiya");
 
     $expected = [
-      "location" => "The Place We Are",
+      "place" => "hiya",
+    ];
+
+    $actual = $this->locationSearchBlock->build();
+
+    $this->assertEquals((object) $expected, (object) $actual);
+  }
+
+  /**
+   * Test that the build method returns NULL if there is no location.
+   */
+  public function testWithNoLocation() : void {
+
+    $this->routeMock
+      ->method('getRouteName')
+      ->willReturn("not grid");
+
+    $expected = [
+      "place" => NULL,
     ];
 
     $actual = $this->locationSearchBlock->build();

--- a/web/modules/weather_data/src/Service/Test/GetGeometryFromGrid.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetGeometryFromGrid.php.test
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\weather_data\Service;
+
+include_once realpath(__DIR__ . "/../WeatherDataService.php");
+
+use Drupal\Core\StringTranslation\TranslationInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test getting geometry from the grid.
+ */
+final class GetGeometryFromGridTest extends TestCase {
+  /**
+   * The mocked HTTP client.
+   *
+   * @var httpClientMock
+   */
+  protected $httpClientMock;
+
+  /**
+   * The WeatherDataService object under test.
+   *
+   * @var weatherDataService
+   */
+  protected $weatherDataService;
+
+  /**
+   * Common setup for all component tests.
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    $this->httpClientMock = new MockHandler([]);
+    $stack = HandlerStack::create($this->httpClientMock);
+    $client = new Client(['handler' => $stack]);
+
+    // Just return the input string. The translation manager is tested by Drupal
+    // so we don't need to.
+    $translationManager = $this->createStub(TranslationInterface::class);
+    $translationManager->method('translate')->will(
+      $this->returnCallback(
+        function ($str) {
+          return $str;
+        }
+      )
+    );
+
+    $this->weatherDataService = new WeatherDataService($client, $translationManager);
+  }
+
+  /**
+   * Tests the happy path.
+   */
+  public function testHappyPath(): void {
+    $expected = [
+      (object) ["lat" => 3, "lon" => 4],
+      (object) ["lat" => 9, "lon" => 5],
+      (object) ["lat" => 9, "lon" => 3],
+    ];
+
+    $this->httpClientMock->append(
+      new Response(200,
+        ['Content-type' => 'application/geo+json'],
+        '{"geometry":{"coordinates":[[[4,3],[5,9],[3,9]]]}}'
+      ),
+    );
+
+    $actual = $this->weatherDataService->getGeometryFromGrid("wfo", 1, 2);
+
+    $this->assertEquals((object) $expected, (object) $actual);
+  }
+
+}

--- a/web/modules/weather_data/src/Service/Test/GetPlaceFromGrid.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetPlaceFromGrid.php.test
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\weather_data\Service;
+
+include_once realpath(__DIR__ . "/../WeatherDataService.php");
+
+use Drupal\Core\StringTranslation\TranslationInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test getting place information from the grid.
+ */
+final class GetPlaceFromGridTest extends TestCase {
+  /**
+   * The mocked HTTP client.
+   *
+   * @var httpClientMock
+   */
+  protected $httpClientMock;
+
+  /**
+   * The WeatherDataService object under test.
+   *
+   * @var weatherDataService
+   */
+  protected $weatherDataService;
+
+  /**
+   * Common setup for all component tests.
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    $this->httpClientMock = new MockHandler([]);
+    $stack = HandlerStack::create($this->httpClientMock);
+    $client = new Client(['handler' => $stack]);
+
+    // Just return the input string. The translation manager is tested by Drupal
+    // so we don't need to.
+    $translationManager = $this->createStub(TranslationInterface::class);
+    $translationManager->method('translate')->will(
+      $this->returnCallback(
+        function ($str) {
+          return $str;
+        }
+      )
+    );
+
+    $this->weatherDataService = new WeatherDataService($client, $translationManager);
+  }
+
+  /**
+   * Tests the happy path.
+   */
+  public function testHappyPath(): void {
+
+    $expected = [
+      "city" => "City",
+      "state" => "Not City, but State",
+    ];
+
+    $this->httpClientMock->append(
+      new Response(200,
+        ['Content-type' => 'application/geo+json'],
+        '{"geometry":{"coordinates":[[[4,3],[5,9],[3,9]]]}}'
+      ),
+    );
+
+    $this->httpClientMock->append(
+      new Response(200,
+        ['Content-type' => 'application/geo+json'],
+        '{"properties":{"relativeLocation":{"properties":{"city":"City","state":"Not City, but State"}}}}'
+      ),
+    );
+
+    $actual = $this->weatherDataService->getPlaceFromGrid("wfo", 1, 2);
+
+    $this->assertEquals((object) $expected, (object) $actual);
+  }
+
+}

--- a/web/modules/weather_data/src/Service/Test/GetPlaceFromLatLon.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetPlaceFromLatLon.php.test
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\weather_data\Service;
+
+include_once realpath(__DIR__ . "/../WeatherDataService.php");
+
+use Drupal\Core\StringTranslation\TranslationInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test getting place information from the grid.
+ */
+final class GetPlaceFromLatLonTest extends TestCase {
+  /**
+   * The mocked HTTP client.
+   *
+   * @var httpClientMock
+   */
+  protected $httpClientMock;
+
+  /**
+   * The WeatherDataService object under test.
+   *
+   * @var weatherDataService
+   */
+  protected $weatherDataService;
+
+  /**
+   * Common setup for all component tests.
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    $this->httpClientMock = new MockHandler([]);
+    $stack = HandlerStack::create($this->httpClientMock);
+    $client = new Client(['handler' => $stack]);
+
+    // Just return the input string. The translation manager is tested by Drupal
+    // so we don't need to.
+    $translationManager = $this->createStub(TranslationInterface::class);
+    $translationManager->method('translate')->will(
+      $this->returnCallback(
+        function ($str) {
+          return $str;
+        }
+      )
+    );
+
+    $this->weatherDataService = new WeatherDataService($client, $translationManager);
+  }
+
+  /**
+   * Tests the happy path.
+   */
+  public function testHappyPath(): void {
+
+    $expected = [
+      "city" => "City",
+      "state" => "Not City, but State",
+    ];
+
+    $this->httpClientMock->append(
+      new Response(200,
+        ['Content-type' => 'application/geo+json'],
+        '{"properties":{"relativeLocation":{"properties":{"city":"City","state":"Not City, but State"}}}}'
+      ),
+    );
+
+    $actual = $this->weatherDataService->getPlaceFromLatLon(32, -93);
+
+    $this->assertEquals((object) $expected, (object) $actual);
+  }
+
+}

--- a/web/modules/weather_data/src/Service/WeatherDataService.php.test
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php.test
@@ -81,7 +81,6 @@ final class WeatherDataServiceGetCurrentConditionsTest extends TestCase {
       "feels_like" => 45,
       "humidity" => 88,
       "icon" => "snow.svg",
-      "location" => "SOMEWHERE - FIX THIS SOON",
       "temperature" => 45,
       "timestamp" => [
         "formatted" => "Thursday 8:00 PM GMT+0000",
@@ -199,7 +198,6 @@ final class WeatherDataServiceGetCurrentConditionsTest extends TestCase {
       "feels_like" => 45,
       "humidity" => 88,
       "icon" => "snow.svg",
-      "location" => "SOMEWHERE - FIX THIS SOON",
       "temperature" => 45,
       "timestamp" => [
         "formatted" => "Thursday 8:00 PM GMT+0000",

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-location-search.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-location-search.html.twig
@@ -1,7 +1,7 @@
 <div>
 
-  {% if content["location"] %}
-  <h1 class="margin-bottom-0">{{ content["location"] }}</h1>
+  {% if content.place %}
+  <h1 class="margin-bottom-0">{{ content.place.city }}, {{ content.place.state }}</h1>
 
   <div>
     <svg


### PR DESCRIPTION
## What does this PR do? 🛠️

- Adds methods to the weather data service:
  - `getGeometryFromGrid(wfo, x, y)` - for a given WFO grid cell, get its geographic bounds
  - `getPlaceFromLatLon(lat, lon)` - for a lat/lon point, get the associated "relative" place name from the API
  - `getPlaceFromGrid(wfo, x, y)` - for a given WFO grid cell, get the associated "relative" place name from the API
    - Under the hood, this first gets the geometry for the grid, picks a point, and then calls `getPlaceFromLatLon()`
- Updates the location search block to get location via the `getPlaceFromGrid()` method
- Updates the location block template to use the new values
- Removes location data from the `getCurrentConditions()` method
- Updates tests accordingly

Closes #474 

## What does the reviewer need to know? 🤔

I think just a `make rebuild` or maybe even just a `make cc` will do the job. 

If you navigate to [http://localhost:8080/local/MPX/108/72/Bob's%20Burgers](http://localhost:8080/local/MPX/108/72/Bob's%20Burgers), you should see that the place name is `Minneapolis, MN`, not `Bob's Burgers`. We're no longer taking the place name from the URL.