### PR TITLE
Fix a bug with how blocks determine if they are configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "prettier": {},
   "scripts": {
-    "cypress:open": "cypress open",
+    "cypress:a11y": "cypress open --project tests/a11y",
+    "cypress:e2e": "cypress open --project tests/e2e",
     "js-format": "npx prettier -w web/themes/**/assets/**/*.js tests/**/*.js *.js",
     "js-lint": "eslint web/**/assets/**/*.js tests/**/*.js *.js",
     "style-format": "npx prettier -w web/themes/**/*.scss",

--- a/tests/e2e/cypress/e2e/invalid-locations-are-not-found.cy.js
+++ b/tests/e2e/cypress/e2e/invalid-locations-are-not-found.cy.js
@@ -1,0 +1,46 @@
+describe("invalid location-based routes return 404", () => {
+  describe("for non-numeric points", () => {
+    [
+      ["with non-numeric latitude", "abc", "123"],
+      ["with non-numeric longitude", "123", "abc"],
+    ].forEach(([test, lat, lon]) => {
+      it(test, () => {
+        cy.request({ url: `/point/${lat}/${lon}`, failOnStatusCode: false })
+          .its("status")
+          .should("equal", 404);
+        cy.visit(`/point/${lat}/${lon}`, { failOnStatusCode: false });
+      });
+    });
+  });
+
+  describe("with invalid WFO", () => {
+    [
+      ["with too-short WFO", "ab"],
+      ["with too-long WFO", "abcd"],
+      ["with WFO with numbers", "a1b"],
+    ].forEach(([test, wfo]) => {
+      it(test, () => {
+        cy.request({ url: `/local/${wfo}/1/1`, failOnStatusCode: false })
+          .its("status")
+          .should("equal", 404);
+        cy.visit(`/local/${wfo}/1/1`, { failOnStatusCode: false });
+      });
+    });
+  });
+
+  describe("with non-numeric grid coordinates", () => {
+    [
+      ["with non-numeric X", "a", "1"],
+      ["with non-numeric Y", "1", "a"],
+      ["with X starting with 0", "01", "1"],
+      ["with Y starting with 0", "1", "01"],
+    ].forEach(([test, x, y]) => {
+      it(test, () => {
+        cy.request({ url: `/local/abc/${x}/${y}`, failOnStatusCode: false })
+          .its("status")
+          .should("equal", 404);
+        cy.visit(`/local/abc/${x}/${y}`, { failOnStatusCode: false });
+      });
+    });
+  });
+});

--- a/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php
@@ -151,7 +151,7 @@ abstract class WeatherBlockBase extends BlockBase implements ContainerFactoryPlu
     // Otherwise, attempt to get it from configuration.
     else {
       $configuredGrid = $this->getConfiguration()["grid"] ?? FALSE;
-      if ($configuredGrid) {
+      if ($configuredGrid != FALSE && $configuredGrid != ",,") {
         $parts = explode(",", $configuredGrid);
 
         $location->grid = (object) [

--- a/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php.test
@@ -161,4 +161,36 @@ final class WeatherBlockBaseTest extends TestCase {
 
   }
 
+  /**
+   * Tests that the location is empty if not on a grid route and not configured.
+   */
+  public function testGetsNoLocationWhenConfiguredFalse() : void {
+    $this->routeMock->method('getRouteName')->willReturn("not grid");
+    $this->currentConditionsBlock->setConfigurationValue("grid", FALSE);
+
+    $expected = (object) [
+      "grid" => FALSE,
+    ];
+
+    $actual = $this->currentConditionsBlock->getLocation();
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Tests that the location is empty if not on a grid route and empty config.
+   */
+  public function testGetsNoLocationWhenConfiguredEmpty() : void {
+    $this->routeMock->method('getRouteName')->willReturn("not grid");
+    $this->currentConditionsBlock->setConfigurationValue("grid", ",,");
+
+    $expected = (object) [
+      "grid" => FALSE,
+    ];
+
+    $actual = $this->currentConditionsBlock->getLocation();
+
+    $this->assertEquals($expected, $actual);
+  }
+
 }


### PR DESCRIPTION
## What does this PR do? 🛠️

- Fixes the logic to determine whether or not a block has been configured by checking for both `false` and the default value `,,`.
- Closes #572
- Adds end-to-end tests to catch the bug
- Adds unit tests to catch the bug