### PR TITLE
Observation distance logging with NewRelic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ install-site-config:
 log: ## Tail the log for the Drupal container
 	docker compose logs --follow drupal
 
+log-ws: ## tail the Drupal Watchdog logs
+	docker compose exec drupal drush watchdog:tail
+
 rebuild: ## Delete the Drupal container and rebuild. Does *NOT* delete the site
 	docker compose stop drupal
 	docker compose rm drupal -f

--- a/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/CurrentConditionsBlock.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\weather_blocks\Plugin\Block;
 
+use Drupal\Core\Logger\LoggerChannelTrait;
+
 /**
  * Provides a block of the current weather conditions.
  *
@@ -13,6 +15,8 @@ namespace Drupal\weather_blocks\Plugin\Block;
  */
 class CurrentConditionsBlock extends WeatherBlockBase
 {
+    use LoggerChannelTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -56,6 +60,8 @@ class CurrentConditionsBlock extends WeatherBlockBase
 
                 return $data;
             } catch (\Throwable $e) {
+                $logger = $this->getLogger("CURRENT_CONDITIONS");
+                $logger->error($e->getMessage());
                 return ["error" => true];
             }
         }

--- a/web/modules/weather_data/src/Service/NewRelicMetrics.php
+++ b/web/modules/weather_data/src/Service/NewRelicMetrics.php
@@ -90,6 +90,7 @@ class NewRelicMetrics
     {
         $logger = $this->getLogger("NEWRELIC");
         $logger->info($response->getStatusCode());
+        return $response;
     }
 
     private function handleError($err)

--- a/web/modules/weather_data/src/Service/NewRelicMetrics.php
+++ b/web/modules/weather_data/src/Service/NewRelicMetrics.php
@@ -70,32 +70,12 @@ class NewRelicMetrics
 
         $promise = $this->client->sendAsync($request);
 
-        $promise
-            ->then(
-                function ($resp) {
-                    $this->handleResponse($resp);
-                },
-                function ($err) {
-                    $this->handleError($err);
-                },
-            )
-            ->then(null, function ($err) {
-                $this->handleError($err);
-            });
-
-        return $promise;
-    }
-
-    private function handleResponse($response)
-    {
-        $logger = $this->getLogger("NEWRELIC");
-        $logger->info($response->getStatusCode());
-        return $response;
-    }
-
-    private function handleError($err)
-    {
-        $logger = $this->getLogger("NEWRELIC");
-        $logger->error($err->getMessage());
+        return $promise->then(
+            null, // success
+            function ($err) {
+                $logger = $this->getLogger("NEWRELIC");
+                $logger->error($err->getMessage());
+            },
+        );
     }
 }

--- a/web/modules/weather_data/src/Service/NewRelicMetrics.php
+++ b/web/modules/weather_data/src/Service/NewRelicMetrics.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\weather_data\Service;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Psr7\Request;
+use Drupal\Core\Site\Settings;
+use Drupal\Core\Logger\LoggerChannelTrait;
+
+class NewRelicMetrics
+{
+    use LoggerChannelTrait;
+
+    private static $requests = [];
+    /**
+     * HTTP client.
+     *
+     * @var \GuzzleHttp\ClientInterface client
+     */
+    private $client;
+
+    /**
+     * A NR API Key
+     *
+     * @var apiKey
+     */
+    private $apiKey;
+
+    /**
+     * The NR Metrics endpoint base url
+     *
+     * @var baseUrl
+     */
+    private $baseUrl;
+
+    public function __construct(ClientInterface $httpClient)
+    {
+        $this->client = $httpClient;
+        $this->apiKey = Settings::get("new_relic_rpm.api_key");
+        $this->baseUrl = Settings::get("new_relic_rpm.metrics.base_url");
+    }
+
+    public function sendMetric($name, $num, $attributes, $type = "gauge")
+    {
+        $headers = [
+            "Content-Type" => "application/json",
+            "Api-Key" => $this->apiKey,
+        ];
+        $postData = [
+            [
+                "metrics" => [
+                    [
+                        "name" => $name,
+                        "type" => $type,
+                        "value" => $num,
+                        "timestamp" => time(),
+                        "attributes" => $attributes,
+                    ],
+                ],
+            ],
+        ];
+
+        $request = new Request(
+            "POST",
+            $this->baseUrl,
+            $headers,
+            json_encode($postData),
+        );
+
+        $promise = $this->client->sendAsync($request);
+
+        $promise
+            ->then(
+                function ($resp) {
+                    $this->handleResponse($resp);
+                },
+                function ($err) {
+                    $this->handleError($err);
+                },
+            )
+            ->then(null, function ($err) {
+                $this->handleError($err);
+            });
+
+        return $promise;
+    }
+
+    private function handleResponse($response)
+    {
+        $logger = $this->getLogger("NEWRELIC");
+        $logger->info($response->getStatusCode());
+    }
+
+    private function handleError($err)
+    {
+        $logger = $this->getLogger("NEWRELIC");
+        $logger->error($err->getMessage());
+    }
+}

