### PR TITLE
Add a `/bundle` endpoint to fully capture all the API data in a single page load

### DIFF
--- a/docs/dev/intercepting-the-api.md
+++ b/docs/dev/intercepting-the-api.md
@@ -70,3 +70,16 @@ from the current time by adding a value and unit: `date:now +1 hour`. The value
 and unit are passed directly into
 [Day.js's `.add` method](https://day.js.org/docs/en/manipulate/add), so use that
 documentation to know what units are available.
+
+## Recording a whole transaction
+
+Sometimes it's easier to capture a whole series of API calls related to a single
+page load so we can attach it to a bug report or issue for future investigation.
+To help with this, the proxy server has another utility that will capture all
+of those calls and produce a zip file with the results.
+
+To enable this, visit [localhost:8081/bundle](http://localhost:8081/bundle). The
+proxy will capture all API calls associated with the next location page load.
+Once that location response is finished, the proxy will revert back to its
+previous behavior (recording, passing through, etc.). The produced zip file will
+be located in the `tests/api/data` directory.

--- a/tests/api/config.js
+++ b/tests/api/config.js
@@ -1,0 +1,41 @@
+let bundling = false;
+let bundleID = false;
+let localService = true;
+let recording = false;
+
+export default {
+  get bundling() {
+    return bundling;
+  },
+  set bundling(v) {
+    bundling = v;
+    if (v === false) {
+      console.log(`CONFIG:   bundle ${bundleID} finished`);
+      bundleID = false;
+    }
+  },
+
+  get bundleID() {
+    return bundleID;
+  },
+  set bundleID(v) {
+    if (bundling && !bundleID) {
+      bundleID = v;
+      console.log(`CONFIG:   starting bundle ${bundleID}`);
+    }
+  },
+
+  get localService() {
+    return localService;
+  },
+  set localService(v) {
+    localService = v;
+  },
+
+  get recording() {
+    return recording;
+  },
+  toggleRecording() {
+    recording = !recording;
+  },
+};

--- a/tests/api/local.js
+++ b/tests/api/local.js
@@ -50,7 +50,7 @@ const processDates = (obj) => {
   });
 };
 
