### PR TITLE
If a given latitude and longitude does not produce a grid, show a "not implemented page

### DIFF
--- a/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
+++ b/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
@@ -61,6 +61,14 @@ final class LocationAndGridRouteController extends ControllerBase {
       // If we don't get a corresponding grid location, throw a 404.
       throw new NotFoundHttpException();
     }
+
+    if ($grid["wfo"] == NULL) {
+      $logger = $this->getLogger("Weather.gov data service");
+      $logger->notice("location has no grid: $lat / $lon");
+
+      return new RedirectResponse("/not-implemented");
+    }
+
     $url = Url::fromRoute("weather_routes.grid", $grid);
     return new RedirectResponse($url->toString());
   }


### PR DESCRIPTION
## What does this PR do? 🛠️

This PR serves as a general purpose stopgap for #517. If any latitude/longitude (taken from search) does not return a grid cell, it redirects to `/not-implemented`. We will need to add content in each environment at that location, but in the meantime it'll at least result in a 404.

It also logs each time this happens so we'll be able to determine if it's happening anywhere else, though that seems unlikely. (Except for the part where a lat/long may be outside of NWS's grids entirely, but we haven't addressed that yet.)

closes #532

## Screenshots (if appropriate): 📸

https://github.com/weather-gov/weather.gov/assets/142943695/d78ffaf4-f6c4-44e9-bf3f-8b47c0257556


