### PR TITLE
Pin our composer version to LTS, not just latest 2.x

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -59,10 +59,10 @@ RUN set -eux; \
   apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
   rm -rf /var/lib/apt/lists/*
 
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:lts /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.1.2
+ENV DRUPAL_VERSION 10.2.2
 
 # Copy in our composer files to start with.
 COPY composer.json /opt/drupal/composer.json


### PR DESCRIPTION
## What does this PR do? 🛠️

Something in the composer 2.7 release changed how directories get created. The 2.2 release line is LTS, though, so we should probably be pinning to that anyway. This PR makes that pin.

It also updates the `DRUPAL_VERSION` environment variable we set to be the right Drupal version. Oops.
