### PR TITLE
Fix DAP

### DIFF
--- a/tests/a11y/cypress/support/e2e.js
+++ b/tests/a11y/cypress/support/e2e.js
@@ -19,7 +19,3 @@ import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
-
-// Ignore uncaught script errors. We can't control what happens with external
-// scripts, so...
-Cypress.on("uncaught:exception", () => false);

--- a/tests/e2e/cypress/support/e2e.js
+++ b/tests/e2e/cypress/support/e2e.js
@@ -18,7 +18,3 @@ import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
-
-// Ignore uncaught script errors. We can't control what happens with external
-// scripts, so...
-Cypress.on("uncaught:exception", () => false);

--- a/tests/load-times/cypress.config.js
+++ b/tests/load-times/cypress.config.js
@@ -4,5 +4,6 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: "http://localhost:8080",
     screenshotOnRunFailure: false,
+    supportFile: false,
   },
 });

--- a/tests/load-times/cypress/support/e2e.js
+++ b/tests/load-times/cypress/support/e2e.js
@@ -1,3 +1,0 @@
-// Ignore uncaught script errors. We can't control what happens with external
-// scripts, so...
-Cypress.on("uncaught:exception", () => false);

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -39,4 +39,6 @@ digital-analytics-program:
   header: true
   version: VERSION
   js:
-    https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NOAA&subagency=NWS&sitetopic=weather,safety: {}
+    https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NOAA&subagency=NWS&sitetopic=weather,safety: {
+      attributes: { id: "_fed_an_ua_tag" }
+    }


### PR DESCRIPTION
## What does this PR do? 🛠️

The DAP script tag requires an ID. The lack of an ID was causing errors in the console log, but it also prevents DAP from working. This PR adds the required ID. It also reverts the test changes from #758, since those changes were only made to accommodate the errors that no longer show up. 😛 