### PR TITLE
Alert description parsing

### DIFF
--- a/web/modules/weather_data/src/Service/Test/TryParsingDescriptionText.php.test
+++ b/web/modules/weather_data/src/Service/Test/TryParsingDescriptionText.php.test
@@ -11,6 +11,9 @@ final class TryParsingDescriptionTextTest extends Base
         parent::setUp();
     }
 
+    /**
+     * Test the tryParsingDescriptionText static method
+     */
     public function testBasic(): void
     {
         $rawDescription = "* WHAT...Snow expected. Total snow accumulations of 5 to 10\ninches.\n\n* WHERE...Eastern San Juan Mountains Above 10000 Feet.\n\n* WHEN...From 11 PM this evening to 11 PM MST Thursday.\n\n* IMPACTS...Travel could be very difficult. The hazardous\nconditions may impact travel over Wolf Creek Pass.";
@@ -24,5 +27,14 @@ final class TryParsingDescriptionTextTest extends Base
         ];
         $this->assertEquals($expected, $parsedDescription);
         
+    }
+
+    public function testNotMatching(): void
+    {
+        $rawDescription = "* This is an alert with\n\nmultiple newlines, but it has nothing to do with the what WHERE WHEN\n format we are concerned with.";
+        $parsedDescription = WeatherAlertTrait::tryParsingDescriptionText($rawDescription);
+        $expected = $rawDescription;
+
+        $this->assertEquals($expected, $parsedDescription);
     }
 }

--- a/web/modules/weather_data/src/Service/Test/TryParsingDescriptionText.php.test
+++ b/web/modules/weather_data/src/Service/Test/TryParsingDescriptionText.php.test
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\weather_data\Service\Test;
+
+use Drupal\weather_data\Service\WeatherAlertTrait;
+
+final class TryParsingDescriptionTextTest extends Base
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testBasic(): void
+    {
+        $rawDescription = "* WHAT...Snow expected. Total snow accumulations of 5 to 10\ninches.\n\n* WHERE...Eastern San Juan Mountains Above 10000 Feet.\n\n* WHEN...From 11 PM this evening to 11 PM MST Thursday.\n\n* IMPACTS...Travel could be very difficult. The hazardous\nconditions may impact travel over Wolf Creek Pass.";
+        $parsedDescription = WeatherAlertTrait::tryParsingDescriptionText($rawDescription);
+
+        $expected = [
+            "what" => "Snow expected. Total snow accumulations of 5 to 10\ninches.",
+            "where" => "Eastern San Juan Mountains Above 10000 Feet.",
+            "when" => "From 11 PM this evening to 11 PM MST Thursday.",
+            "impacts" => "Travel could be very difficult. The hazardous\nconditions may impact travel over Wolf Creek Pass."
+        ];
+        $this->assertEquals($expected, $parsedDescription);
+        
+    }
+}

--- a/web/modules/weather_data/src/Service/Test/WeatherAlertTrait.php.test
+++ b/web/modules/weather_data/src/Service/Test/WeatherAlertTrait.php.test
@@ -34,18 +34,23 @@ final class WeatherAlertTraitTest extends Base
                 "onset" => "Sunday, 10/01, 2:32 PM MDT",
                 "ends" => "Sunday, 10/01, 4:32 PM MDT",
                 "expires" => "Sunday, 10/01, 6:32 PM MDT",
+                "usesParsedDescription" => false,
             ],
             (object) [
                 "areaDesc" => false,
                 "event" => "volcano warning",
-                "description" =>
-                    "* WHAT...Bad weather\n\n* WHERE...Places\n\n* FAKE...This goes away",
+                "description" => [
+                    "what" => "Bad weather",
+                    "where" => "Places",
+                    "fake" => "This goes away"
+                ],
                 "geometry" => [],
                 "instruction" =>
                     "Duck! And coooover!\n\nJust duck! And cooooover!",
                 "onset" => false,
                 "ends" => false,
                 "expires" => false,
+                "usesParsedDescription" => true,
             ],
             (object) [
                 "areaDesc" => "place 1",
@@ -57,6 +62,7 @@ final class WeatherAlertTraitTest extends Base
                 "instruction" => false,
                 "ends" => false,
                 "expires" => false,
+                "usesParsedDescription" => false,
             ],
             (object) [
                 "event" => "air quality alert",
@@ -67,6 +73,7 @@ final class WeatherAlertTraitTest extends Base
                 "ends" => false,
                 "expires" => false,
                 "onset" => "Tuesday, 01/09, 12:00 PM MST",
+                "usesParsedDescription" => false,
             ],
             (object) [
                 "event" => "air quality alert",
@@ -77,6 +84,7 @@ final class WeatherAlertTraitTest extends Base
                 "ends" => false,
                 "expires" => false,
                 "onset" => "Tuesday, 01/09, 1:00 PM MST",
+                "usesParsedDescription" => false,
             ],
             (object) [
                 "event" => "air quality alert",
@@ -87,6 +95,7 @@ final class WeatherAlertTraitTest extends Base
                 "ends" => false,
                 "expires" => false,
                 "onset" => "Tuesday, 01/09, 1:00 PM MST",
+                "usesParsedDescription" => false,
             ],
             (object) [
                 "event" => "air quality alert",
@@ -97,6 +106,7 @@ final class WeatherAlertTraitTest extends Base
                 "ends" => false,
                 "expires" => false,
                 "onset" => "Tuesday, 01/09, 2:00 PM MST",
+                "usesParsedDescription" => false,
             ],
         ];
     }

