### PR TITLE
No longer import content on deployments

### DIFF
--- a/scripts/post-deploy.sh
+++ b/scripts/post-deploy.sh
@@ -22,11 +22,5 @@ drush list | grep "config:import" > /dev/null || install_drupal
 echo  "Updating drupal ... "
 drush state:set system.maintenance_mode 1 -y
 drush deploy -y
-# TODO: Remove and only pull content down
-# Temporarily importing content that was created locally
-for file in web/scs-export/*; do
-    file=${file#*/};
-    drush content:import $file;
-done
 drush state:set system.maintenance_mode 0 -y
 echo "Bootstrap finished"


### PR DESCRIPTION
## What does this PR do? 🛠️

The content we store in our repo is mostly just to get a representative site stood up quickly. Now that our deployed environments are up, we no longer need to import this content into them.
