### PR TITLE
Fetch hazards for a location and put them on the page

### DIFF
--- a/web/config/block.block.new_weather_theme_localalertsblock.yml
+++ b/web/config/block.block.new_weather_theme_localalertsblock.yml
@@ -1,0 +1,26 @@
+uuid: 4e85aca8-d34e-40e8-a911-2d3031114987
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+    - weather_blocks
+  theme:
+    - new_weather_theme
+id: new_weather_theme_localalertsblock
+theme: new_weather_theme
+region: location
+weight: 0
+provider: null
+plugin: weathergov_local_alerts
+settings:
+  id: weathergov_local_alerts
+  label: 'Local alerts block'
+  label_display: '0'
+  provider: weather_blocks
+  grid: ',,'
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: '/local/*'

--- a/web/modules/weather_blocks/src/Plugin/Block/LocalAlertsBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/LocalAlertsBlock.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\weather_blocks\Plugin\Block;
+
+/**
+ * Provides a block of active alerts for a location.
+ *
+ * @Block(
+ *   id = "weathergov_local_alerts",
+ *   admin_label = @Translation("Local alerts block"),
+ *   category = @Translation("weather.gov"),
+ * )
+ */
+class LocalAlertsBlock extends WeatherBlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $location = $this->getLocation();
+
+    if ($location->grid) {
+      $grid = $location->grid;
+
+      $data = $this->weatherData->getAlertsForGrid(
+        $grid->wfo,
+        $grid->x,
+        $grid->y
+      );
+      return ["alerts" => $data];
+    }
+    return NULL;
+  }
+
+}

