### PR TITLE
Hide unnecessary fields in the weather narrative content type

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
   <testsuites>
     <testsuite name="unit tests">
       <directory suffix=".php.test">web/themes/new_weather_theme</directory>
+      <directory suffix=".php.test">web/themes/weathergov_admin</directory>
       <directory suffix=".php.test">web/modules/weather_blocks</directory>
       <directory suffix=".php.test">web/modules/weather_data</directory>
     </testsuite>
@@ -12,7 +13,8 @@
     processUncoveredFiles="true"
   >
     <include>
-      <directory>web/themes/new_weather_theme</directory>
+      <directory suffix=".theme">web/themes/new_weather_theme</directory>
+      <directory suffix=".theme">web/themes/weathergov_admin</directory>
       <directory>web/modules/weather_blocks</directory>
       <directory>web/modules/weather_data</directory>
     </include>

--- a/web/config/block.block.weathergov_admin_breadcrumbs.yml
+++ b/web/config/block.block.weathergov_admin_breadcrumbs.yml
@@ -1,0 +1,20 @@
+uuid: 0973755f-7b76-42e1-8252-66ac8e9f31c4
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - weathergov_admin
+id: weathergov_admin_breadcrumbs
+theme: weathergov_admin
+region: breadcrumb
+weight: 0
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/web/config/block.block.weathergov_admin_help.yml
+++ b/web/config/block.block.weathergov_admin_help.yml
@@ -1,0 +1,20 @@
+uuid: b8011e6d-4e31-4787-aea0-14d26211d122
+langcode: en
+status: true
+dependencies:
+  module:
+    - help
+  theme:
+    - weathergov_admin
+id: weathergov_admin_help
+theme: weathergov_admin
+region: help
+weight: 0
+provider: null
+plugin: help_block
+settings:
+  id: help_block
+  label: Help
+  label_display: '0'
+  provider: help
+visibility: {  }

--- a/web/config/block.block.weathergov_admin_mainpagecontent.yml
+++ b/web/config/block.block.weathergov_admin_mainpagecontent.yml
@@ -1,0 +1,20 @@
+uuid: ce08fadd-dda3-4a39-91b2-111fce76d407
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - weathergov_admin
+id: weathergov_admin_mainpagecontent
+theme: weathergov_admin
+region: content
+weight: -2
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/web/config/block.block.weathergov_admin_messages.yml
+++ b/web/config/block.block.weathergov_admin_messages.yml
@@ -1,0 +1,20 @@
+uuid: c4da8d37-a053-4612-a462-4144dcef9413
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - weathergov_admin
+id: weathergov_admin_messages
+theme: weathergov_admin
+region: highlighted
+weight: 0
+provider: null
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: 'Status Messages'
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/web/config/block.block.weathergov_admin_pagetitle.yml
+++ b/web/config/block.block.weathergov_admin_pagetitle.yml
@@ -1,0 +1,18 @@
+uuid: 34be14d5-7c2d-46ef-953d-6805967e09c7
+langcode: en
+status: true
+dependencies:
+  theme:
+    - weathergov_admin
+id: weathergov_admin_pagetitle
+theme: weathergov_admin
+region: header
+weight: 0
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  label_display: '0'
+  provider: core
+visibility: {  }

--- a/web/config/block.block.weathergov_admin_primaryadminactions.yml
+++ b/web/config/block.block.weathergov_admin_primaryadminactions.yml
@@ -1,0 +1,18 @@
+uuid: 646fcc28-d637-415a-9b99-03926080521b
+langcode: en
+status: true
+dependencies:
+  theme:
+    - weathergov_admin
+id: weathergov_admin_primaryadminactions
+theme: weathergov_admin
+region: content
+weight: -3
+provider: null
+plugin: local_actions_block
+settings:
+  id: local_actions_block
+  label: 'Primary admin actions'
+  label_display: '0'
+  provider: core
+visibility: {  }

