### PR TITLE
Conditionally rendering the alerts tab and tab area

### DIFF
--- a/tests/e2e/cypress/e2e/tabbed-nav.cy.js
+++ b/tests/e2e/cypress/e2e/tabbed-nav.cy.js
@@ -82,7 +82,8 @@ describe("<tabbed-nav> component tests", () => {
         cy.get("weathergov-alert-list a").each((anchorEl) => {
           const alertId = anchorEl.attr("href").split("#")[1];
           cy.wrap(anchorEl).click();
-          cy.get(`#${alertId}`).as("alertEl")
+          cy.get(`#${alertId}`)
+            .as("alertEl")
             .find(".usa-accordion__content")
             .invoke("attr", "hidden")
             .should("not.exist")
@@ -126,8 +127,8 @@ describe("<tabbed-nav> component tests", () => {
     it("Navigates to the correct alert accordion and opens it if hash present", () => {
       const alertId = "alert_2";
       cy.visit(`/local/TST/10/10#${alertId}`);
-      cy
-        .get(`#${alertId}`).as("alertEl")
+      cy.get(`#${alertId}`)
+        .as("alertEl")
         .find(".usa-accordion__content")
         .invoke("attr", "hidden")
         .should("not.exist")
@@ -139,11 +140,11 @@ describe("<tabbed-nav> component tests", () => {
         .should("be.visible");
     });
 
-    ["hourly", "daily"].forEach(tabName => {
+    ["hourly", "daily"].forEach((tabName) => {
       it(`Acticates the ${tabName} tab if the hash for it is present`, () => {
         cy.visit(`/local/TST/10/10#${tabName}`);
-        cy
-          .get(`.tab-button[data-tab-name="${tabName}"]`).as("tabButton")
+        cy.get(`.tab-button[data-tab-name="${tabName}"]`)
+          .as("tabButton")
           .invoke("attr", "data-selected")
           .should("exist")
           .get("@tabButton")
@@ -154,6 +155,15 @@ describe("<tabbed-nav> component tests", () => {
           .invoke("attr", "data-selected")
           .should("exist");
       });
+    });
+  });
+
+  describe("Conditional tabs", () => {
+    it("Should not display an alerts tab or area if there are no alerts", () => {
+      cy.visit("local/TST/1/1");
+      cy.get('.tab-button[data-tab-name="alerts"]')
+        .should("not.exist");
+      cy.get('#alerts').should("not.exist");
     });
   });
 });

--- a/web/themes/new_weather_theme/templates/layout/page--local.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--local.html.twig
@@ -134,15 +134,20 @@
         {{ drupal_block("weathergov_current_conditions") }}
 
       <tabbed-nav class="display-block position-relative">
-          <div class="tab-buttons padding-bottom-4 padding-top-4 top-0 z-top display-flex flex-row flex-justify position-sticky bg-white top-4 mobile-lg:grid-col-8 desktop:grid-col-6">
-              <button role="button" class="tab-button" data-tab-name="alerts" aria-controls="alerts">{{ "Alerts" | t }}</button>
+        <div class="tab-buttons padding-bottom-4 padding-top-4 top-0 z-top display-flex flex-row flex-justify position-sticky bg-white top-4 mobile-lg:grid-col-8 desktop:grid-col-6">
+          {% if weather.alerts %}
+          <button role="button" class="tab-button" data-tab-name="alerts" aria-controls="alerts">{{ "Alerts" | t }}</button>
+          {% endif %}
                   <button role="button" class="tab-button" data-tab-name="outlook" aria-controls="outlook">{{ "Outlook" | t}}</button>
               <button role="button" class="tab-button" data-tab-name="hourly" aria-controls="hourly">{{ "Hourly" | t }}</button>
               <button role="button" class="tab-button" data-tab-name="daily" aria-controls="daily">{{ "Daily" | t }}</button>
-          </div>
+        </div>
+
+        {% if weather.alerts %}
           <div class="tab-container" id="alerts">
               {{ drupal_block("weathergov_local_alerts") }}
           </div>
+          {% endif %}
           <div class="tab-container" id="outlook">
               <div class="tablet:grid-col-6 padding-right-2">
           {{ drupal_block("weathergov_weather_story") }}


### PR DESCRIPTION
## What does this PR do? 🛠️
As a follow on to the tabbed-nav work and in addressing to #729, this PR ensures that the "Alerts" tab is only rendered on location pages that actually have alerts.

## What does the reviewer need to know? 🤔
`make cc` should do the trick. Note that we are using the recorded demo endpoints for sample data of with/without alerts.

## Screenshots (if appropriate): 📸
<details>
<summary>No alerts</summary>

![Screen Shot 2024-02-02 at 1 45 56 PM](https://github.com/weather-gov/weather.gov/assets/105373963/1f6b6518-c068-47af-85a8-a3be955fd083)


</details>

<details>
<summary>With alerts</summary>


![Screen Shot 2024-02-02 at 1 46 04 PM](https://github.com/weather-gov/weather.gov/assets/105373963/ace5f95e-9f3f-416f-a398-505b501804ba)


</details>