### PR TITLE
replace h4 with h4-styled paragraph

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
@@ -1,7 +1,7 @@
 {% for alert in content.alerts %}
 <div class="usa-alert usa-alert--error" role="alert">
   <div class="usa-alert__body">
-    <h4 class="usa-alert__heading">{{ alert.event }}</h4>
+    <p class="usa-alert__heading text-bold">{{ alert.event }}</p>
     {% if alert.whatWhereWhen | length > 0 %}
       <ul>
       {% for item in alert.whatWhereWhen %}


### PR DESCRIPTION
## What does this PR do? 🛠️

Remove the `<h4>` element from the prototype alert component and replaces it with an h4-styled paragraph element. This fixes the heading ordering.

Closes #599 

## What does the reviewer need to know? 🤔

`make cc`