### PR TITLE
Basic error handling in weather blocks

### DIFF
--- a/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php
@@ -23,30 +23,34 @@ class CurrentConditionsBlock extends WeatherBlockBase
         if ($location->grid) {
             $grid = $location->grid;
 
-            $place = $this->weatherData->getPlaceFromGrid(
-                $grid->wfo,
-                $grid->x,
-                $grid->y,
-            );
+            try {
+                $place = $this->weatherData->getPlaceFromGrid(
+                    $grid->wfo,
+                    $grid->x,
+                    $grid->y,
+                );
 
-            $data = $this->weatherData->getCurrentConditionsFromGrid(
-                $grid->wfo,
-                $grid->x,
-                $grid->y,
-            );
+                $data = $this->weatherData->getCurrentConditionsFromGrid(
+                    $grid->wfo,
+                    $grid->x,
+                    $grid->y,
+                );
 
-            // We generally expect our internal places to be objects with city
-            // and state keys. However, if the user arrived here using location
-            // search, we may have gotten a suggested place name that cannot be
-            // cleanly parsed into just city and state. In that case, the entire
-            // place name is stuffed into the city. So we only want to combine
-            // these two if they both actually exist.
-            $data["place"] = $place->city;
-            if ($place->state) {
-                $data["place"] .= ", " . $place->state;
+                // We generally expect our internal places to be objects with city
+                // and state keys. However, if the user arrived here using location
+                // search, we may have gotten a suggested place name that cannot be
+                // cleanly parsed into just city and state. In that case, the entire
+                // place name is stuffed into the city. So we only want to combine
+                // these two if they both actually exist.
+                $data["place"] = $place->city;
+                if ($place->state) {
+                    $data["place"] .= ", " . $place->state;
+                }
+
+                return $data;
+            } catch (\Throwable $e) {
+                return ["error" => true];
             }
-
-            return $data;
         }
     }
 }

--- a/web/modules/weather_blocks/src/Plugin/Block/DailyForecastBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/DailyForecastBlock.php
@@ -23,13 +23,17 @@ class DailyForecastBlock extends WeatherBlockBase
         if ($location->grid) {
             $grid = $location->grid;
 
-            return $this->weatherData->getDailyForecastFromGrid(
-                $grid->wfo,
-                $grid->x,
-                $grid->y,
-                false,
-                3,
-            );
+            try {
+                return $this->weatherData->getDailyForecastFromGrid(
+                    $grid->wfo,
+                    $grid->x,
+                    $grid->y,
+                    false,
+                    3,
+                );
+            } catch (\Throwable $e) {
+                return ["error" => true];
+            }
         }
         return null;
     }

--- a/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
@@ -58,14 +58,19 @@ class HourlyForecastBlock extends WeatherBlockBase
 
             $config = $this->getConfiguration();
             $max = $config["max_items"] ?? "12";
-            $data = $this->weatherData->getHourlyForecastFromGrid(
-                $grid->wfo,
-                $grid->x,
-                $grid->y,
-            );
-            $data = array_slice($data, 0, $max);
 
-            return ["hours" => $data];
+            try {
+                $data = $this->weatherData->getHourlyForecastFromGrid(
+                    $grid->wfo,
+                    $grid->x,
+                    $grid->y,
+                );
+                $data = array_slice($data, 0, $max);
+
+                return ["hours" => $data];
+            } catch (\Throwable $e) {
+                return ["error" => true];
+            }
         }
         return null;
     }

--- a/web/modules/weather_blocks/src/Plugin/Block/LocalAlertListBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/LocalAlertListBlock.php
@@ -23,12 +23,16 @@ class LocalAlertListBlock extends WeatherBlockBase
         if ($location->grid) {
             $grid = $location->grid;
 
-            $data = $this->weatherData->getAlertsForGrid(
-                $grid->wfo,
-                $grid->x,
-                $grid->y,
-            );
-            return ["alerts" => $data];
+            try {
+                $data = $this->weatherData->getAlertsForGrid(
+                    $grid->wfo,
+                    $grid->x,
+                    $grid->y,
+                );
+                return ["alerts" => $data];
+            } catch (\Throwable $e) {
+                return ["error" => true];
+            }
         }
         return null;
     }