-export default async (request, response, { record }) => {
+export default async (request, response) => {
   // Put the query string back together.
   const query = Object.entries(request.query)
     .map(([key, value]) => `${key}=${value}`)
@@ -63,15 +63,11 @@ export default async (request, response, { record }) => {
 
   const fileExists = await exists(filePath);
 
-  console.log(
-    `request for ${request.path}; target file ${
-      fileExists ? "exists" : "DOES NOT exist"
-    } at ${filePath}`,
-  );
-
   if (!fileExists) {
-    await proxy(request, response, { record });
+    console.log(`LOCAL:    local file does not exist; proxying`);
+    await proxy(request, response);
   } else {
+    console.log(`LOCAL:    serving local file: ${filePath}`);
     const output = JSON.parse(await fs.readFile(filePath));
     processDates(output);
 

--- a/tests/api/local.js
+++ b/tests/api/local.js
@@ -70,7 +70,7 @@ export default async (request, response, { record }) => {
   );
 
   if (!fileExists) {
-    await proxy(request, response, { record, filePath });
+    await proxy(request, response, { record });
   } else {
     const output = JSON.parse(await fs.readFile(filePath));
     processDates(output);

--- a/tests/api/main.js
+++ b/tests/api/main.js
@@ -7,6 +7,8 @@ const port = process.env.PORT ?? 8081;
 
 let serveLocalFiles = true;
 let record = false;
+let bundle = false;
+let bundleTimer = false;
 
 app.get("*", (req, res) => {
   if (req.path === "/no-local") {
@@ -33,10 +35,25 @@ app.get("*", (req, res) => {
     return;
   }
 
-  if (serveLocalFiles) {
-    serveLocally(req, res, { record });
+  if (req.path === "/bundle") {
+    bundle = true;
+    res.write("The next sequence of requests will be recorded and bundled");
+    console.log("The next sequence of requests will be recorded and bundled");
+    res.end();
+    return;
+  }
+
+  if (bundle) {
+    clearTimeout(bundleTimer);
+    bundleTimer = setTimeout(() => {
+      bundle = false;
+    }, 3_000);
+  }
+
+  if (bundle || !serveLocalFiles) {
+    proxyToApi(req, res, { bundle });
   } else {
-    proxyToApi(req, res, { record });
+    serveLocally(req, res, { bundle, record });
   }
 });
 

--- a/tests/api/main.js
+++ b/tests/api/main.js
@@ -1,18 +1,14 @@
 import express from "express";
 import proxyToApi from "./proxy.js";
+import config from "./config.js";
 import serveLocally from "./local.js";
 
 const app = express();
 const port = process.env.PORT ?? 8081;
 
-let serveLocalFiles = true;
-let record = false;
-let bundle = false;
-let bundleTimer = false;
-
 app.get("*", (req, res) => {
   if (req.path === "/no-local") {
-    serveLocalFiles = false;
+    config.localService = false;
     res.write("Locally-served files are now disabled");
     console.log("Locally-served files are now disabled");
     res.end();
@@ -20,7 +16,7 @@ app.get("*", (req, res) => {
   }
 
   if (req.path === "/local") {
-    serveLocalFiles = true;
+    config.localService = true;
     res.write("Locally-served files are now enabled");
     console.log("Locally-served files are now enabled");
     res.end();
@@ -28,32 +24,30 @@ app.get("*", (req, res) => {
   }
 
   if (req.path === "/record") {
-    record = !record;
-    res.write(`Recording is now ${record ? "en" : "dis"}abled`);
-    console.log(`Recording is now ${record ? "en" : "dis"}abled`);
+    config.toggleRecording();
+    res.write(`Recording is now ${config.recording ? "en" : "dis"}abled`);
+    console.log(`Recording is now ${config.recording ? "en" : "dis"}abled`);
     res.end();
     return;
   }
 
   if (req.path === "/bundle") {
-    bundle = true;
+    config.bundling = true;
     res.write("The next sequence of requests will be recorded and bundled");
     console.log("The next sequence of requests will be recorded and bundled");
     res.end();
     return;
   }
 
-  if (bundle) {
-    clearTimeout(bundleTimer);
-    bundleTimer = setTimeout(() => {
-      bundle = false;
-    }, 3_000);
-  }
+  const query = Object.entries(req.query)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+  console.log(`REQUEST:  ${req.path}${query.length > 0 ? `?${query}` : ""}`);
 
-  if (bundle || !serveLocalFiles) {
-    proxyToApi(req, res, { bundle });
+  if (!config.localService) {
+    proxyToApi(req, res);
   } else {
-    serveLocally(req, res, { bundle, record });
+    serveLocally(req, res);
   }
 });
 

--- a/tests/api/package-lock.json
+++ b/tests/api/package-lock.json
@@ -6,6 +6,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "archiver": "^6.0.1",
         "dayjs": "^1.11.10",
         "express": "^4.18.2",
         "prettier": "^3.2.0"
@@ -45,16 +46,58 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.1.tgz",
+      "integrity": "sha512-CXGy4poOLBKptiZH//VlWdFuUC1RESbdZjGjILwBuZ73P7WkAUN0htfSfBq/7k6FRFlpu7bg4JOkj1vU9G6jcQ==",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^5.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-4.0.1.tgz",
+      "integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
+      "dependencies": {
+        "glob": "^8.0.0",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
+    "node_modules/b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -110,6 +153,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -158,6 +209,20 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.1.tgz",
+      "integrity": "sha512-MPh//1cERdLtqwO3pOFLeXtpuai0Y2WCd5AhtKxznqM7WtaMYaOEMSgn45d9D10sIHSfIKE603HlOp8OPGrvag==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^5.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -195,6 +260,34 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-5.0.0.tgz",
+      "integrity": "sha512-B0EPa1UK+qnpBZpG+7FgPCu0J2ETLpXq09o9BkLkEAhdB6Z61Qo4pJ3JYu0c+Qi+/SAL7QThqnzS06pmSSyZaw==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.10",
@@ -306,6 +399,11 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -351,6 +449,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -387,6 +490,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -399,6 +520,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -409,6 +549,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -495,6 +640,15 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -549,6 +703,54 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -708,7 +910,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -730,6 +931,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/parseurl": {
@@ -771,6 +980,11 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -803,6 +1017,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -823,6 +1042,46 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -970,6 +1229,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.15.6",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -980,6 +1256,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -1040,6 +1326,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1056,11 +1347,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/zip-stream": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-5.0.1.tgz",
+      "integrity": "sha512-UfZ0oa0C8LI58wJ+moL46BDIMgCQbnsb+2PoiJYtonhBsMh2bq1eRBVkvjfVsqbEHd9/EgKPUuL9saSSsec8OA==",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "compress-commons": "^5.0.1",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     }
   }
 }

--- a/tests/api/package.json
+++ b/tests/api/package.json
@@ -5,6 +5,7 @@
     "start": "nodemon -e js main.js"
   },
   "dependencies": {
+    "archiver": "^6.0.1",
     "dayjs": "^1.11.10",
     "express": "^4.18.2",
     "prettier": "^3.2.0"

--- a/tests/api/proxy.js
+++ b/tests/api/proxy.js
@@ -1,7 +1,8 @@
 import https from "https";
 import save from "./save.js";
+import config from "./config.js";
 
-export default (req, res, { bundle = false, record = false } = {}) => {
+export default (req, res) => {
   // Reassemble the query string, if any.
   const qs = Object.entries(req.query)
     .map(([key, value]) => `${key}=${value}`)
@@ -30,9 +31,10 @@ export default (req, res, { bundle = false, record = false } = {}) => {
           // Write out the response.
           if (!res.writableEnded) {
             res.write(output.join(""));
+            console.log("PROXY:    response finished");
 
-            if (bundle || record) {
-              save(req, proxyResponse, output.join(""), { bundle });
+            if (config.recording || config.bundling) {
+              save(req, proxyResponse, output.join(""));
             }
           }
           res.end();

--- a/tests/api/proxy.js
+++ b/tests/api/proxy.js
@@ -42,15 +42,23 @@ export default (req, res, { record = false, filePath = false } = {}) => {
 
           // If we're supposed to record and we have a file path...
           if (record && !!filePath && proxyResponse.statusCode >= 200) {
-            console.log(`record this to ${filePath}`);
+            const contentType = proxyResponse.headers["content-type"];
 
-            // Make the directory structure if necessary, then write out the
-            // formatted JSON.
-            await fs.mkdir(path.dirname(filePath), { recursive: true });
-            const json = await format(output.join(""), { parser: "json" });
-            await fs.writeFile(filePath, json, {
-              encoding: "utf-8",
-            });
+            // Only capture JSON responses.
+            if (
+              contentType === "application/json" ||
+              contentType === "application/geo+json"
+            ) {
+              console.log(`record this to ${filePath}`);
+
+              // Make the directory structure if necessary, then write out the
+              // formatted JSON.
+              await fs.mkdir(path.dirname(filePath), { recursive: true });
+              const json = await format(output.join(""), { parser: "json" });
+              await fs.writeFile(filePath, json, {
+                encoding: "utf-8",
+              });
+            }
           }
         };
 

--- a/tests/api/save.js
+++ b/tests/api/save.js
@@ -9,6 +9,10 @@ let endOfBundleTimer = false;
 export default async (request, response, output) => {
   const requestID = request.headers["wx-gov-response-id"];
 
+  if(config.bundling && !requestID){
+    return;
+  }
+
   // If we're supposed to capture a bundle and we haven't yet, this is the one
   // to capture. Save off the request ID.
   if (config.bundling) {

--- a/tests/api/save.js
+++ b/tests/api/save.js
@@ -1,0 +1,71 @@
+import archiver from "archiver";
+import { createWriteStream, promises as fs } from "fs";
+import path from "path";
+import { format } from "prettier";
+
+let currentBundleId = false;
+let endOfBundleTimer = false;
+
+export default async (request, response, output, { bundle = false }) => {
+  const requestId = request.headers["wx-gov-response-id"];
+
+  // If we're supposed to capture a bundle and we haven't yet, this is the one
+  // to capture. Save off the request ID.
+  if (bundle) {
+    if (bundle && currentBundleId === false) {
+      console.log(`starting bundle ${requestId}`);
+      currentBundleId = requestId;
+    }
+
+    // Stop bundling after 3 seconds of silence on this request ID.
+    clearTimeout(endOfBundleTimer);
+    endOfBundleTimer = setTimeout(() => {
+      const bundlePath = `./data/bundle_${requestId}`;
+      const outPath = `./data/bundle_${requestId}.zip`;
+
+      const archive = archiver("zip");
+      const outStream = createWriteStream(outPath);
+
+      archive.directory(bundlePath, false).pipe(outStream);
+
+      outStream.on("close", async () => {
+        await fs.rm(bundlePath, { recursive: true });
+
+        console.log(`bundle ${currentBundleId} finished`);
+      });
+
+      archive.finalize();
+    }, 3_000);
+  }
+
+  // If we are bundling and this request ID is the same as our bundle ID, then
+  // save it to the bundle folder. Otherwise put it in the normal place.
+  const dataPath =
+    bundle && currentBundleId === requestId
+      ? `./data/bundle_${requestId}`
+      : "./data";
+
+  // Put the query string back together.
+  const query = Object.entries(request.query)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+
+  // The file path is the request path plus the query string, if any.
+  const filePath = `${path.join(dataPath, request.path)}${
+    query.length > 0 ? "__" : ""
+  }${query}.json`;
+
+  const contentType = response.headers["content-type"].replace(/\/geo\+/, "/");
+
+  if (response.statusCode >= 200 && contentType === "application/json") {
+    console.log(`record this to ${filePath}`);
+
+    // Make the directory structure if necessary, then write out the
+    // formatted JSON.
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const json = await format(output, { parser: "json" });
+    await fs.writeFile(filePath, json, {
+      encoding: "utf-8",
+    });
+  }
+};

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -57,6 +57,15 @@ class WeatherDataService
     private $t;
 
     /**
+     * Response ID.
+     *
+     * Used to identify which response we're handling with our API calls.
+     *
+     * @var String responseId
+     */
+    private $responseId;
+
+    /**
      * The request currently being responded to.
      *
      * @var request
@@ -99,6 +108,11 @@ class WeatherDataService
         $this->legacyMapping = json_decode(
             file_get_contents(__DIR__ . "/legacyMapping.json"),
         );
+
+        // For a given request, assign it a response ID. We'll send this in the
+        // headers to the API. If we've already gotten an ID for this response,
+        // keep it.
+        $this->responseId = uniqid();
     }
 
     /**
@@ -116,13 +130,6 @@ class WeatherDataService
             $baseUrl = getEnv("API_URL");
             $baseUrl = $baseUrl == false ? "https://api.weather.gov" : $baseUrl;
             $url = $baseUrl . $url;
-        }
-
-        // For a given request, assign it a response ID. We'll send this in the
-        // headers to the API. If we've already gotten an ID for this response,
-        // keep it.
-        if (!$this->responseId) {
-            $this->responseId = uniqid();
         }
 
         $cacheHit = $this->cache->get($url);


### PR DESCRIPTION
## What does this PR do? 🛠️

The API proxy server now has an endpoint at [localhost:8081/bundle](http://localhost:8081/bundle) that will enable capturing a "bundle" of API responses associated with the same page load. The result is a ZIP file that we can share more easily. Just unzip it locally and then visit the same location page that generated the bundle. (You may have to clear your Drupal cache first, or wait a minute or so for them to expire.)

Also adds a header to our outgoing API requests identifying the Drupal response we're servicing. That's necessary for the whole "bundling" thing, but we might other uses for it in the future. It's not a personal identifier – it's based on the current time.