--- a/web/modules/weather_blocks/src/Plugin/Block/LocalAlertsBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/LocalAlertsBlock.php.test
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\weather_blocks\Plugin\Block;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\weather_data\Service\WeatherDataService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the LocalAlerts block.
+ */
+final class LocalAlertsBlockTest extends TestCase {
+  /**
+   * A ready-to-use local alerts block object.
+   *
+   * @var currentConditionsBlock
+   */
+  protected $localAlertsBlock;
+
+  /**
+   * A mock of the route object.
+   *
+   * @var routeMock
+   */
+  protected $routeMock;
+
+  /**
+   * A mocked WeatherData service object.
+   *
+   * @var weatherData
+   *
+   * This is injected into the current conditions block object being tested with
+   * dependency injection.
+   */
+  protected $weatherData;
+
+  /**
+   * Common setup for all component tests.
+   *
+   * Creates a mock of a weather data service and injects it into a new local
+   * alert block object.
+   */
+  protected function setUp() : void {
+    $definition = [
+      "provider" => "weather_blocks",
+    ];
+
+    $this->weatherData = $this->createStub(WeatherDataService::class);
+
+    $this->routeMock = $this->createStub(RouteMatchInterface::class);
+    $this->routeMock->method('getRouteName')->willReturn("weather_routes.grid");
+
+    $this->currentConditionsBlock = new LocalAlertsBlock([], '', $definition, $this->weatherData, $this->routeMock);
+
+  }
+
+  /**
+   * Test that the block returns the expected data if we're on a grid route.
+   */
+  public function testBuild() : void {
+    $this->weatherData->method('getAlertsForGrid')->willReturn('here be alerts');
+
+    $expected = ["alerts" => "here be alerts"];
+    $actual = $this->currentConditionsBlock->build();
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Test that the block returns null if we're not on a grid route.
+   */
+  public function testBuildNotGridRoute(): void {
+    $definition = [
+      "provider" => "weather_blocks",
+    ];
+
+    $this->weatherData = $this->createStub(WeatherDataService::class);
+
+    $this->routeMock = $this->createStub(RouteMatchInterface::class);
+    $this->routeMock->method('getRouteName')->willReturn("weather_routes.not-grid");
+
+    $this->currentConditionsBlock = new LocalAlertsBlock([], '', $definition, $this->weatherData, $this->routeMock);
+
+    $actual = $this->currentConditionsBlock->build();
+
+    $this->assertEquals(NULL, $actual);
+  }
+
+}

--- a/web/modules/weather_data/src/Service/Test/WeatherAlertTrait.php.test
+++ b/web/modules/weather_data/src/Service/Test/WeatherAlertTrait.php.test
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\weather_data\Service\Test;
+
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Tests for WeatherAlertTrait.
+ */
+final class WeatherAlertTraitTest extends Base {
+
+  /**
+   * The expected results of the happy path.
+   *
+   * @var expected
+   */
+  protected $expected;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->expected = [
+      (object) [
+        "areaDesc" => "place 1",
+        "event" => "Weather Warning",
+        "description" => [
+          "There is a warning for:",
+          "Places listed",
+          "You should prepare.",
+        ],
+        "geometry" => [
+          [-71.89, 43.64],
+          [-71.91, 44.14],
+        ],
+        "whatWhereWhen" => [],
+      ],
+      (object) [
+        "areaDesc" => "place 2",
+        "event" => "Weather Watch",
+        "description" => [
+          "* WHAT...Bad weather",
+          "* WHERE...Places",
+          "* WHEN...Until it stops.",
+          "* IMPACTS...Badness.",
+        ],
+        "geometry" => [],
+        "whatWhereWhen" => [
+          ["name" => "what", "value" => "Bad weather"],
+          ["name" => "where", "value" => "Places"],
+          ["name" => "when", "value" => "Until it stops."],
+          ["name" => "impacts", "value" => "Badness."],
+        ],
+      ],
+      (object) [
+        "event" => "Weather Advisory",
+        "description" => [
+          "* WHAT...Bad weather",
+          "* WHERE...Places",
+          "* FAKE...This goes away",
+        ],
+        "geometry" => [],
+        "whatWhereWhen" => [
+          ["name" => "what", "value" => "Bad weather"],
+          ["name" => "where", "value" => "Places"],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Test the getAlertsForLatLon method.
+   */
+  public function testGetAlertsForLatLon(): void {
+    $this->httpClientMock->append(
+      new Response(
+        200,
+        ['Content-Type' => 'application/geo+json'],
+        file_get_contents(__DIR__ . "/test_data/alerts.good.json")
+      )
+    );
+
+    $actual = $this->weatherDataService->getAlertsForLatLon(20, 30);
+
+    $this->assertEquals($this->expected, $actual);
+  }
+
+  /**
+   * Test the getAlertsForGrid method.
+   */
+  public function testGetAlertsForGrid(): void {
+    $this->httpClientMock->append(
+      new Response(200,
+        ['Content-type' => 'application/geo+json'],
+        '{"geometry":{"coordinates":[[[4,3],[5,9],[3,9]]]}}'
+      ),
+    );
+
+    $this->httpClientMock->append(
+      new Response(
+        200,
+        ['Content-Type' => 'application/geo+json'],
+        file_get_contents(__DIR__ . "/test_data/alerts.good.json")
+      )
+    );
+
+    $actual = $this->weatherDataService->getAlertsForGrid("abc", 20, 30);
+
+    $this->assertEquals($this->expected, $actual);
+
+    $this->assertEquals(2, count($this->httpCallStack), 2);
+    $this->assertEquals("/gridpoints/abc/20,30", $this->httpCallStack[0]["request"]->getUri()->getPath());
+    $this->assertEquals("/alerts/active", $this->httpCallStack[1]["request"]->getUri()->getPath());
+    $this->assertEquals("status=actual&point=3,4", $this->httpCallStack[1]["request"]->getUri()->getQuery());
+  }
+
+}

--- a/web/modules/weather_data/src/Service/Test/test_data/alerts.good.json
+++ b/web/modules/weather_data/src/Service/Test/test_data/alerts.good.json
@@ -1,0 +1,35 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-71.89, 43.64],
+            [-71.91, 44.14]
+          ]
+        ]
+      },
+      "properties": {
+        "areaDesc": "place 1",
+        "event": "Weather Warning",
+        "description": "There is a warning for:\n\nPlaces listed\n\nYou should prepare."
+      }
+    },
+    {
+      "geometry": null,
+      "properties": {
+        "areaDesc": "place 2",
+        "event": "Weather Watch",
+        "description": "* WHAT...Bad weather\n\n* WHERE...Places\n\n* WHEN...Until it stops.\n\n* IMPACTS...Badness."
+      }
+    },
+    {
+      "geometry": null,
+      "properties": {
+        "event": "Weather Advisory",
+        "description": "* WHAT...Bad weather\n\n* WHERE...Places\n\n* FAKE...This goes away"
+      }
+    }
+  ]
+}