--- a/web/config/block.block.weathergov_admin_tabs.yml
+++ b/web/config/block.block.weathergov_admin_tabs.yml
@@ -1,0 +1,20 @@
+uuid: f84473ae-a8b3-4d36-ac6a-01a89f6b4f98
+langcode: en
+status: true
+dependencies:
+  theme:
+    - weathergov_admin
+id: weathergov_admin_tabs
+theme: weathergov_admin
+region: header
+weight: 0
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Primary Tabs'
+  label_display: '0'
+  provider: core
+  primary: true
+  secondary: false
+visibility: {  }

--- a/web/config/block.block.weathergov_admin_tabs_2.yml
+++ b/web/config/block.block.weathergov_admin_tabs_2.yml
@@ -1,0 +1,20 @@
+uuid: 0dd81d78-fe2f-4fb0-a44a-103acb650c52
+langcode: en
+status: true
+dependencies:
+  theme:
+    - weathergov_admin
+id: weathergov_admin_tabs_2
+theme: weathergov_admin
+region: pre_content
+weight: 0
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Secondary Tabs'
+  label_display: '0'
+  provider: core
+  primary: false
+  secondary: true
+visibility: {  }

--- a/web/config/core.entity_form_display.node.weather_narrative.default.yml
+++ b/web/config/core.entity_form_display.node.weather_narrative.default.yml
@@ -11,7 +11,6 @@ dependencies:
     - node.type.weather_narrative
   module:
     - image
-    - path
     - text
 id: node.weather_narrative.default
 targetEntityType: node
@@ -20,7 +19,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 121
+    weight: 1
     region: content
     settings:
       rows: 9
@@ -28,79 +27,33 @@ content:
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-  created:
-    type: datetime_timestamp
-    weight: 10
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_forecaster_image:
     type: image_image
-    weight: 122
+    weight: 2
     region: content
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
-  field_weather_tags:
-    type: entity_reference_autocomplete
-    weight: 124
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   field_wfo:
     type: options_select
-    weight: 122
+    weight: 3
     region: content
     settings: {  }
-    third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  promote:
-    type: boolean_checkbox
-    weight: 15
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 120
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    weight: 16
-    region: content
-    settings:
-      display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-hidden: {  }
+hidden:
+  created: true
+  field_weather_tags: true
+  path: true
+  promote: true
+  status: true
+  sticky: true
+  uid: true

--- a/web/config/core.entity_view_display.node.weather_narrative.default.yml
+++ b/web/config/core.entity_view_display.node.weather_narrative.default.yml
@@ -23,7 +23,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 101
+    weight: 0
     region: content
   field_forecaster_image:
     type: image
@@ -34,26 +34,15 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 102
-    region: content
-  field_weather_tags:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 104
+    weight: 1
     region: content
   field_wfo:
     type: list_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 102
+    weight: 2
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 100
-    region: content
-hidden: {  }
+hidden:
+  field_weather_tags: true
+  links: true

--- a/web/config/core.extension.yml
+++ b/web/config/core.extension.yml
@@ -58,4 +58,5 @@ theme:
   claro: 0
   stable9: 0
   new_weather_theme: 0
+  weathergov_admin: 0
 profile: minimal

--- a/web/config/field.field.node.weather_conditional.body.yml
+++ b/web/config/field.field.node.weather_conditional.body.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.body
+    - filter.format.basic_html
     - node.type.weather_conditional
   module:
     - text
@@ -20,5 +21,6 @@ default_value_callback: ''
 settings:
   display_summary: true
   required_summary: false
-  allowed_formats: {  }
+  allowed_formats:
+    - basic_html
 field_type: text_with_summary

--- a/web/config/field.field.node.weather_narrative.body.yml
+++ b/web/config/field.field.node.weather_narrative.body.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.node.body
     - filter.format.basic_html
-    - filter.format.plain_text
     - node.type.weather_narrative
   module:
     - text
