### PR TITLE
Tabbed navigation a11y fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "axe-core": "^4.8.3",
         "cypress": "^13.6.4",
         "cypress-axe": "^1.5.0",
+        "cypress-plugin-tab": "^1.0.5",
         "dayjs": "^1.11.10",
         "eslint": "^8.56.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -628,6 +629,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ally.js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
+      "integrity": "sha512-ZewdfuwP6VewtMN36QY0gmiyvBfMnmEaNwbVu2nTS6zRt069viTgkYgaDiqu6vRJ1VJCriNqV0jGMu44R8zNbA==",
+      "dev": true,
+      "dependencies": {
+        "css.escape": "^1.5.0",
+        "platform": "1.3.3"
       }
     },
     "node_modules/ansi-colors": {
@@ -1407,6 +1418,12 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1499,6 +1516,15 @@
       "peerDependencies": {
         "axe-core": "^3 || ^4",
         "cypress": "^10 || ^11 || ^12 || ^13"
+      }
+    },
+    "node_modules/cypress-plugin-tab": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz",
+      "integrity": "sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==",
+      "dev": true,
+      "dependencies": {
+        "ally.js": "^1.4.1"
       }
     },
     "node_modules/cypress/node_modules/supports-color": {
@@ -4683,6 +4709,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
+      "integrity": "sha512-VJK1SRmXBpjwsB4YOHYSturx48rLKMzHgCqDH2ZDa6ZbMS/N5huoNqyQdK5Fj/xayu3fqbXckn5SeCS1EbMDZg==",
+      "dev": true
     },
     "node_modules/postcss": {
       "version": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "axe-core": "^4.8.3",
     "cypress": "^13.6.4",
     "cypress-axe": "^1.5.0",
+    "cypress-plugin-tab": "^1.0.5",
     "dayjs": "^1.11.10",
     "eslint": "^8.56.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/tests/e2e/cypress/e2e/tabbed-nav.cy.js
+++ b/tests/e2e/cypress/e2e/tabbed-nav.cy.js
@@ -161,9 +161,75 @@ describe("<tabbed-nav> component tests", () => {
   describe("Conditional tabs", () => {
     it("Should not display an alerts tab or area if there are no alerts", () => {
       cy.visit("local/TST/1/1");
-      cy.get('.tab-button[data-tab-name="alerts"]')
-        .should("not.exist");
-      cy.get('#alerts').should("not.exist");
+      cy.get('.tab-button[data-tab-name="alerts"]').should("not.exist");
+      cy.get("#alerts").should("not.exist");
+    });
+  });
+
+  describe("a11y tablist/tabpanel guidelines tests", () => {
+    beforeEach(() => {
+      cy.visit("/local/TST/10/10");
+    });
+
+    it("puts focus on the corresponding tabpanel when tab is pushed from a focussed tab button", () => {
+      cy.get('[role="tab"][data-selected]').as("selectedTab").focus();
+      cy.get("@selectedTab").tab();
+
+      cy.get(":focus")
+        .should("have.class", "tab-container")
+        .invoke("attr", "id")
+        .should("equal", "alerts");
+    });
+
+    it("can navigate to the next (right) element when right arrow key is pressed", () => {
+      cy.get('.tab-button[data-tab-name="alerts"]').as("selectedTab").focus();
+      cy.get("@selectedTab")
+        .type("{rightArrow}");
+      cy
+        .get(".tab-button:focus")
+        .should("have.class", "tab-button")
+        .invoke("attr", "data-tab-name")
+        .should("equal", "outlook");
+    });
+
+    it("If current tab is the first one, pressing left will cycle to the _last_ button in the list", () => {
+      cy.get(".tab-button:first-child").as("selectedTab").focus();
+
+      cy.get("@selectedTab")
+        .type("{leftArrow}");
+      cy
+        .get(".tab-button:focus")
+        .should("match", ":last-child");
+    });
+
+    it("If current tab is the last one, pressing right will cycle to the _first_ button in the list", () => {
+      cy.get(".tab-button:last-child").as("selectedTab").focus();
+
+      cy.get("@selectedTab")
+        .type("{rightArrow}");
+      cy
+        .get(".tab-button:focus")
+        .should("match", ":first-child");
+    });
+
+    it("Home key puts focus on the first tab button in the tablist", () => {
+      cy.get(".tab-button:last-child").as("selectedTab").focus();
+
+      cy.get("@selectedTab")
+        .type("{home}");
+      cy
+        .get(".tab-button:focus")
+        .should("match", ":first-child");
+    });
+
+    it("End key puts the focus on the last tab button in the tablist", () => {
+      cy.get(".tab-button:nth-child(2)").as("selectedTab").focus();
+
+      cy.get("@selectedTab")
+        .type("{end}");
+      cy
+        .get(".tab-button:focus")
+        .should("match", ":last-child");
     });
   });
 });

--- a/tests/e2e/cypress/support/e2e.js
+++ b/tests/e2e/cypress/support/e2e.js
@@ -15,6 +15,6 @@
 
 // Import commands.js using ES2015 syntax:
 import "./commands";
-
+import "cypress-plugin-tab";
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/web/themes/new_weather_theme/templates/layout/page--local.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--local.html.twig
@@ -133,35 +133,36 @@
 
         {{ drupal_block("weathergov_current_conditions") }}
 
-      <tabbed-nav class="display-block position-relative">
-        <div class="tab-buttons padding-bottom-4 padding-top-4 top-0 z-top display-flex flex-row flex-justify position-sticky bg-white top-4 mobile-lg:grid-col-8 desktop:grid-col-6">
+        <tabbed-nav class="display-block position-relative">
+          <div id="tablist-label" class="usa-sr-only">{{ "Weather information sections" | t }}</div>
+          <div role="tablist" class="tab-buttons padding-bottom-4 padding-top-4 top-0 z-top display-flex flex-row flex-justify position-sticky bg-white top-4 mobile-lg:grid-col-8 desktop:grid-col-6" aria-labelledby="tablist-label">
           {% if weather.alerts %}
-          <button role="button" class="tab-button" data-tab-name="alerts" aria-controls="alerts">{{ "Alerts" | t }}</button>
+            <button role="tab" id="alerts-tab-button" class="tab-button" data-tab-name="alerts" aria-controls="alerts">{{ "Alerts" | t }}</button>
           {% endif %}
-                  <button role="button" class="tab-button" data-tab-name="outlook" aria-controls="outlook">{{ "Outlook" | t}}</button>
-              <button role="button" class="tab-button" data-tab-name="hourly" aria-controls="hourly">{{ "Hourly" | t }}</button>
-              <button role="button" class="tab-button" data-tab-name="daily" aria-controls="daily">{{ "Daily" | t }}</button>
+          <button role="tab" id="outlook-tab-button" class="tab-button" data-tab-name="outlook" aria-controls="outlook">{{ "Outlook" | t}}</button>
+          <button role="tab" id="hourly-tab-button" class="tab-button" data-tab-name="hourly" aria-controls="hourly">{{ "Hourly" | t }}</button>
+          <button role="tab" id="daily-tab-button" class="tab-button" data-tab-name="daily" aria-controls="daily">{{ "Daily" | t }}</button>
         </div>
 
         {% if weather.alerts %}
-          <div class="tab-container" id="alerts">
+          <div class="tab-container" id="alerts"  role="tabpanel" aria-labelledby="alerts-tab-button" tabindex="0">
               {{ drupal_block("weathergov_local_alerts") }}
           </div>
-          {% endif %}
-          <div class="tab-container" id="outlook">
-              <div class="tablet:grid-col-6 padding-right-2">
-          {{ drupal_block("weathergov_weather_story") }}
-        </div>
-        <div class="tablet:grid-col-6 padding-left-2">
+        {% endif %}
+        <div class="tab-container" id="outlook"  role="tabpanel" aria-labelledby="outlook-tab-button" tabindex="0">
+          <div class="tablet:grid-col-6 padding-right-2">
+            {{ drupal_block("weathergov_weather_story") }}
+          </div>
+          <div class="tablet:grid-col-6 padding-left-2">
             {{ drupal_block("weathergov_wfo_promo") }}
+          </div>
         </div>
-          </div>
-          <div class="tab-container" id="hourly">
-              {{ drupal_block("weathergov_hourly_forecast") }}
-          </div>
-          <div class="tab-container" id="daily">
-              {{ drupal_block("weathergov_daily_forecast") }}
-          </div>
+        <div class="tab-container" id="hourly" role="tabpanel" aria-labelledby="hourly-tab-button" tabindex="0">
+          {{ drupal_block("weathergov_hourly_forecast") }}
+        </div>
+        <div class="tab-container" id="daily" role="tabpanel" aria-labelledby="daily-tab-button" tabindex="0">
+          {{ drupal_block("weathergov_daily_forecast") }}
+        </div>
       </tabbed-nav>
     </div>
   </main>


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR addresses #733 by adding the expected accessibility behavior and attributes as [recommended by the W3C per these guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-manual/).

## What does the reviewer need to know? 🤔
Appropriate ARIA attributes and relationships have been added where needed, and we've added a few e2e tests to make sure the navigation that W3C recommends is implemented properly. Specific nav things to look out for:
* If a tab is in focus, pressing the `Tab` key __should not__ move to the next tab button, but rather put the focus into the corresponding tabpanel (ie the tab's content container).
* Left/right arrow keys are used to put the focus on the next or previous tab button, if a tab button is currently in focus (instead of the `Tab` key, see above)
* Left/right arrows that go too far in either direction should simply cycle around to the first/last tab button as needed
* Home key puts focus on the first tab button
* End key puts focus on the last tab button

## Testing
__Please__ be sure the a11y test this locally using VoiceOver or Accessibility Inspector!
