### PR TITLE
Remove dupe of alert description

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
@@ -19,9 +19,6 @@
     <p>
       Issued by {{ alert.senderName }}
     </p>
-    <p>
-      {{ alert.description | nl2br }}
-    </p>
 
     {% if alert.usesParsedDescription %}
       {% for label, infoText in alert.description %}


### PR DESCRIPTION
## What does this PR do?
#666 identified a couple of issues, one of which is that the alert description seemed to be displaying twice. This PR removes the duplicate display.


## Screenshots (if appropriate): 📸

<details>
<summary>Before:</summary>

![Screen Shot 2024-01-19 at 1 31 14 PM](https://github.com/weather-gov/weather.gov/assets/105373963/03f1928c-87b4-4ae1-931a-8a7c94926bfd)


</details>

  
<details>
<summary>After:</summary>
  
![Screen Shot 2024-01-19 at 1 31 56 PM](https://github.com/weather-gov/weather.gov/assets/105373963/1671bbcc-6e2f-4045-9250-d6823eeff48e)
 

</details>