### PR TITLE
Add global template data

### DIFF
--- a/web/modules/weather_blocks/weather_blocks.module
+++ b/web/modules/weather_blocks/weather_blocks.module
@@ -1,1 +1,46 @@
 <?php
+
+// This hook lets us alter the variables at the page level. These variables are
+// available globally to all templates.
+function weather_blocks_template_preprocess_default_variables_alter(
+    &$variables,
+    $hook,
+) {
+    // Let's create a single global that contains all of our stuff, rather than
+    // scattering them around. Yay, namespaces!
+    $weatherMetadata = [
+        "alerts" => false,
+        "place" => false,
+    ];
+
+    // First, get our grid information, if we have it.
+    $container = \Drupal::getContainer();
+    $route = $container->get("current_route_match");
+
+    $wfo = $route->getParameter("wfo");
+    $x = $route->getParameter("gridX");
+    $y = $route->getParameter("gridY");
+
+    // If we do, then we can start populating globals.
+    if ($wfo != null && $x != null && $y != null) {
+        $weatherData = $container->get("weather_data");
+
+        try {
+            $alerts = $weatherData->getAlertsForGrid($wfo, $x, $y);
+            $weatherMetadata["alerts"] = count($alerts) > 0;
+        } catch (Throwable $e) {
+        }
+
+        try {
+            $place = $weatherData->getPlaceFromGrid($wfo, $x, $y);
+            if ($place) {
+                $weatherMetadata["place"] = trim(
+                    $place->city . ", " . $place->state,
+                );
+            }
+        } catch (Throwable $e) {
+        }
+    }
+
+    $variables["weather"] = $weatherMetadata;
+}

--- a/web/themes/new_weather_theme/templates/layout/html.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/html.html.twig
@@ -35,7 +35,7 @@
 <html{{ html_attributes }}>
   <head>
     <head-placeholder token="{{ placeholder_token }}">
-    <title>{{ head_title|safe_join(' | ') }}</title>
+    <title>{% if weather.place %}{{ weather.place }} | {% endif %}{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
     <link rel="stylesheet" href="/{{ directory }}/assets/css/styles.css" />


### PR DESCRIPTION
## What does this PR do? 🛠️

Implements the `template_preprocess_default_variables_alter` hook to inject some of our own globals. We can add to this later as-needed, but for now, our globals object looks like this:

```
{
  alerts: <bool; default false>,
  place: <bool|string; default false>
}
```

Then we can use those in any of our twig templates with `{{ weather.alerts }}` or `{{ weather.place }}`. This PR also adds the location page place name to the page title using this global data.

## What does the reviewer need to know? 🤔

I don't think we can do dependency injection on these module-level hook handlers, so it's a little messy and... perhaps untestable? Not thrilled about that but I mean... I suspect we're already testing a lot more than most Drupal sites.

`make rebuild && make cc`