### PR TITLE
Remaining accessibility fixes

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
@@ -37,29 +37,27 @@ set classes = [
           <div class="display-flex flex-column flex-align-center">
             {#  TODO: we will need to provide translation for this alt text #}
             <span class="usa-sr-only">
-              day will be high of "{{  data.daytime.temperature }}" degrees
+              day will be high of "{{  data.daytime.temperature }}" degrees Fahrenheit
             </span>
             <div class="display-flex flex-row">
-              <span class="font-body-xl position-relative">
+              <span class="font-body-xl position-relative" aria-hidden="true">
                 {{ data.daytime.temperature }}
-                <span class="font-body-3xs position-absolute display-inline-block left-full margin-top-05">&#x2109;</span>
+                <span class="font-body-3xs position-absolute display-inline-block left-full margin-top-05">℉</span>
               </span>
-              {# use HTML entity that reads "degree farenheit" to screen readers #}
             </div>
             <div class="display-flex flex-row">
               {#  TODO: we will need to provide translation for this alt text #}
               <span class="usa-sr-only">
-                night will be low of "{{  data.overnight.temperature }}" degrees
+                night will be low of "{{  data.overnight.temperature }}" degrees Fahrenheit
               </span>
-              <span class="position-relative font-body-lg text-gray-50">
+              <span class="position-relative font-body-lg text-gray-50" aria-hidden="true">
                 <div class="font-body-3xs position-absolute margin-left-neg-105">
                   <svg aria-hidden="true" role="img" style="width:9px;height:9px;">
                     <use xlink:href="{{ "/" ~ directory ~ '/assets/images/spritesheet.svg#overnight' }}"></use>
                   </svg>
                 </div>
                 {{ data.overnight.temperature }}
-                <div class="font-body-3xs display-inline-block position-absolute left-full">&#x2109</div>
-                {# use HTML entity that reads "degree farenheit" to screen readers #}
+                <div class="font-body-3xs display-inline-block position-absolute left-full">℉</div>
               </span>
             </div>
           </div>

--- a/web/themes/new_weather_theme/templates/navigation/menu--footer.html.twig
+++ b/web/themes/new_weather_theme/templates/navigation/menu--footer.html.twig
@@ -1,4 +1,4 @@
-  <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="{{ 'Important links' | t }}">
+  <nav class="usa-identifier__section usa-identifier__section--required-links">
     <div class="usa-identifier__container padding-0">
       <ul class="usa-identifier__required-links-list">
         {% for item in items %}


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR deals with two remaining accessibility concerns highlighted in #516 :
- [ ] Footer` links are grouped in multiple elements with aria labels?
- [ ] Daily forecast: Repetition temperature reads “day will be high of “54” degrees 54º night will be low of 48ºF”

## What does the reviewer need to know? 🤔
You will want to use VoiceOver to test the following:
- That the links in the footer are labelled only as "footer primary links"
- That the daily forecast temperature text items are read as a complete sentence, and that the individual number and degrees texts are not read (separately) at all