--- a/web/modules/weather_data/src/Service/NewRelicMetrics.php
+++ b/web/modules/weather_data/src/Service/NewRelicMetrics.php
@@ -34,15 +34,28 @@ class NewRelicMetrics
      */
     private $baseUrl;
 
+    /**
+     * The CF or local application name
+     *
+     * @var applicationName
+     */
+    private $applicationName;
+
     public function __construct(ClientInterface $httpClient)
     {
         $this->client = $httpClient;
         $this->apiKey = Settings::get("new_relic_rpm.api_key");
         $this->baseUrl = Settings::get("new_relic_rpm.metrics.base_url");
+        $this->applicationName = Settings::get("wx.application_name");
+        if (!$this->applicationName) {
+            $this->applicationName = "local";
+        }
     }
 
     public function sendMetric($name, $num, $attributes, $type = "gauge")
     {
+        $attributes["applicationName"] = $this->applicationName;
+
         $headers = [
             "Content-Type" => "application/json",
             "Api-Key" => $this->apiKey,

--- a/web/modules/weather_data/src/Service/Test/Base.php
+++ b/web/modules/weather_data/src/Service/Test/Base.php
@@ -6,10 +6,12 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\weather_data\Service\WeatherDataService;
+use Drupal\weather_data\Service\NewRelicMetrics;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\Promise;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Request;
@@ -53,6 +55,13 @@ abstract class Base extends TestCase
      * @var requestMock
      */
     protected $requestMock;
+
+    /**
+     * Mocked NewRelicMetric object
+     *
+     * @var newRelicMock
+     */
+    protected $newRelicMock;
 
     /**
      * WeatherDataService mock object, to be used as $self.
@@ -99,6 +108,10 @@ abstract class Base extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->newRelicMock = $this->getMockBuilder(NewRelicMetrics::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         // The WeatherDataService ingests this RequestStack service, but it
         // immediately uses it to get an instance of the current request and
         // saves the request object. So our mock should be prepped to supply
@@ -114,6 +127,12 @@ abstract class Base extends TestCase
             $requestStack,
             $this->cacheMock,
             $this->databaseMock,
+            $this->newRelicMock,
         );
+    }
+
+    protected function setUpNewRelicMock(): void
+    {
+        $promise = new Promise();
     }
 }

--- a/web/modules/weather_data/src/Service/Test/Base.php
+++ b/web/modules/weather_data/src/Service/Test/Base.php
@@ -130,9 +130,4 @@ abstract class Base extends TestCase
             $this->newRelicMock,
         );
     }
-
-    protected function setUpNewRelicMock(): void
-    {
-        $promise = new Promise();
-    }
 }

--- a/web/modules/weather_data/src/Service/Test/GetCurrentConditionsFromGrid.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetCurrentConditionsFromGrid.php.test
@@ -10,10 +10,32 @@ use GuzzleHttp\Psr7\Response;
 final class GetCurrentConditionsFromGridTest extends Base
 {
     /**
+     * Sets up the appropriate mocks for distance
+     * computation and logging
+     */
+    public function setupDistanceLogging()
+    {
+        $this->selfMock->method("getObsDistanceInfo")->willReturn([
+            "distance" => 42.1,
+            "withinGridCell" => false,
+            "obsPoint" => [
+                "lon" => 42,
+                "lat" => 42,
+            ],
+            "obsStation" => "FAKE",
+            "stationIndex" => 0,
+        ]);
+
+        $this->selfMock->method("logObservationDistanceInfo")->willReturn(null);
+    }
+
+    /**
      * Sets up the HTTP mock for a happy-path of API data for an observation.
      */
     public function setupHappyPath($whichObservation)
     {
+        $this->setupDistanceLogging();
+
         $this->httpClientMock->append(
             new Response(
                 200,
@@ -21,6 +43,13 @@ final class GetCurrentConditionsFromGridTest extends Base
                 file_get_contents(
                     __DIR__ . "/test_data/observation-stations.good.json",
                 ),
+            ),
+        );
+        $this->httpClientMock->append(
+            new Response(
+                200,
+                ["Content-type" => "application/geo+json"],
+                '{"geometry":{"coordinates":[[[4,3],[5,9],[3,9]]]}}',
             ),
         );
         $this->httpClientMock->append(
@@ -71,6 +100,7 @@ final class GetCurrentConditionsFromGridTest extends Base
             "wfo",
             1,
             2,
+            $this->selfMock,
         );
 
         $this->assertEquals((object) $expected, (object) $actual);
@@ -88,6 +118,7 @@ final class GetCurrentConditionsFromGridTest extends Base
             "wfo",
             1,
             2,
+            $this->selfMock,
         );
 
         $this->assertEquals((object) $expected, (object) $actual);
@@ -105,6 +136,7 @@ final class GetCurrentConditionsFromGridTest extends Base
             "wfo",
             1,
             2,
+            $this->selfMock,
         );
 
         $this->assertEquals((object) $expected, (object) $actual);
@@ -122,6 +154,7 @@ final class GetCurrentConditionsFromGridTest extends Base
             "wfo",
             1,
             2,
+            $this->selfMock,
         );
 
         $this->assertEquals((object) $expected, (object) $actual);