@@ -24,5 +23,4 @@ settings:
   required_summary: false
   allowed_formats:
     - basic_html
-    - plain_text
 field_type: text_with_summary

--- a/web/config/system.action.user_add_role_action.forecaster.yml
+++ b/web/config/system.action.user_add_role_action.forecaster.yml
@@ -1,0 +1,14 @@
+uuid: 06ef691c-b9cd-4e13-b14e-833e87eb1f14
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.forecaster
+  module:
+    - user
+id: user_add_role_action.forecaster
+label: 'Add the Forecaster role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: forecaster

--- a/web/config/system.action.user_remove_role_action.forecaster.yml
+++ b/web/config/system.action.user_remove_role_action.forecaster.yml
@@ -1,0 +1,14 @@
+uuid: ebb82243-aab8-4abb-b4f1-ffdbd0021da0
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.forecaster
+  module:
+    - user
+id: user_remove_role_action.forecaster
+label: 'Remove the Forecaster role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: forecaster

--- a/web/config/system.theme.yml
+++ b/web/config/system.theme.yml
@@ -1,4 +1,4 @@
 _core:
   default_config_hash: 6lQ55NXM9ysybMQ6NzJj4dtiQ1dAkOYxdDompa-r_kk
-admin: claro
+admin: weathergov_admin
 default: new_weather_theme

--- a/web/config/user.role.forecaster.yml
+++ b/web/config/user.role.forecaster.yml
@@ -1,0 +1,19 @@
+uuid: e2a8bcf5-f6a5-49e1-b0a2-1b0660e3a1a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.weather_narrative
+  module:
+    - node
+id: forecaster
+label: Forecaster
+weight: 4
+is_admin: null
+permissions:
+  - 'create weather_narrative content'
+  - 'delete any weather_narrative content'
+  - 'delete weather_narrative revisions'
+  - 'edit any weather_narrative content'
+  - 'revert weather_narrative revisions'
+  - 'view weather_narrative revisions'

--- a/web/themes/new_weather_theme/new_weather_theme.info.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.info.yml
@@ -1,7 +1,7 @@
 name: Weather.gov
 type: theme
 description: The weather.gov theme.
-'base theme': stable9
+base theme: stable9
 libraries:
   - new_weather_theme/base
   - new_weather_theme/messages

--- a/web/themes/new_weather_theme/tests/new_weather_theme.theme.php.test
+++ b/web/themes/new_weather_theme/tests/new_weather_theme.theme.php.test
@@ -1,0 +1,58 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require dirname(__DIR__, 1) . "/new_weather_theme.theme";
+
+/**
+ * Test the new_weather_theme hooks.
+ */
+final class NewWeatherThemeHooksTest extends TestCase {
+
+  /**
+   * Test that if the form allows previewing images, it is not modified.
+   */
+  public function testImageWidgetPreprocessorHookDoesNothingIfAccessIsPermitted(): void {
+    $variables = [
+      "data" => [
+        "preview" => [
+          "#access" => TRUE,
+        ],
+      ],
+    ];
+
+    new_weather_theme_preprocess_image_widget($variables);
+
+    $expected = [
+      "data" => [
+        "preview" => [
+          "#access" => TRUE,
+        ],
+      ],
+    ];
+
+    $this->assertEquals($expected, $variables);
+  }
+
+  /**
+   * Test that if preview access is disabled, the setting is removed entirely.
+   */
+  public function testImageWidgetPreprocessorHookUnsetsIfAccessIsDenied(): void {
+    $variables = [
+      "data" => [
+        "preview" => [
+          "#access" => FALSE,
+        ],
+      ],
+    ];
+
+    new_weather_theme_preprocess_image_widget($variables);
+
+    $expected = [
+      "data" => [],
+    ];
+
+    $this->assertEquals($expected, $variables);
+  }
+
+}

