### PR TITLE
Fix-up current conditions for screen readers

### DIFF
--- a/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php
@@ -21,10 +21,20 @@ class CurrentConditionsBlock extends WeatherBlockBase {
 
     if ($location->grid) {
       $grid = $location->grid;
+
+      $place = $this->weatherData->getPlaceFromGrid(
+        $grid->wfo,
+        $grid->x,
+        $grid->y
+      );
+
       $data = $this->weatherData->getCurrentConditionsFromGrid(
         $grid->wfo,
         $grid->x,
         $grid->y);
+
+      $data["place"] = $place->city . ", " . $place->state;
+
       return $data;
     }
     return NULL;

--- a/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php.test
@@ -58,9 +58,16 @@ final class CurrentConditionsBlockTest extends TestCase {
    * Test that the block returns the expected data if we're on a grid route.
    */
   public function testBuild() : void {
-    $this->weatherData->method('getCurrentConditionsFromGrid')->willReturn('this is weather data');
+    $this->weatherData->method('getPlaceFromGrid')->willReturn((object) [
+      "city" => "Placeville",
+      "state" => "Statesylvania",
+    ]);
+    $this->weatherData->method('getCurrentConditionsFromGrid')->willReturn(["info" => "this is weather data"]);
 
-    $expected = "this is weather data";
+    $expected = [
+      "info" => "this is weather data",
+      "place" => "Placeville, Statesylvania",
+    ];
     $actual = $this->currentConditionsBlock->build();
 
     $this->assertEquals($expected, $actual);

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -1,7 +1,7 @@
 {# Widgets and stuff. This is presented as a row of columns. #}
 <div class="grid-row weather-gov-current-conditions">
   <h2 class="usa-sr-only">{{ label }}</h2>
-  <div class="grid-row flex-row margin-y-4 tablet:margin-left-4">
+  <div class="grid-row flex-row margin-y-4 tablet:margin-left-4" aria-hidden="true">
     {# First column: weather icon #}
     <div class="icon margin-right-1">
       {{ source(directory ~ "/assets/images/weather/icons/conditions/" ~ content.icon )}}
@@ -59,14 +59,24 @@
         </weather-timestamp>
       </p>
       <p class="margin-0 margin-top-05">
-        {{ "The weather in <strong>@place</strong> is <strong>@conditions</strong>.
-          Temperature is <strong>@temperature℉</strong>.
-          Humidity is <strong>@humidity%</strong>"
+        {{ "The weather in <strong>@place</strong>, is <strong>@conditions</strong>.
+          Temperature is <strong>@temperature℉</strong>." |
+          t({
+            "@place": content.place,
+            "@conditions": content.conditions.long | lower,
+            "@temperature": content.temperature,
+          })
+        }}
+        {% if content.feels_like != content.temperature %}
+        {{ " It feels like <strong>@feelsLike℉</strong>." |
+          t({
+            "@feelsLike": content.feels_like
+          })
+        }}
+        {% endif %}
+        {{ " Humidity is <strong>@humidity%</strong>"
         |
         t({
-          "@place": content.location,
-          "@conditions": content.conditions.long | lower,
-          "@temperature": content.temperature,
           "@humidity": content.humidity
         })
         }}{% if content.wind.speed > 0 %}


### PR DESCRIPTION
## What does this PR do? 🛠️

- Fixes a bug where the narrative text in the current conditions component did not include the place name anymore. (Broken in #501)
- Adds "feels like" temperature to the narrative text
- Hides the widget-like display from screen readers and skips straight to the narrative text. 