### PR TITLE
Add an extra time period to our daily forecast test data

### DIFF
--- a/tests/api/data/gridpoints/TST/1,1/forecast.json
+++ b/tests/api/data/gridpoints/TST/1,1/forecast.json
@@ -411,6 +411,33 @@
         "icon": "/icons/land/night/cold?size=medium",
         "shortForecast": "Mostly Cloudy",
         "detailedForecast": "Mostly cloudy, with a low around -6. West northwest wind around 15 mph."
+      },
+      {
+        "number": 15,
+        "name": "Monday",
+        "startTime": "date:now +168 hour",
+        "endTime": "date:now +180 hour",
+        "isDaytime": true,
+        "temperature": 32,
+        "temperatureUnit": "F",
+        "temperatureTrend": null,
+        "probabilityOfPrecipitation": {
+          "unitCode": "wmoUnit:percent",
+          "value": null
+        },
+        "dewpoint": {
+          "unitCode": "wmoUnit:degC",
+          "value": -20
+        },
+        "relativeHumidity": {
+          "unitCode": "wmoUnit:percent",
+          "value": 91
+        },
+        "windSpeed": "15 mph",
+        "windDirection": "WNW",
+        "icon": "/icons/land/night/cold?size=medium",
+        "shortForecast": "Mostly Cloudy",
+        "detailedForecast": "Mostly cloudy, with a low around -6. West northwest wind around 15 mph."
       }
     ]
   }


### PR DESCRIPTION
## What does this PR do? 🛠️

The test daily forecast data doesn't have enough time periods to cover every case, so sometimes the last day in the extended forecast only shows a high or low temperature but not both. This adds another period so that doesn't happen. Basically this test data fix is so we don't think there's a bug where there isn't. 😛 