--- a/web/modules/weather_blocks/src/Plugin/Block/LocalAlertsBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/LocalAlertsBlock.php
@@ -23,12 +23,16 @@ class LocalAlertsBlock extends WeatherBlockBase
         if ($location->grid) {
             $grid = $location->grid;
 
-            $data = $this->weatherData->getAlertsForGrid(
-                $grid->wfo,
-                $grid->x,
-                $grid->y,
-            );
-            return ["alerts" => $data];
+            try {
+                $data = $this->weatherData->getAlertsForGrid(
+                    $grid->wfo,
+                    $grid->x,
+                    $grid->y,
+                );
+                return ["alerts" => $data];
+            } catch (\Throwable $e) {
+                return ["error" => true];
+            }
         }
         return null;
     }

--- a/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/LocationSearchBlock.php
@@ -22,16 +22,20 @@ class LocationSearchBlock extends WeatherBlockBase
 
         if ($location->grid) {
             $grid = $location->grid;
-            $data = $this->weatherData->getPlaceFromGrid(
-                $grid->wfo,
-                $grid->x,
-                $grid->y,
-            );
+            try {
+                $data = $this->weatherData->getPlaceFromGrid(
+                    $grid->wfo,
+                    $grid->x,
+                    $grid->y,
+                );
 
-            if ($data) {
-                return [
-                    "place" => $data,
-                ];
+                if ($data) {
+                    return [
+                        "place" => $data,
+                    ];
+                }
+            } catch (\Throwable $e) {
+                return ["error" => true];
             }
         }
 

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -1,6 +1,9 @@
 {# Widgets and stuff. This is presented as a row of columns. #}
 <div class="weather-gov-current-conditions">
   <h2>Current Conditions</h2>
+  {% if content.error %}
+  {% include '@new_weather_theme/partials/uswds-alert.html.twig' with { 'level': "error", body: "There was an error loading the current conditions." } %}
+  {% else %}
 
   {# We hide from screenreaders and use the weather narrative (below) instead #}
   <div data-wx-current-conditions-narrative aria-hidden="true">
@@ -110,4 +113,5 @@
       {{content.stationInfo.elevation}} ft
     </div>
   </div>
+{% endif %}
 </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
@@ -1,5 +1,9 @@
 <div class="daily-forecast-block tablet:grid-col-6 mobile-lg:grid-col-8">
   <h2>Daily forecast</h2>
+  {% if content.error %}
+  {% include '@new_weather_theme/partials/uswds-alert.html.twig' with { 'level': "error", body: "There was an error loading the daily forecast." } %}
+  {% else %}
+
   <h3>Next {{(content.detailed | length) + 1}} days</h3>
   <ol class="usa-list--unstyled">
     {# Attempt to render the period(s) associated with the current day #}
@@ -38,4 +42,5 @@
       </li>
     {% endfor %}
   </ol>
+  {% endif %}
 </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
@@ -1,5 +1,8 @@
 <div class="hourly-forecast-block tablet:grid-col-6 mobile-lg:grid-col-8">
   <h2>Hourly forecast</h2>
+  {% if content.error %}
+  {% include '@new_weather_theme/partials/uswds-alert.html.twig' with { 'level': "error", body: "There was an error loading the hourly forecast." } %}
+  {% else %}
   <ol class="grid-row flex-column minh-card usa-list--unstyled">
     {% for hour in content.hours %}
       <li class="margin-bottom-3">
@@ -23,4 +26,5 @@
       </li>
     {% endfor %}
   </ol>
+  {% endif %}
 </div>

--- a/web/themes/new_weather_theme/templates/partials/uswds-alert.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/uswds-alert.html.twig
@@ -1,0 +1,6 @@
+<div class="usa-alert usa-alert--{{ level | default('info') }}">
+  <div class="usa-alert__body">
+    {% if heading %}<h3 class="usa-alert__heading">{{ heading }}</h3>{% endif %}
+    {% if body %}<div class="usa-alert__text">{{ body }}</div>{% endif %}
+  </div>
+</div>


### PR DESCRIPTION
## What does this PR do? 🛠️

- Updates the weather data service to cache exceptions if an API endpoint fails after backoff-retries, so other blocks won't waste time trying the same thing.
- Updates all of our blocks that use API data to catch exceptions and send back an `error` boolean
- Adds a USWDS alert partial
- Updates the blocks' twig templates to show a USWDS alert partial if there is an error

closes #651

## What does the reviewer need to know? 🤔

`make cc` and *maybe* `make rebuild`, because as ever, I'm not sure what's necessary to get PHP changes to take effect.

## Screenshots (if appropriate): 📸

![image](https://github.com/weather-gov/weather.gov/assets/142943695/9db00eb0-a297-431b-b157-93421b5cd8e4)

<!--- Make sure you add a subject matter expert to the Reviewers list -->
