### PR TITLE
Add an option for users to use their browser's geolocation feature

### DIFF
--- a/web/themes/new_weather_theme/assets/js/components/locationSearch.js
+++ b/web/themes/new_weather_theme/assets/js/components/locationSearch.js
@@ -105,12 +105,17 @@ const setupBrowserGeolocation = async () => {
           goToLocationPage(lat, long);
         },
         // Error callback
-        ({ code }) => {
+        ({ code, message }) => {
           if (code > 1) {
             // There was a problem getting the user's location. They allowed it,
             // but the browser gave us an error.
             // (Error code 1 is for when the user denies access to location, so
             // for our purposes, that is not an error.)
+
+            // eslint-disable-next-line no-alert
+            alert(
+              `There was a problem getting your location. Here's what your browser told us: ${message}`,
+            );
           }
         },
       );

--- a/web/themes/new_weather_theme/assets/js/components/locationSearch.js
+++ b/web/themes/new_weather_theme/assets/js/components/locationSearch.js
@@ -1,3 +1,123 @@
+const goToLocationPage = (latitude, longitude) => {
+  // Push the next URL into the history to preserve the current URL in the
+  // browser history stack.
+  window.history.pushState(null, null, `/point/${latitude}/${longitude}`);
+  window.location.href = `/point/${latitude}/${longitude}`;
+};
+
+const setupBrowserGeolocation = async () => {
+  const button = document.querySelector(
+    "button#weathergov-use-browser-location",
+  );
+
+  // If the browser does not support the geolocation API, just bail out. Take
+  // the "use my location" button away too. Also bop out if we don't have a
+  // button for some reason. Just being safe.
+  if (!button || !navigator.geolocation) {
+    button?.parentElement?.previousElementSibling.remove();
+    button?.parentElement?.remove();
+
+    return;
+  }
+
+  // Whether we should independently prompt the user prior to asking the browser
+  // for their location. IF we can detect existing permissions AND the user has
+  // not already granted or denied us, THEN we should prompt first. If we can't
+  // detect existing permissions, don't prompt because otherwise we end up
+  // putting up our prompt for that user every time they try to use their
+  // location.
+  let shouldPrompt = false;
+
+  if (navigator.permissions) {
+    try {
+      // Query for geolocation permissions.
+      const status = await navigator.permissions.query({
+        name: "geolocation",
+      });
+
+      // If the user has already denied location, we can go ahead and bail out.
+      // Changing browser settings is not detectable within the page, so they'll
+      // have to reload to get the option back anyway.
+      //
+      // Might need to reconsider this. It might be preferable to leave the
+      // button and show users a popup. There are several reasons we might get
+      // the "denied" state:
+      //
+      // 1. The web browser does not have permission from the operating system.
+      // 2. The web browser is configured to deny permission by default.
+      // 3. The user has denied access to our site in particular.
+      //
+      // In cases 1 and 2, users may not be aware of their settings. If we show
+      // the button and then popup a message when they click it letting them
+      // know they need to change their browser settings, maybe that's useful.
+      // The immediate drawback I can think of is we have no way of knowing
+      // whether it's a browser setting or an operating system setting, so we
+      // can't give them any more helpful advice than "check your settings."
+      //
+      // In case 3, however, we should just leave the user alone. They have
+      // already said no, and that should be the end of it.
+      //
+      // Key important takeaway, though, is that "denied" means all of those
+      // things and it is impossible for us to know which.
+      if (status.state === "denied") {
+        button.parentElement.previousElementSibling.remove();
+        button.parentElement.remove();
+        return;
+      }
+
+      // If the user has not denied us permission, then we should show our own
+      // prompt if the user has not yet granted us permission.
+      shouldPrompt = status.state === "prompt";
+    } catch (_) {
+      // An exception in the permissions API likely indicates that the specific
+      // attribute we queried for isn't available. That doesn't mean the feature
+      // doesn't exist, though, so we should continue as if the permissions API
+      // doesn't exist at all and not use our prompt.
+    }
+  }
+
+  button.addEventListener("click", async () => {
+    let proceed = true;
+
+    // If location is available and we know that the user has neither denied or
+    // granted us permission to use it, we will let them know before asking for
+    // it. It's kind of a double-opt-in.
+    if (shouldPrompt) {
+      // Not sure why eslint doesn't want us to use confirm(). This seems like
+      // exactly what it exists for.
+      // eslint-disable-next-line no-alert
+      proceed = window.confirm(
+        "We will now ask your browser to provide your location. If you approve, you will not be asked again. Your location information is only used to find your forecast.",
+      );
+    }
+
+    // If we don't know about the permission, we were already approved to use
+    // it, or the user has signaled that we can ask for it... ask for it!
+    if (proceed) {
+      navigator.geolocation.getCurrentPosition(
+        // Success callback
+        ({ coords: { latitude, longitude } }) => {
+          // Scale down the precision on these.
+          const lat = Math.round(latitude * 1_000) / 1_000;
+          const long = Math.round(longitude * 1_000) / 1_000;
+
+          // And navigate away!
+          goToLocationPage(lat, long);
+        },
+        // Error callback
+        ({ code }) => {
+          if (code > 1) {
+            // There was a problem getting the user's location. They allowed it,
+            // but the browser gave us an error.
+            // (Error code 1 is for when the user denies access to location, so
+            // for our purposes, that is not an error.)
+          }
+        },
+      );
+    }
+  });
+};
+
 const createOneTimeJSONP = () => {
   const name = `weathergov_${[...Array(30)]
     .map(() => Math.round(Math.random() * 36).toString(36))
@@ -23,13 +143,12 @@ const createOneTimeJSONP = () => {
 };
 
 const locationSelected = async (event) => {
-
   // We only care about change events that have
   // come from select elements with the "weather location"
   // name.
   // Note that we cannot use the id here, because USWDS strips it,
   // giving the input element it inserts that id value instead
-  if(!event.target.getAttribute('name') === "weather location"){
+  if (!event.target.getAttribute("name") === "weather location") {
     return;
   }
   const { value } = event.target;
@@ -40,8 +159,8 @@ const locationSelected = async (event) => {
 
   if (
     !results.error &&
-      Array.isArray(results.locations) &&
-      results.locations.length > 0
+    Array.isArray(results.locations) &&
+    results.locations.length > 0
   ) {
     const {
       locations: [
@@ -54,24 +173,21 @@ const locationSelected = async (event) => {
     const lat = Math.round(geometry.y * 1_000) / 1_000;
     const long = Math.round(geometry.x * 1_000) / 1_000;
 
-    // Push the next URL into the history to preserve the current URL in the
-    // browser history stack.
-    window.history.pushState(null, null, `/point/${lat}/${long}`);
-    window.location.href = `/point/${lat}/${long}`;
+    goToLocationPage(lat, long);
   }
 };
 
 const searchChanged = async (event) => {
   // We only care about input elements with the
   // id that we've specified in the template.
-  if(!event.target.id === "weather-location-search"){
+  if (!event.target.id === "weather-location-search") {
     return;
   }
   const { value } = event.target;
 
   // The select element is a sibling to this input.
-  const selectElement = event.target.parentElement.querySelector('select');
-  
+  const selectElement = event.target.parentElement.querySelector("select");
+
   if (value.length >= 3) {
     const { load, name } = createOneTimeJSONP();
     const url = `https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?f=json&countryCode=USA%2CPRI%2CVIR%2CGUM%2CASM&category=Land+Features%2CBay%2CChannel%2CCove%2CDam%2CDelta%2CGulf%2CLagoon%2CLake%2COcean%2CReef%2CReservoir%2CSea%2CSound%2CStrait%2CWaterfall%2CWharf%2CAmusement+Park%2CHistorical+Monument%2CLandmark%2CTourist+Attraction%2CZoo%2CCollege%2CBeach%2CCampground%2CGolf+Course%2CHarbor%2CNature+Reserve%2COther+Parks+and+Outdoors%2CPark%2CRacetrack%2CScenic+Overlook%2CSki+Resort%2CSports+Center%2CSports+Field%2CWildlife+Reserve%2CAirport%2CFerry%2CMarina%2CPier%2CPort%2CResort%2CPostal%2CPopulated+Place&maxSuggestions=10&_=1695666335097&text=${value}&callback=${name}`;
@@ -96,6 +212,8 @@ export default () => {
   // Instead, we wait for the events we care about to bubble
   // up to the document and filter by attributes, ensuring
   // we act on the location input combo box only.
-  document.addEventListener('input', searchChanged);
-  document.addEventListener('change', locationSelected);
+  document.addEventListener("input", searchChanged);
+  document.addEventListener("change", locationSelected);
+
+  setupBrowserGeolocation();
 };

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-location-search.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-location-search.html.twig
@@ -20,9 +20,15 @@
   {% endif %}
 
   <form class="usa-form" data-location-search>
-    <label class="usa-label" for="weather-location-search">
-      {{ 'Search for a location' | t }}
-    </label>
+    <div class="display-flex flex-align-end">
+      <label class="usa-label" for="weather-location-search">
+        {{ 'Search for a location' | t }}
+      </label>
+      <div class="margin-x-1">|</div>
+      <div class="">
+        <button id="weathergov-use-browser-location" type="button" class="usa-button usa-button--unstyled">{{ 'Use my location' | t }}</button>
+      </div>
+    </div>
     <div class="usa-combo-box" data-filter=".*">
       <select class="usa-select" name="weather location" id="weather-location-search">
 


### PR DESCRIPTION
## What does this PR do? 🛠️

Adds a button users can click to use their browser's geolocation feature instead of typing in a location. The behavior is roughly as follows:

![image](https://github.com/weather-gov/weather.gov/assets/142943695/284f2e72-ae8a-419b-9400-49722b39a7e4)

The idea is if the user has not already given us permission, we will first let them know we're going to ask for it and disclose how we'll use that information. Then we ask the browser, which will usually generate a browser-supplied prompt to allow/prevent.

Closes #184 

## What does the reviewer need to know? 🤔

`make cc` should do the job.

## Screenshots (if appropriate): 📸


<details>
<summary>The location search component gets a new button:</summary>

![Screenshot 2023-12-08 at 12-24-43 Welcome to Weather 2 0 Weather gov](https://github.com/weather-gov/weather.gov/assets/142943695/dba59146-e15f-471b-9a7c-3017ef8d8fa2)

</details>

<details>
<summary>The prompt if the user has not previously given us permission to use location:</summary>

![Screenshot 2023-12-08 at 12 25 10 PM](https://github.com/weather-gov/weather.gov/assets/142943695/b02f6c98-0703-4350-998f-66ee42477203)

</details>

<!--- Make sure you add a subject matter expert to the Reviewers list -->