@@ -132,6 +165,7 @@ final class GetCurrentConditionsFromGridTest extends Base
      */
     public function testOneObservationStationWithNoTemperature(): void
     {
+        $this->setupDistanceLogging();
         $this->httpClientMock->append(
             new Response(
                 200,
@@ -139,6 +173,14 @@ final class GetCurrentConditionsFromGridTest extends Base
                 file_get_contents(
                     __DIR__ . "/test_data/observation-stations.good.json",
                 ),
+            ),
+        );
+
+        $this->httpClientMock->append(
+            new Response(
+                200,
+                ["Content-type" => "application/geo+json"],
+                '{"geometry":{"coordinates":[[[4,3],[5,9],[3,9]]]}}',
             ),
         );
 
@@ -170,13 +212,14 @@ final class GetCurrentConditionsFromGridTest extends Base
             "wfo",
             1,
             2,
+            $this->selfMock,
         );
         $actual = $actual["temperature"];
 
         $this->assertEquals($expected, $actual);
 
         // Expected calls: list observation stations, station 1, station 2.
-        $this->assertEquals(3, count($this->httpCallStack));
+        $this->assertEquals(4, count($this->httpCallStack));
     }
 
     /**
@@ -184,6 +227,7 @@ final class GetCurrentConditionsFromGridTest extends Base
      */
     public function testThreeObservationStationsWithTemperature(): void
     {
+        $this->setupDistanceLogging();
         $this->httpClientMock->append(
             new Response(
                 200,
@@ -191,6 +235,14 @@ final class GetCurrentConditionsFromGridTest extends Base
                 file_get_contents(
                     __DIR__ . "/test_data/observation-stations.good.json",
                 ),
+            ),
+        );
+
+        $this->httpClientMock->append(
+            new Response(
+                200,
+                ["Content-type" => "application/geo+json"],
+                '{"geometry":{"coordinates":[[[4,3],[5,9],[3,9]]]}}',
             ),
         );
 
@@ -240,12 +292,13 @@ final class GetCurrentConditionsFromGridTest extends Base
             "wfo",
             1,
             2,
+            $this->selfMock,
         );
 
         $this->assertEquals($expected, $actual);
 
         // Expected calls: list stations, station 1, station 2, station 3.