--- a/web/modules/weather_data/src/Service/WeatherAlertTrait.php
+++ b/web/modules/weather_data/src/Service/WeatherAlertTrait.php
@@ -33,6 +33,23 @@ trait WeatherAlertTrait
         return $str;
     }
 
+    static function tryParsingDescriptionText($str)
+    {
+        $regex = "/\*\s*(?<label>[A-Z]+)\.\.\.(?<content>.*)(\n{2}|$)/sU";
+        if(preg_match_all($regex, $str, $matches)){
+            $result = [];
+            for($i = 0; $i < count($matches['label']); $i++){
+                $label = strtolower($matches['label'][$i]);
+                $content = $matches['content'][$i];
+                $result[$label] = $content;
+            }
+
+            return $result;
+        }
+
+        return $str;
+    }
+
     /**
      * Get active alerts for a WFO grid cell.
      */
@@ -110,4 +127,6 @@ trait WeatherAlertTrait
 
         return $alerts;
     }
+
+    
 }

--- a/web/modules/weather_data/src/Service/WeatherAlertTrait.php
+++ b/web/modules/weather_data/src/Service/WeatherAlertTrait.php
@@ -84,9 +84,17 @@ trait WeatherAlertTrait
                 $output->geometry = [];
             }
 
-            $output->description = self::fixupNewlines(
-                $output->description ?? false,
-            );
+            $alertDescription = self::tryParsingDescriptionText($output->description);
+            if(!is_array($alertDescription)){
+                $output->description = self::fixupNewlines(
+                    $alertDescription ?? false,
+                );
+                $output->usesParsedDescription = false;
+            } else {
+                $output->description = $alertDescription;
+                $output->usesParsedDescription = true;
+            }
+            
             $output->instruction = self::fixupNewlines(
                 $output->instruction ?? false,
             );

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
@@ -14,9 +14,9 @@
       {{ alert.description | nl2br }}
     </p>
 
-    {% if usesParsedDescription %}
+    {% if alert.usesParsedDescription %}
       {% for label, infoText in alert.description %}
-        <h3>{{ label }}</h3>
+        <h3>{{ label | capitalize }}</h3>
         <p>{{ infoText }}</p>
       {% endfor %}
     {% else %}

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
@@ -13,6 +13,16 @@
     <p>
       {{ alert.description | nl2br }}
     </p>
+
+    {% if usesParsedDescription %}
+      {% for label, infoText in alert.description %}
+        <h3>{{ label }}</h3>
+        <p>{{ infoText }}</p>
+      {% endfor %}
+    {% else %}
+      <p>{{ alert.description }}</p>
+    {% endif %}
+
     {% if alert.instruction %}
     <h3>What to do</h3>
     <p>


### PR DESCRIPTION
## What does this PR do? 🛠️
Per #589, this PR implements basic Alert `description` field parsing, along with basic integration into the alert template.

## What does the reviewer need to know? 🤔
The parsing is regex based. It will look for any word in all caps followed by ellipses, and use that as the label. This means we don't specifically search for WHAT/WHEN/WHERE/IMPACTS tokens. If we want to be more literal to the observed format, and more strict, we can switch over.
  
When the regex matches successfully, the `description` field on the processed alert object will become an associative array whose keys are the labels in lowercase ("what" "where" etc) and whose values are the text content for that label.
  
When the regex fails to match, the plain description string is displayed, with the white space adjusted.

## Screenshots (if appropriate): 📸
<details>
<summary>Before:</summary>
  
<img width="1244" alt="Screen Shot 2024-01-17 at 6 27 25 PM" src="https://github.com/weather-gov/weather.gov/assets/105373963/15b5d222-fd90-43bf-931e-842a0640393c">

</details>

<details>
<summary>After:</summary>
  
<img width="1063" alt="Screen Shot 2024-01-17 at 6 24 23 PM" src="https://github.com/weather-gov/weather.gov/assets/105373963/35abafcf-e172-4e2c-9109-a080458c0052">

</details>
