### PR TITLE
Hazard accordion styling

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alert-list.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alert-list.html.twig
@@ -1,6 +1,6 @@
 <weathergov-alert-list>
 {% for alert in content.alerts %}
-<div class="usa-alert usa-alert--info usa-alert--slim margin-top-0" role="alert">
+<div class="usa-alert usa-alert--warning usa-alert--slim margin-top-0 padding-y-05" role="alert">
   <div class="usa-alert__body">
     <a href="#alert_{{ loop.index }}">
       {{ alert.event }}

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
@@ -1,9 +1,17 @@
-<weathergov-alerts>
+<weathergov-alerts class="display-block">
 {% for alert in content.alerts %}
 <a id="alert_{{ loop.index }}"></a>
-<div class="usa-alert usa-alert" role="alert">
-  <div class="usa-alert__body">
-    <h2 class="usa-alert__heading">{{ alert.event }}</h2>
+<div class="usa-accordion usa-accordion--bordered margin-top-1">
+  <h2 class="usa-accordion__heading">
+    <button
+      type="button"
+      class="usa-accordion__button"
+      aria-expanded="{{ (loop.index == 1) ? 'true' : 'false' }}"
+      aria-controls="a{{ loop.index }}">
+      {{ alert.event }}
+    </button>
+  </h2>
+  <div id="a{{loop.index}}" class="usa-accordion__content usa-prose">
     <p>
       In effect from {{ alert.onset }}
       {% if alert.ends %} - {{ alert.ends }}{% endif %}


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR implements the changes requested in #657, primarily the use of USWDS accordions for the hazard alert information.
  
We have also adjusted the styling according to the ticket.

## What does the reviewer need to know? 🤔
The first alert accordion will be open and the others should be closed.

## Screenshots (if appropriate): 📸
<details>
<summary>Example:</summary>

![localhost_8080_local_TST_10_10_](https://github.com/weather-gov/weather.gov/assets/105373963/41d3131a-1b4b-4d84-b78f-675535398e2a)


</details>
