### PR TITLE
Forecaster can use admin theme

### DIFF
--- a/web/config/user.role.forecaster.yml
+++ b/web/config/user.role.forecaster.yml
@@ -6,6 +6,7 @@ dependencies:
     - node.type.weather_narrative
   module:
     - node
+    - system
 id: forecaster
 label: Forecaster
 weight: 4
@@ -16,4 +17,5 @@ permissions:
   - 'delete weather_narrative revisions'
   - 'edit any weather_narrative content'
   - 'revert weather_narrative revisions'
+  - 'view the administration theme'
   - 'view weather_narrative revisions'


### PR DESCRIPTION
## What does this PR do? 🛠️
Adds permissions for the Forecaster role, such that the admin theme will load (ie, when editing or creating content, there is appropriate styling and the correct theme loads)

## What does the reviewer need to know? 🤔
When editing content as a user who is a Forecaster, you should **not** see any unstyled content.
