### PR TITLE
Update our list of contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "contributors": [
     "Claire Annan",
     "Stacy Dion",
+    "Eric Gade",
     "Shad Keene",
+    "Igor Korenfeld",
+    "Logan McDonald",
     "Sarah MH",
     "Colin Murphy",
     "Corey Pieper",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "Shad Keene",
     "Sarah MH",
     "Colin Murphy",
+    "Corey Pieper",
     "Katrina Ranjo",
     "Kari Sheets",
     "Greg Walker",
+    "Elijah Wright",
     "Janel Yamashiro"
   ],
   "license": "CC0-1.0",


### PR DESCRIPTION
## What does this PR do? 🛠️

We keep our contributors list in the root `package.json` file, but we haven't updated it in a while. This PR adds our deputy product owner @coreypieper and friend-of-the-show @elijah-wright.

Also adds @partly-igor, @eric-gade, and @loganmcdonald-noaa, team members who cycled in a while back. Goes to show just how long it's been since we've updated this thing.

If any of you would rather not be included in the list, just let me know and I'll update it.