### PR TITLE
Add primary key indexes on spatial tables

### DIFF
--- a/spatial-data/load-shapefiles.js
+++ b/spatial-data/load-shapefiles.js
@@ -51,6 +51,7 @@ const loadCWAs = async () => {
 CREATE TABLE IF NOT EXISTS
  weathergov_geo_cwas
  (
+    id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
    wfo VARCHAR(3),
    cwa VARCHAR(3),
    region VARCHAR(2),
@@ -62,6 +63,7 @@ CREATE TABLE IF NOT EXISTS
 
   await dropIndexIfExists(db, "cwas_spatial_idx", "weathergov_geo_cwas");
   await db.query("TRUNCATE TABLE weathergov_geo_cwas");
+  await db.query("ALTER TABLE weathergov_geo_cwas AUTO_INCREMENT=0");
 
   const getSqlForShape = async ({ done, value }) => {
     if (done) {
@@ -121,6 +123,7 @@ const loadStates = async () => {
     `CREATE TABLE IF NOT EXISTS
       weathergov_geo_states
       (
+        id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
         state VARCHAR(2),
         name TEXT,
         fips VARCHAR(2),
@@ -131,6 +134,7 @@ const loadStates = async () => {
   await dropIndexIfExists(db, "states_spatial_idx", "weathergov_geo_states");
 
   await db.query("TRUNCATE TABLE weathergov_geo_states");
+  await db.query("ALTER TABLE weathergov_geo_states AUTO_INCREMENT=0");
 
   const getSqlForShape = async ({ done, value }) => {
     if (done) {
@@ -182,6 +186,7 @@ const loadCounties = async () => {
     `CREATE TABLE IF NOT EXISTS
       weathergov_geo_counties
       (
+        id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
         state VARCHAR(2),
         stateName TEXT,
         stateFips VARCHAR(2),
@@ -212,6 +217,7 @@ const loadCounties = async () => {
   ]);
 
   await db.query("TRUNCATE TABLE weathergov_geo_counties");
+  await db.query("ALTER TABLE weathergov_geo_counties AUTO_INCREMENT=0");
 
   const getSqlForShape = async ({ done, value }) => {
     if (done) {
@@ -319,6 +325,7 @@ const loadPlaces = async () => {
     `CREATE TABLE IF NOT EXISTS
       weathergov_geo_places
         (
+          id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
           name TEXT,
           state TEXT,
           stateName TEXT,
@@ -330,8 +337,8 @@ const loadPlaces = async () => {
         )`,
   );
   await dropIndexIfExists(db, "places_spatial_idx", "weathergov_geo_places");
-
   await db.query("TRUNCATE TABLE weathergov_geo_places");
+  await db.query("ALTER TABLE weathergov_geo_places AUTO_INCREMENT=0");
 
   await Promise.all(
     places.map((place) =>
@@ -410,10 +417,9 @@ const downloadAndUnzip = async (url) => {
   console.log(`   [${filename}] done`);
 };
 
-
-async function main(){
+async function main() {
   await downloadAndUnzip(
-  "https://www.weather.gov/source/gis/Shapefiles/County/c_05mr24.zip",
+    "https://www.weather.gov/source/gis/Shapefiles/County/c_05mr24.zip",
   );
   await downloadAndUnzip(
     "https://www.weather.gov/source/gis/Shapefiles/County/s_05mr24.zip",


### PR DESCRIPTION
## What does this PR do? 🛠️

For performance reasons, Drupal wants to use the `READ COMMITTED` isolation level in the database (it helps prevent deadlocks). This isolation level requires that every table have a primary key. Our spatial tables do not define any primary keys, so we end up with Drupal giving us an error:

![Screenshot 2024-02-16 at 12 43 33 PM](https://github.com/weather-gov/weather.gov/assets/142943695/6877da4c-f049-453a-9763-75393ee03fd0)

This PR updates the `load-shapefiles.js` (which isn't a 100% accurate name anymore, but we can deal with that later if we want to) so that when a spatial table is created, it also gets an autoincrementing `id` column set as the primary key. I chose this route rather than using a field on the data because the data is ***not*** unique. (E.g., there are 3,360 counties, but only 3,269 unique county FIPS codes, which means some of the counties are duplicated. And in the places table, we know NYC shows up a couple dozen times – all with the same physical location so it's fine.)

For our existing environments, we can run this one-off script against them instead. It just takes one argument – the cloud environment being targeted. It'll then setup the appropriate SSH tunnel and add the `id` columns to the existing tables.

```shell
if [ -z "$1" ]; then
    echo 'Please specify a space to load spatial data into (i.e. beta)' >&2
    exit 1
fi

if [ ! $(command -v jq) ] || [ ! $(command -v cf) ]; then
    echo "jq and cf packages must be installed. Please install via your preferred manager."
    exit 1
fi

TARGET="weathergov-$1"

cf target -o nws-weathergov -s $1

# Get an available local port.
LOCAL_PORT=$(netstat -aln | awk '
  $6 == "LISTEN" {
    if ($4 ~ "[.:][0-9]+$") {
      split($4, a, /[:.]/);
      port = a[length(a)];
      p[port] = 1
    }
  }
  END {
    for (i = 3000; i < 65000 && p[i]; i++){};
    if (i == 65000) {exit 1};
    print i
  }
')

# Trap exit signals so we can force our background process to exit as well.
trap "exit" SIGINT SIGTERM
trap "kill 0" EXIT

# Get database service connection details from cf
cf curl "/v2/apps/$(cf app --guid $TARGET)/env" | jq -r '.system_env_json.VCAP_SERVICES["aws-rds"][0].credentials' | jq -r '[.host, .port, .db_name, .username, .password]|@tsv' |
while read -r host port db username password; do
  echo "setting up SSH tunnel..."
  # open a tunnel
  cf ssh -N -T -L $LOCAL_PORT:$host:$port $TARGET &
  sleep 5

  # load
  docker compose run --rm -T spatial node -e '
const mariadb = require("mariadb");
(async () => {
const args = process.argv.slice(1);
const connectionDetails = {
  user: args[0],
  password: args[1],
  database: args[2],
  host: args[3],
  port: args[4],
};
console.log(connectionDetails);
const db = await mariadb.createConnection(connectionDetails);
console.log("wfos...");
await db.query("ALTER TABLE weathergov_geo_cwas ADD COLUMN id int AUTO_INCREMENT PRIMARY KEY");
console.log("states...");
await db.query("ALTER TABLE weathergov_geo_states ADD COLUMN id int AUTO_INCREMENT PRIMARY KEY");
console.log("counties...");
await db.query("ALTER TABLE weathergov_geo_counties ADD COLUMN id int AUTO_INCREMENT PRIMARY KEY");
console.log("places...");
await db.query("ALTER TABLE weathergov_geo_places ADD COLUMN id int AUTO_INCREMENT PRIMARY KEY");
console.log("done");
await db.end();
})();' $username $password $db host.docker.internal $LOCAL_PORT
done

```

All of our cloud environments need to have the indexes added before the next time we update the spatial data. There's no immediate rush, just "eventually."