### PR TITLE
Enable Twig debugging and disable markup caching in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ export-content: ## Export all content to web/scs-export
 
 import-config: ## Import the Drupal configuration from the config directory into your site
 	docker compose exec drupal drush config:import -y
+	docker compose exec drupal drush twig:debug on
+	docker compose exec drupal drush state:set disable_rendered_output_cache_bins 1
 
 import-content: web/scs-export/* ## Import content from web/scs-export
 	for file in $^; do \
@@ -49,6 +51,8 @@ import-content: web/scs-export/* ## Import content from web/scs-export
 install-site: install-site-config import-content ## Install a minimal Drupal site using the configuration in the config directory and exported content
 install-site-config:
 	docker compose exec drupal drush site:install minimal --existing-config --account-pass=root -y
+	docker compose exec drupal drush twig:debug on
+	docker compose exec drupal drush state:set disable_rendered_output_cache_bins 1
 
 log: ## Tail the log for the Drupal container
 	docker compose logs --follow drupal


### PR DESCRIPTION
## What does this PR do? 🛠️

Enabling Twig debugging causes it to add HTML comments to the markdown that tell you what templates it is searching for along the way, which is super helpful for figuring out what a new template should be named.

Disabling the markup cache means that any change to a template file will be rendered immediately so you do not need to manually clear the cache. You'll still need to clear the cache for module changes.

## What does the reviewer need to know? 🤔

`make import-config` will get this change configured. Thereafter, `zap` and `reset-site` will also do it. These two settings are ***NOT*** included in exported configurations, so there's no risk of accidentally pushing them into production.

## Screenshots (if appropriate): 📸

![image](https://github.com/weather-gov/weather.gov/assets/142943695/ba1929a5-24cb-486f-ac83-306355701cb5)