--- a/web/modules/weather_data/src/Service/WeatherAlertTrait.php
+++ b/web/modules/weather_data/src/Service/WeatherAlertTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\weather_data\Service;
+
+/**
+ * Add weather alert methods.
+ */
+trait WeatherAlertTrait {
+
+  /**
+   * Get active alerts for a WFO grid cell.
+   */
+  public function getAlertsForGrid($wfo, $x, $y) {
+    $geometry = $this->getGeometryFromGrid($wfo, $x, $y);
+    $point = $geometry[0];
+
+    return $this->getAlertsForLatLon($point->lat, $point->lon);
+  }
+
+  /**
+   * Get active alerts for a latitude and longitude.
+   */
+  public function getAlertsForLatLon($lat, $lon) {
+    $alerts = $this->getFromWeatherAPI("https://api.weather.gov/alerts/active?status=actual&point=$lat,$lon");
+
+    $alerts = array_map(function ($alert) {
+      $output = clone $alert->properties;
+
+      if ($alert->geometry != NULL) {
+        $output->geometry = $alert->geometry->coordinates[0];
+      }
+      else {
+        $output->geometry = [];
+      }
+
+      $www = explode("\n\n", $alert->properties->description);
+
+      $www = array_map(function ($line) {
+        $parts = explode("...", $line);
+        if (count($parts) > 1) {
+          $name = strtolower(substr($parts[0], 2));
+          return ["name" => $name, "value" => str_replace("\n", " ", $parts[1])];
+        }
+        return ["name" => FALSE];
+      }, $www);
+
+      $www = array_filter($www, function ($item) {
+        $expected = ["what", "when", "where", "impacts"];
+        return in_array($item["name"], $expected);
+      });
+
+      $output->description = explode("\n\n", $alert->properties->description);
+
+      $output->whatWhereWhen = $www;
+
+      return $output;
+    }, $alerts->features);
+
+    return $alerts;
+  }
+
+}

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Exception\ServerException;
 class WeatherDataService {
   use LoggerChannelTrait;
   use UnitConversionTrait;
+  use WeatherAlertTrait;
 
   const NUMBER_OF_OBS_STATIONS_TO_TRY = 3;
 

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
@@ -1,0 +1,21 @@
+{% for alert in content.alerts %}
+<div class="usa-alert usa-alert--error" role="alert">
+  <div class="usa-alert__body">
+    <h4 class="usa-alert__heading">{{ alert.event }}</h4>
+    {% if alert.whatWhereWhen | length > 0 %}
+      <ul>
+      {% for item in alert.whatWhereWhen %}
+        <li><strong>{{ item.name }}:</strong> {{ item.value }}</li>
+      {% endfor %}
+      </ul>
+    {% else %}
+      {% for paragraph in alert.description %}
+      <p>{{ paragraph }}</p>
+      {% endfor %}
+    {% endif %}
+    <p class="margin-bottom-0">
+      {{ alert.instruction }}
+    </p>
+  </div>
+</div>
+{% endfor %}


### PR DESCRIPTION
## What does this PR do? 🛠️

Very roughly puts alerts on the location page. These haven't been styled according to designs, they're just USWDS alerts plopped on the page, to show that we can get them.

The alerts from the API come in a few different configurations, but the biggest issue I think we'll run into in the short term is the description text. In some cases, the text is ***only*** the "what/when/where/impacts" bits. Other times, those bits are missing entirely and the description is some other blurb. I suspect there are cases where the description is both at once. This PR does not attempt to address all of those cases, though it makes a first pass at pulling out the what/when/where/impacts statements if it can.

Closes #522.

## What does the reviewer need to know? 🤔

```
make cc
make import-config
```

It may also want a `make rebuild`, but that *shouldn't* be necessary. But who knows, the Drupal cache is pretty mystical.

## Screenshots (if appropriate): 📸

![image_480](https://github.com/weather-gov/weather.gov/assets/142943695/8bf26a99-34b1-4e52-879e-4d342898d819)
