### PR TITLE
update link to creating weather stories

### DIFF
--- a/web/themes/new_weather_theme/templates/layout/page--user.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--user.html.twig
@@ -164,7 +164,7 @@
 
       {% if logged_in %}
         <h1>Weather.gov content management</h2>
-        <a href="/node/add/weather_narrative" class="usa-button">Create a weather story</a>
+        <a href="/node/add/weather_story" class="usa-button">Create a weather story</a>
       {% else %}
 
       <div class="grid-row">


### PR DESCRIPTION
## What does this PR do? 🛠️

In #660, the `weather_narrative` content type was removed and replaced with `weather_story`. However, the `/user` page template wasn't updated accordingly. This PR makes that update.