-        $this->assertEquals(4, count($this->httpCallStack));
+        $this->assertEquals(5, count($this->httpCallStack));
     }
 
     /**
@@ -260,6 +313,7 @@ final class GetCurrentConditionsFromGridTest extends Base
             "wfo",
             1,
             2,
+            $this->selfMock,
         );
 
         $this->assertEquals((object) $expected, (object) $actual);
@@ -277,6 +331,7 @@ final class GetCurrentConditionsFromGridTest extends Base
             "wfo",
             1,
             2,
+            $this->selfMock,
         );
 
         $this->assertEquals((object) $expected, (object) $actual);
@@ -346,6 +401,8 @@ final class GetCurrentConditionsFromGridTest extends Base
             $expected["wind"]["direction"] = $scenario[1];
             $expected["wind"]["shortDirection"] = $scenario[2];
 
+            $this->setupDistanceLogging();
+
             $this->httpClientMock->append(
                 new Response(
                     200,
@@ -355,6 +412,15 @@ final class GetCurrentConditionsFromGridTest extends Base
                     ),
                 ),
             );
+
+            $this->httpClientMock->append(
+                new Response(
+                    200,
+                    ["Content-type" => "application/geo+json"],
+                    '{"geometry":{"coordinates":[[[4,3],[5,9],[3,9]]]}}',
+                ),
+            );
+
             $this->httpClientMock->append(
                 new Response(
                     200,
@@ -367,6 +433,7 @@ final class GetCurrentConditionsFromGridTest extends Base
                 "wfo",
                 1,
                 2,
+                $this->selfMock,
             );
 
             $this->assertEquals((object) $expected, (object) $actual);

--- a/web/modules/weather_data/src/Service/Test/GetCurrentConditionsFromGrid.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetCurrentConditionsFromGrid.php.test
@@ -214,7 +214,12 @@ final class GetCurrentConditionsFromGridTest extends Base
             ->expects($this->once())
             ->method("getObsDistanceInfo")
             ->will(
-                $this->returnCallback(function ($geo, $obs, $idx) {
+                $this->returnCallback(function (
+                    $refPoint,
+                    $obs,
+                    $wfoGeom,
+                    $idx,
+                ) {
                     $this->assertEquals(1, $idx);
                 }),
             );

--- a/web/modules/weather_data/src/Service/Test/GetCurrentConditionsFromGrid.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetCurrentConditionsFromGrid.php.test
@@ -208,6 +208,17 @@ final class GetCurrentConditionsFromGridTest extends Base
 
         $expected = 45;
 
+        // We expect the observation API to have
+        // been called twice (index 1)
+        $this->selfMock
+            ->expects($this->once())
+            ->method("getObsDistanceInfo")
+            ->will(
+                $this->returnCallback(function ($geo, $obs, $idx) {
+                    $this->assertEquals(1, $idx);
+                }),
+            );
+
         $actual = $this->weatherDataService->getCurrentConditionsFromGrid(
             "wfo",
             1,
@@ -287,6 +298,10 @@ final class GetCurrentConditionsFromGridTest extends Base
         );
 
         $expected = null;
+
+        // For now, we do not expect calls that exceed the
+        // maximum observation station call size to be logged.
+        $this->selfMock->expects($this->never())->method("getObsDistanceInfo");
 
         $actual = $this->weatherDataService->getCurrentConditionsFromGrid(
             "wfo",

--- a/web/modules/weather_data/src/Service/Test/GetObsDistanceInfo.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetObsDistanceInfo.php.test
@@ -87,4 +87,83 @@ final class GetObsDistanceInfoTest extends Base
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testWithoutReferencePoint()
+    {
+        $statement = $this->createStub(StatementInterface::class);
+
+        $referencePoint = null;
+
+        $wfoGeometry = [
+            (object) [
+                "lat" => 0,
+                "lon" => 0,
+            ],
+            (object) [
+                "lat" => 10,
+                "lon" => 0,
+            ],
+            (object) [
+                "lat" => 10,
+                "lon" => 10,
+            ],
+            (object) [
+                "lat" => 0,
+                "lon" => 10,
+            ],
+            (object) [
+                "lat" => 0,
+                "lon" => 0,
+            ],
+        ];
+
+        $obs = (object) [
+            "geometry" => (object) [
+                "coordinates" => [
+                    2, //lon
+                    2, //lat
+                ],
+            ],
+            "properties" => (object) [
+                "station" => "FAKE",
+            ],
+        ];
+
+        $expectedQuery =
+            "SELECT ST_DISTANCE_SPHERE(ST_GEOMFROMTEXT('POINT(2 2)'), ST_GEOMFROMTEXT('POINT(0 0)')) as distance, ST_WITHIN(ST_GEOMFROMTEXT('POINT(2 2)'), ST_GEOMFROMTEXT('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')) as within;";
+
+        $this->databaseMock
+            ->method("query")
+            ->will(
+                $this->returnValueMap([[$expectedQuery, [], [], $statement]]),
+            );
+
+        $expected = [
+            "distance" => 1,
+            "withinGridCell" => true,
+            "usesReferencePoint" => false,
+            "obsPoint" => [
+                "lat" => 2,
+                "lon" => 2,
+            ],
+            "obsStation" => "FAKE",
+            "stationIndex" => 0,
+        ];
+
+        $statement->method("fetch")->willReturn(
+            (object) [
+                "distance" => 1,
+                "within" => true,
+            ],
+        );
+
+        $actual = $this->weatherDataService->getObsDistanceInfo(
+            $referencePoint,
+            $obs,
+            $wfoGeometry,
+            0,
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/web/modules/weather_data/src/Service/Test/GetObsDistanceInfo.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetObsDistanceInfo.php.test
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\weather_data\Service\Test;
+
+use Drupal\Core\Database\StatementInterface;
+
+final class GetObsDistanceInfoTest extends Base
+{
+    public function testWithReferencePoint()
+    {
+        $statement = $this->createStub(StatementInterface::class);
+
+        $referencePoint = (object) [
+            "lat" => 5,
+            "lon" => 5,
+        ];
+
+        $wfoGeometry = [
+            (object) [
+                "lat" => 0,
+                "lon" => 0,
+            ],
+            (object) [
+                "lat" => 10,
+                "lon" => 0,
+            ],
+            (object) [
+                "lat" => 10,
+                "lon" => 10,
+            ],
+            (object) [
+                "lat" => 0,
+                "lon" => 10,
+            ],
+            (object) [
+                "lat" => 0,
+                "lon" => 0,
+            ],
+        ];
+
+        $obs = (object) [
+            "geometry" => (object) [
+                "coordinates" => [
+                    2, //lon
+                    2, //lat
+                ],
+            ],
+            "properties" => (object) [
+                "station" => "FAKE",
+            ],
+        ];
+
+        $expectedQuery =
+            "SELECT ST_DISTANCE_SPHERE(ST_GEOMFROMTEXT('POINT(2 2)'), ST_GEOMFROMTEXT('POINT(5 5)')) as distance, ST_WITHIN(ST_GEOMFROMTEXT('POINT(2 2)'), ST_GEOMFROMTEXT('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')) as within;";
+
+        $this->databaseMock
+            ->method("query")
+            ->will(
+                $this->returnValueMap([[$expectedQuery, [], [], $statement]]),
+            );
+
+        $expected = [
+            "distance" => 1,
+            "withinGridCell" => true,
+            "usesReferencePoint" => true,
+            "obsPoint" => [
+                "lat" => 2,
+                "lon" => 2,
+            ],
+            "obsStation" => "FAKE",
+            "stationIndex" => 0,
+        ];
+
+        $statement->method("fetch")->willReturn(
+            (object) [
+                "distance" => 1,
+                "within" => true,
+            ],
+        );
+
+        $actual = $this->weatherDataService->getObsDistanceInfo(
+            $referencePoint,
+            $obs,
+            $wfoGeometry,
+            0,
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/web/modules/weather_data/src/Service/Test/GetObsDistanceInfo.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetObsDistanceInfo.php.test
@@ -51,7 +51,10 @@ final class GetObsDistanceInfoTest extends Base
         ];
 
         $expectedQuery =
-            "SELECT ST_DISTANCE_SPHERE(ST_GEOMFROMTEXT('POINT(2 2)'), ST_GEOMFROMTEXT('POINT(5 5)')) as distance, ST_WITHIN(ST_GEOMFROMTEXT('POINT(2 2)'), ST_GEOMFROMTEXT('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')) as within;";
+            "SELECT ST_DISTANCE_SPHERE(ST_GEOMFROMTEXT('POINT(2 2)'), " .
+            "ST_GEOMFROMTEXT('POINT(5 5)')) as distance, ST_W" .
+            "ITHIN(ST_GEOMFROMTEXT('POINT(2 2)'), ST_GEOMFRO" .
+            "MTEXT('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')) as within;";
 
         $this->databaseMock
             ->method("query")
@@ -130,7 +133,10 @@ final class GetObsDistanceInfoTest extends Base
         ];
 
         $expectedQuery =
-            "SELECT ST_DISTANCE_SPHERE(ST_GEOMFROMTEXT('POINT(2 2)'), ST_GEOMFROMTEXT('POINT(0 0)')) as distance, ST_WITHIN(ST_GEOMFROMTEXT('POINT(2 2)'), ST_GEOMFROMTEXT('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')) as within;";
+            "SELECT ST_DISTANCE_SPHERE(ST_GEOMFROMTEXT('POINT(2 2)')" .
+            ", ST_GEOMFROMTEXT('POINT(0 0)')) as distance, " .
+            "ST_WITHIN(ST_GEOMFROMTEXT('POINT(2 2)'), ST_G" .
+            "EOMFROMTEXT('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')) as within;";
 
         $this->databaseMock
             ->method("query")

--- a/web/modules/weather_data/src/Service/Test/LogObservationDistanceInfo.php.test
+++ b/web/modules/weather_data/src/Service/Test/LogObservationDistanceInfo.php.test
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\weather_data\Service\Test;
+
+use GuzzleHttp\Promise\Promise;
+
+final class LogObservationDistanceInfoTest extends Base
+{
+    /**
+     * Ensure that logging obs data sends metrics
+     *
+     * We use a stubbed promise and ensure that
+     * we attempt to resolve it once.
+     */
+    public function testSendingMetric()
+    {
+        $obsDistanceInfo = [
+            "withinGridCell" => true,
+            "stationIndex" => 1,
+            "obsStation" => "FAKE",
+            "distance" => 1000,
+            "usesReferencePoint" => true,
+        ];
+
+        $mockPromise = $this->createMock(Promise::class);
+        $mockPromise
+            ->expects($this->once())
+            ->method("wait")
+            ->willReturn($mockPromise);
+
+        $this->newRelicMock->method("sendMetric")->willReturn($mockPromise);
+
+        $this->weatherDataService->logObservationDistanceInfo($obsDistanceInfo);
+    }
+}

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -89,7 +89,7 @@ class WeatherDataService
      */
     private $stashedAlerts;
 
