### PR TITLE
Hourly/Daily forecast blocks using lists

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
@@ -11,10 +11,10 @@ set classes = [
     <h2{{title_attributes }}>{{ label }}</h2>
   {% endif %}
   {{ title_suffix }}
-  <div class="grid-row flex-row minh-card">
+  <ul class="grid-row flex-row minh-card usa-list--unstyled">
     {%  for data in content.days %}
       {%  set hasPrecipitation = data.daytime.probabilityOfPrecipitation %}
-      <div class="tablet:grid-col padding-4 margin-right-2">
+      <li class="tablet:grid-col padding-4 margin-right-2">
         <time class="display-block text-bold tablet:text-center font-heading-md" datetime="{{ data.daytime.startTime }}">
           {{ data.daytime.shortDayName }}
         </time>
@@ -60,7 +60,7 @@ set classes = [
             </div>
           </div>
         </div>
-      </div>
+      </li>
     {%  endfor %}
-  </div>
+  </ul>
 </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
@@ -11,7 +11,7 @@ set classes = [
     <h2{{title_attributes }}>{{ label }}</h2>
   {% endif %}
   {{ title_suffix }}
-  <ul class="grid-row flex-row minh-card usa-list--unstyled">
+  <ol class="grid-row flex-row minh-card usa-list--unstyled">
     {%  for data in content.days %}
       {%  set hasPrecipitation = data.daytime.probabilityOfPrecipitation %}
       <li class="tablet:grid-col padding-4 margin-right-2">
@@ -62,5 +62,5 @@ set classes = [
         </div>
       </li>
     {%  endfor %}
-  </ul>
+  </ol>
 </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
@@ -12,7 +12,7 @@
   {% endif %}
   {{ title_suffix }}
   {# Forecast:  hour, icon, condition desc (short), change of precip, temp degree, temp scale #}
-  <ul class="grid-row flex-row minh-card usa-list--unstyled">
+  <ol class="grid-row flex-row minh-card usa-list--unstyled">
 
     {% for hour in content.hours %}
       <li class="tablet:grid-col padding-x-4">
@@ -33,5 +33,5 @@
         </div>
       </li>
     {% endfor %}
-  </ul>
+  </ol>
 </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
@@ -12,10 +12,10 @@
   {% endif %}
   {{ title_suffix }}
   {# Forecast:  hour, icon, condition desc (short), change of precip, temp degree, temp scale #}
-  <div class="grid-row flex-row minh-card">
+  <ul class="grid-row flex-row minh-card usa-list--unstyled">
 
     {% for hour in content.hours %}
-      <div class="tablet:grid-col padding-x-4">
+      <li class="tablet:grid-col padding-x-4">
         <div class="display-flex tablet:flex-column flex-justify flex-align-center tablet:minh-card">
           <time class="display-block text-uppercase text-bold tablet:text-center font-heading-md" datetime="2011-11-18T03:00-05:00">{{ hour.time }}</time>
           <div class="icon margin-y-1">
@@ -31,7 +31,7 @@
             {# use HTML entity that reads "degree farenheit" to screen readers #}
           </div>
         </div>
-      </div>
+      </li>
     {% endfor %}
-  </div>
+  </ul>
 </div>


### PR DESCRIPTION
## What does this PR do? 🛠️
Structuring the markup of daily and hourly forecast cards as lists. This makes more sense semantically and might be better from an accessibility perspective.
  
This is in relation to the corresponding item in #516 

## Screenshots (if appropriate): 📸
No screenshots, because they appear identically as before.