--- a/web/themes/weathergov_admin/tests/weathergov_admin.theme.php.test
+++ b/web/themes/weathergov_admin/tests/weathergov_admin.theme.php.test
@@ -1,0 +1,35 @@
+<?php
+
+use Drupal\Core\Form\FormStateInterface;
+use PHPUnit\Framework\TestCase;
+
+require dirname(__DIR__, 1) . "/weathergov_admin.theme";
+
+/**
+ * Test the weathergov_admin theme hooks.
+ */
+final class WeatherGovAdminThemeHooksTest extends TestCase {
+
+  /**
+   * Test that form elements are disabled.
+   */
+  public function testWeatherNarrativeFormAlterHook(): void {
+    $form = [];
+
+    $formState = $this->createStub(FormStateInterface::class);
+
+    weathergov_admin_form_node_weather_narrative_form_alter($form, $formState);
+
+    $expected = [
+      "revision_information" => [
+        "#access" => FALSE,
+      ],
+      "menu" => [
+        "#access" => FALSE,
+      ],
+    ];
+
+    $this->assertEquals($expected, $form);
+  }
+
+}

--- a/web/themes/weathergov_admin/weathergov_admin.info.yml
+++ b/web/themes/weathergov_admin/weathergov_admin.info.yml
@@ -1,0 +1,5 @@
+name: Weather.gov Admin
+type: theme
+description: The weather.gov admin theme.
+base theme: claro
+core_version_requirement: ^10

--- a/web/themes/weathergov_admin/weathergov_admin.info.yml
+++ b/web/themes/weathergov_admin/weathergov_admin.info.yml
@@ -3,3 +3,17 @@ type: theme
 description: The weather.gov admin theme.
 base theme: claro
 core_version_requirement: ^10
+package: weather.gov
+
+regions:
+  header: 'Header'
+  pre_content: 'Pre-content'
+  breadcrumb: Breadcrumb
+  highlighted: Highlighted
+  help: Help
+  content: Content
+  page_top: 'Page top'
+  page_bottom: 'Page bottom'
+  sidebar_first: 'First sidebar'
+regions_hidden:
+  - sidebar_first

--- a/web/themes/weathergov_admin/weathergov_admin.theme
+++ b/web/themes/weathergov_admin/weathergov_admin.theme
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Functions to support theming.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_FORM_ID_alter() for the weather narrative form.
+ *
+ * Function hook name format is like this: MODULENAME_form_FORMID_alter.
+ *
+ * To find a form ID, the easiest thing seem to be to use the generic form alter
+ * hook to inspect the ID. The generic editor hook is below, commented out.
+ */
+function weathergov_admin_form_node_weather_narrative_form_alter(array &$form, FormStateInterface $formState) {
+  // Global submission logging should always be disabled and never changed.
+  $form['revision_information']['#access'] = FALSE;
+  $form['menu']['#access'] = FALSE;
+}
+
+/* function weathergov_admin_form_alter(array &$form, $formState, $formId) { } */


### PR DESCRIPTION
## What does this PR do? 🛠️

* Adds a new admin theme that derives from the Claro theme (our current default)
* Sets the admin theme to our new one
* Adds a hook to our new theme to remove the menu configuration and revision information panels from the weather narrative creation page
* Updates the content type configuration to hide additional fields:
  * "Published" checkbox - it will just always be enabled for now (scheduling will be a separate body of work)
  * Tags
  * URL aliases
  * Front-page promotion
  * Authoring information (we will derive this from the logged-in user)
* Limits the body input type to basic HTML, so there's no dropdown box for users to choose their type

## What does the reviewer need to know? 🤔

You'll need to import config. That should be it.

## Screenshots (if appropriate): 📸


![Screenshot 2023-12-14 at 15-09-51 Create Weather narrative Weather gov](https://github.com/weather-gov/weather.gov/assets/142943695/e61a4d06-d562-44ba-af13-d67eb395bb3e)