-  /**
+    /**
      * NewRelic API handler
      */
     private $newRelic;
@@ -107,7 +107,6 @@ class WeatherDataService
      * @var stashedPoint
      */
     public $stashedPoint;
-
 
     /**
      * Constructor.

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -520,6 +520,51 @@ class WeatherDataService
     }
 
     /**
+     * Compute the distance between a source point and an obs station
+     *
+     * Returns the distance in meters
+     */
+    public function logObservationDistance($sourcePoint, $obs, $index = 0)
+    {
+        $logger = $this->getLogger("Weather.gov data service");
+        $serialized = [
+            "sourcePoint" => [
+                "lon" => $sourcePoint[0],
+                "lat" => $sourcePoint[1],
+            ],
+            "obsPoint" => [
+                "lon" => $obs->geometry->coordinates[0],
+                "lat" => $obs->geometry->coordinates[1],
+            ],
+            "obsStation" => $obs->properties->station,
+            "stationIndex" => $index,
+        ];
+
+        $sourceText =
+            'POINT("' . $sourcePoint[0] . " " . $sourcePoint[1] . '")';
+        $obsText =
+            'POINT("' .
+            $obs->geometry->coordinates[0] .
+            " " .
+            $obs->geometry->coordinates[1] .
+            '")';
+
+        $sql =
+            'SELECT ST_DISTANCE_SPHERE(GeomFromText("' .
+            $sourceText .
+            '"), GeomFromText("' .
+            $obsText .
+            '"))';
+
+        $result = $this->database->query($sql)->fetch();
+
+        $serialized["distance"] = $result;
+        $serialized = json_encode($serialized);
+
+        logger->notice("[OBSERVATION][" . $index . "]" . $serialized);
+    }
+
+    /**
      * Get a geometry from a WFO grid.
      *
      * @return stdClass

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -626,12 +626,7 @@ class WeatherDataService
             ],
         );
 
-        try {
-            $promise->wait();
-        } catch (Exception $e) {
-            $logger = $this->getLogger("NEWRELIC");
-            $logger->error($e->getMessage());
-        }
+        $promise->wait();
     }
 
     /**

--- a/web/modules/weather_data/weather_data.services.yml
+++ b/web/modules/weather_data/weather_data.services.yml
@@ -4,4 +4,7 @@ services:
     arguments: ['@entity_type.manager', '@string_translation', '@request_stack', '@cache.default']
   weather_data:
     class: Drupal\weather_data\Service\WeatherDataService
-    arguments: ['@http_client', '@string_translation', '@request_stack', '@cache.default', '@database']
+    arguments: ['@http_client', '@string_translation', '@request_stack', '@cache.default', '@database', '@newrelic_metrics']
+  newrelic_metrics:
+    class: Drupal\weather_data\Service\NewRelicMetrics
+    arguments: ['@http_client']

--- a/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
+++ b/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
@@ -54,6 +54,12 @@ final class LocationAndGridRouteController extends ControllerBase
     {
         $grid = $this->weatherData->getGridFromLatLon($lat, $lon);
 
+        // Stash the reference point in the data service
+        $this->weatherData->stashedPoint = (object) [
+            "lat" => $lat,
+            "lon" => $lon,
+        ];
+
         if ($grid == null) {
             // If we don't get a corresponding grid location, throw a 404.
             throw new NotFoundHttpException();

--- a/web/sites/default/settings.cloudgov.php
+++ b/web/sites/default/settings.cloudgov.php
@@ -40,12 +40,10 @@ foreach ($cf_service_data as $service_list) {
                 "sha256",
                 $service["credentials"]["hash_salt"],
             );
-            if (!empty($service["credentials"]["newrelic_license"])) {
-                $settings["new_relic_rpm.api_key"] = 
-                    $service["credentials"]["newrelic_license"];
-                $config["new_relic_rpm.settings"]["api_key"] = 
-                    $service["credentials"]["newrelic_license"];
-            };
+            $settings["new_relic_rpm.api_key"] = 
+                $service["credentials"]["newrelic_license"];
+            $config["new_relic_rpm.settings"]["api_key"] = 
+                $service["credentials"]["newrelic_license"];
         } elseif (stristr($service["name"], "storage")) {
             $config["s3fs.settings"]["access_key"] =
                 $service["credentials"]["access_key_id"];
@@ -107,5 +105,3 @@ switch ($application_environment) {
             "https://beta.weather.gov";
         break;
 }
-
-$settings["new_relic_rpm.api_key"] = "HELLO ERIC!";

--- a/web/sites/default/settings.cloudgov.php
+++ b/web/sites/default/settings.cloudgov.php
@@ -107,3 +107,6 @@ switch ($application_environment) {
             "https://beta.weather.gov";
         break;
 }
+
+// Add the application name so that it can be used in NewRelic reporting
+$settings["wx.application_name"] = $cf_application_data["application_name"];

--- a/web/sites/default/settings.cloudgov.php
+++ b/web/sites/default/settings.cloudgov.php
@@ -38,7 +38,7 @@ foreach ($cf_service_data as $service_list) {
         } elseif (stristr($service["name"], "secrets")) {
             $settings["hash_salt"] = hash(
                 "sha256",
-                $service["credentials"]["hash_salt"],
+                $service["credentials"]["HASH_SALT"],
             );
             if (!empty($service["credentials"]["NEWRELIC_LICENSE"])) {
                 $settings["new_relic_rpm.api_key"] = 

--- a/web/sites/default/settings.cloudgov.php
+++ b/web/sites/default/settings.cloudgov.php
@@ -40,10 +40,12 @@ foreach ($cf_service_data as $service_list) {
                 "sha256",
                 $service["credentials"]["hash_salt"],
             );
-            $settings["new_relic_rpm.api_key"] = 
-                $service["credentials"]["newrelic_license"];
-            $config["new_relic_rpm.settings"]["api_key"] = 
-                $service["credentials"]["newrelic_license"];
+            if (!empty($service["credentials"]["NEWRELIC_LICENSE"])) {
+                $settings["new_relic_rpm.api_key"] = 
+                    $service["credentials"]["NEWRELIC_LICENSE"];
+                $config["new_relic_rpm.settings"]["api_key"] = 
+                    $service["credentials"]["NEWRELIC_LICENSE"];
+            };
         } elseif (stristr($service["name"], "storage")) {
             $config["s3fs.settings"]["access_key"] =
                 $service["credentials"]["access_key_id"];

--- a/web/sites/default/settings.cloudgov.php
+++ b/web/sites/default/settings.cloudgov.php
@@ -107,3 +107,5 @@ switch ($application_environment) {
             "https://beta.weather.gov";
         break;
 }
+
+$settings["new_relic_rpm.api_key"] = "HELLO ERIC!";

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -761,6 +761,9 @@ $settings['file_scan_ignore_directories'] = [
   'bower_components',
 ];
 
+// Add the newrelic endpoint for the Metrics API
+$settings["new_relic_rpm.metrics.base_url"] = "https://metric-api.newrelic.com/metric/v1";
+
 // Pull in anything special for local developement
 if (file_exists(DRUPAL_ROOT . '/sites/settings.dev.php')) {
   include DRUPAL_ROOT . '/sites/settings.dev.php';


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR, in part, implements the logging features outlined in #765 . It also implements additional changes we determined were needed as we went along, in particular the use of NewRelic as the logging endpoint for these distance metrics.
  
To summarize the primary task in the ticket: we want to log the number of stations a user had to cycle through until getting to a "valid" observation station, and to also log the distance from the user to that valid observation station.

## What does the reviewer need to know? 🤔
### Distance calculation ###
Until we merge in the [point url PR](https://github.com/weather-gov/weather.gov/pull/769), we will not have a reliable point to measure from when getting the distance to the observation station. Instead, this PR implements a workaround: we take the WFO grid cell geometry, find the closest point in that geometry to the observation station, and then use the distance from that point.
  
Because an observation station could potentially be _inside_ of the WFO grid cell, we also include a boolean that tells us if the station is within its corresponding cell.
  
### NewRelic "Metric" integration ###
After some discussion, we decided to use the [NewRelic Metrics API](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api/) for recording these observation data.
  
To accomplish this, we've created a new class/service called `NewRelicMetrics` that is injected into the `WeatherDataService` as a dependency.
  
#### Guzzle and Async Requests ####
Our Drupal setup uses Guzzle as the HTTP client, and Guzzle has the ability to perform potentially non-blocking requests via its [async capabilities](https://docs.guzzlephp.org/en/stable/quickstart.html#async-requests) and the use of promises. We have implemented the `NewRelicMetrics` object in using these capabilities, in anticipation of future refactoring of all external service HTTP requests.
  
However, the current NewRelic calls are not _currently_ non-blocking -- we are explicitly calling a `wait()` method from within the `WeatherDataService`. In the future, we will want to use some kind of threaded queue object or pool to schedule all async requests. This call to `wait()` should be refactored at that point.
  
### "Stashed" weather data values ###
Because a single `WeatherDataService` instance is used per-request, we have added a property called `stashedGridGeometry` that does a sort of "cache" of any previously requested geometry values, since obtaining these values normally requires an extra API call. If the property is set, we simply use that value. If not, we fetch data for it.
