### PR TITLE
Show hourly (or six-hourly... whatevs) precipitation amounts

### DIFF
--- a/tests/api/data/testing/gridpoints/BMX/59,84.json
+++ b/tests/api/data/testing/gridpoints/BMX/59,84.json
@@ -38,663 +38,663 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T10:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +2 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +9 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +12 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +20 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +22 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +23 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT2H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +24 hours / PT2H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +31 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +42 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT2H",
+          "validTime": "date:now +43 hours / PT2H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +45 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
+          "validTime": "date:now +46 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
+          "validTime": "date:now +47 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
+          "validTime": "date:now +48 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
+          "validTime": "date:now +49 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT2H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +50 hours / PT2H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +64 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +65 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +67 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +68 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +70 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT3H",
-          "value": 11.111111111111111
+          "validTime": "date:now +75 hours / PT3H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +79 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +81 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +82 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT2H",
-          "value": 17.777777777777779
+          "validTime": "date:now +83 hours / PT2H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +87 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +89 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +91 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +93 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +94 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +95 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +96 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
+          "validTime": "date:now +97 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT2H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +98 hours / PT2H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +101 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +105 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +106 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT2H",
+          "validTime": "date:now +107 hours / PT2H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +114 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +115 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +116 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +117 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +118 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +119 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +120 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +129 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
+          "validTime": "date:now +130 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT2H",
-          "value": 21.111111111111111
+          "validTime": "date:now +131 hours / PT2H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +138 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +140 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT2H",
-          "value": 11.111111111111111
+          "validTime": "date:now +142 hours / PT2H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +145 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT2H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +146 hours / PT2H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +150 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +154 hours / PT1H",
           "value": 21.666666666666668
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
-          "value": 22.777777777777779
+          "validTime": "date:now +155 hours / PT2H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
+          "validTime": "date:now +159 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +161 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +162 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT2H",
-          "value": 16.111111111111111
+          "validTime": "date:now +163 hours / PT2H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT3H",
+          "validTime": "date:now +165 hours / PT3H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT2H",
+          "validTime": "date:now +168 hours / PT2H",
           "value": 15
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT2H",
+          "validTime": "date:now +170 hours / PT2H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +173 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +174 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +175 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +177 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +178 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT2H",
+          "validTime": "date:now +179 hours / PT2H",
           "value": 24.444444444444443
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
-          "value": 23.888888888888889
+          "validTime": "date:now +181 hours / PT1H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +182 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +183 hours / PT1H",
           "value": 21.666666666666668
         }
       ]
@@ -703,384 +703,384 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT2H",
+          "validTime": "date:now +4 hours / PT2H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +6 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +8 hours / PT1H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT3H",
+          "validTime": "date:now +9 hours / PT3H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT2H",
+          "validTime": "date:now +12 hours / PT2H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT2H",
+          "validTime": "date:now +18 hours / PT2H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT3H",
+          "validTime": "date:now +20 hours / PT3H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT3H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +23 hours / PT3H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT2H",
+          "validTime": "date:now +26 hours / PT2H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT2H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +34 hours / PT2H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT5H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +39 hours / PT5H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT6H",
+          "validTime": "date:now +44 hours / PT6H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT2H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +50 hours / PT2H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +52 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +53 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT2H",
+          "validTime": "date:now +54 hours / PT2H",
           "value": 10
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT3H",
+          "validTime": "date:now +56 hours / PT3H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT3H",
-          "value": 11.111111111111111
+          "validTime": "date:now +59 hours / PT3H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT2H",
+          "validTime": "date:now +62 hours / PT2H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT2H",
+          "validTime": "date:now +64 hours / PT2H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT2H",
+          "validTime": "date:now +67 hours / PT2H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT2H",
+          "validTime": "date:now +70 hours / PT2H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +75 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT2H",
+          "validTime": "date:now +76 hours / PT2H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +79 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +80 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +81 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
+          "validTime": "date:now +82 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +83 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +85 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +86 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT2H",
+          "validTime": "date:now +87 hours / PT2H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT2H",
+          "validTime": "date:now +89 hours / PT2H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT2H",
+          "validTime": "date:now +91 hours / PT2H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT2H",
+          "validTime": "date:now +93 hours / PT2H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT5H",
+          "validTime": "date:now +95 hours / PT5H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT2H",
+          "validTime": "date:now +103 hours / PT2H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT2H",
+          "validTime": "date:now +105 hours / PT2H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT3H",
+          "validTime": "date:now +107 hours / PT3H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT6H",
+          "validTime": "date:now +110 hours / PT6H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT2H",
+          "validTime": "date:now +116 hours / PT2H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT2H",
+          "validTime": "date:now +118 hours / PT2H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT2H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +120 hours / PT2H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT2H",
+          "validTime": "date:now +122 hours / PT2H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT2H",
+          "validTime": "date:now +127 hours / PT2H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT2H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +129 hours / PT2H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT3H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +131 hours / PT3H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT6H",
+          "validTime": "date:now +134 hours / PT6H",
           "value": 5
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT3H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +140 hours / PT3H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT3H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +143 hours / PT3H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT2H",
+          "validTime": "date:now +146 hours / PT2H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +149 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +150 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT2H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +151 hours / PT2H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT5H",
+          "validTime": "date:now +153 hours / PT5H",
           "value": 10
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT3H",
+          "validTime": "date:now +158 hours / PT3H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT3H",
-          "value": 11.111111111111111
+          "validTime": "date:now +161 hours / PT3H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT2H",
+          "validTime": "date:now +164 hours / PT2H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-27T07:00:00+00:00/PT2H",
+          "validTime": "date:now +166 hours / PT2H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT2H",
+          "validTime": "date:now +168 hours / PT2H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT2H",
+          "validTime": "date:now +170 hours / PT2H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT2H",
-          "value": 13.888888888888889
+          "validTime": "date:now +172 hours / PT2H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT8H",
+          "validTime": "date:now +174 hours / PT8H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT2H",
-          "value": 13.888888888888889
+          "validTime": "date:now +182 hours / PT2H",
+          "value": 13.88888888888889
         }
       ]
     },
@@ -1088,35 +1088,35 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT13H",
-          "value": 17.222222222222221
+          "validTime": "date:now +0 hours / PT13H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT13H",
-          "value": 21.111111111111111
+          "validTime": "date:now +24 hours / PT13H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT13H",
-          "value": 21.111111111111111
+          "validTime": "date:now +48 hours / PT13H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT13H",
-          "value": 17.777777777777779
+          "validTime": "date:now +72 hours / PT13H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT13H",
+          "validTime": "date:now +96 hours / PT13H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT13H",
-          "value": 21.111111111111111
+          "validTime": "date:now +120 hours / PT13H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT13H",
-          "value": 22.777777777777779
+          "validTime": "date:now +144 hours / PT13H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT13H",
+          "validTime": "date:now +168 hours / PT13H",
           "value": 24.444444444444443
         }
       ]
@@ -1125,39 +1125,39 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT6H",
+          "validTime": "date:now +0 hours / PT6H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT14H",
+          "validTime": "date:now +16 hours / PT14H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT14H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +40 hours / PT14H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT14H",
-          "value": 11.111111111111111
+          "validTime": "date:now +64 hours / PT14H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT14H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +88 hours / PT14H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT14H",
+          "validTime": "date:now +112 hours / PT14H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT14H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +136 hours / PT14H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT14H",
+          "validTime": "date:now +160 hours / PT14H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-28T01:00:00+00:00/PT14H",
+          "validTime": "date:now +184 hours / PT14H",
           "value": 15.555555555555555
         }
       ]
@@ -1166,671 +1166,671 @@
       "uom": "wmoUnit:percent",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-20T10:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 82
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 24
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 22
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 28
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 30
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT2H",
+          "validTime": "date:now +19 hours / PT2H",
           "value": 65
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT2H",
+          "validTime": "date:now +22 hours / PT2H",
           "value": 70
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT3H",
+          "validTime": "date:now +24 hours / PT3H",
           "value": 76
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
+          "validTime": "date:now +27 hours / PT2H",
           "value": 73
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 54
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 47
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT2H",
+          "validTime": "date:now +33 hours / PT2H",
           "value": 37
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT2H",
+          "validTime": "date:now +35 hours / PT2H",
           "value": 36
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 49
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +43 hours / PT1H",
           "value": 62
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
+          "validTime": "date:now +44 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +45 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
+          "validTime": "date:now +46 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
+          "validTime": "date:now +47 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
+          "validTime": "date:now +48 hours / PT1H",
           "value": 77
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
+          "validTime": "date:now +49 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
+          "validTime": "date:now +50 hours / PT1H",
           "value": 85
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
+          "validTime": "date:now +51 hours / PT1H",
           "value": 86
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 85
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 54
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 83
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +68 hours / PT1H",
           "value": 91
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 96
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 98
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 99
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT4H",
+          "validTime": "date:now +72 hours / PT4H",
           "value": 100
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": 98
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 95
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 86
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +79 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
+          "validTime": "date:now +82 hours / PT1H",
           "value": 49
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +83 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 46
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 49
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +89 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT2H",
+          "validTime": "date:now +91 hours / PT2H",
           "value": 64
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
+          "validTime": "date:now +94 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +95 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +96 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
+          "validTime": "date:now +97 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT2H",
+          "validTime": "date:now +98 hours / PT2H",
           "value": 79
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 77
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +106 hours / PT1H",
           "value": 35
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT2H",
+          "validTime": "date:now +107 hours / PT2H",
           "value": 33
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
+          "validTime": "date:now +109 hours / PT1H",
           "value": 36
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
+          "validTime": "date:now +111 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +114 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": 74
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +120 hours / PT1H",
           "value": 79
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 83
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 88
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 85
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 79
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +128 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +129 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
+          "validTime": "date:now +130 hours / PT1H",
           "value": 35
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT2H",
+          "validTime": "date:now +131 hours / PT2H",
           "value": 33
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 36
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 41
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 46
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 49
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
+          "validTime": "date:now +138 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +140 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT1H",
+          "validTime": "date:now +142 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
+          "validTime": "date:now +143 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 74
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +145 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
+          "validTime": "date:now +146 hours / PT1H",
           "value": 85
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
+          "validTime": "date:now +147 hours / PT1H",
           "value": 86
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 79
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
+          "validTime": "date:now +151 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +152 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +154 hours / PT1H",
           "value": 47
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
+          "validTime": "date:now +155 hours / PT2H",
           "value": 44
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
+          "validTime": "date:now +157 hours / PT1H",
           "value": 46
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
+          "validTime": "date:now +159 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
+          "validTime": "date:now +161 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +162 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
+          "validTime": "date:now +163 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
+          "validTime": "date:now +164 hours / PT1H",
           "value": 74
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT1H",
+          "validTime": "date:now +165 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-27T07:00:00+00:00/PT1H",
+          "validTime": "date:now +166 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT1H",
+          "validTime": "date:now +167 hours / PT1H",
           "value": 82
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT1H",
+          "validTime": "date:now +168 hours / PT1H",
           "value": 87
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": 88
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
+          "validTime": "date:now +170 hours / PT1H",
           "value": 92
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +171 hours / PT1H",
           "value": 93
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 92
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
+          "validTime": "date:now +173 hours / PT1H",
           "value": 88
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
+          "validTime": "date:now +175 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +178 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT2H",
+          "validTime": "date:now +179 hours / PT2H",
           "value": 54
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +182 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +183 hours / PT1H",
           "value": 61
         }
       ]
@@ -1839,663 +1839,663 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T10:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +2 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +9 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +12 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +20 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +22 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +23 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT2H",
+          "validTime": "date:now +24 hours / PT2H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT2H",
+          "validTime": "date:now +26 hours / PT2H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +31 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +42 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT2H",
+          "validTime": "date:now +43 hours / PT2H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +45 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
+          "validTime": "date:now +46 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
+          "validTime": "date:now +47 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
+          "validTime": "date:now +48 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +49 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
+          "validTime": "date:now +50 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +51 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +64 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +65 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +67 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +68 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +70 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT3H",
-          "value": 11.111111111111111
+          "validTime": "date:now +75 hours / PT3H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +79 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +81 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +82 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT2H",
-          "value": 17.777777777777779
+          "validTime": "date:now +83 hours / PT2H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +87 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +89 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +90 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +91 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +94 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +95 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +96 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
+          "validTime": "date:now +97 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT2H",
+          "validTime": "date:now +98 hours / PT2H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +105 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +106 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT2H",
+          "validTime": "date:now +107 hours / PT2H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +114 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +115 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +117 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +120 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +122 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +129 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
+          "validTime": "date:now +130 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT2H",
-          "value": 21.111111111111111
+          "validTime": "date:now +131 hours / PT2H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +138 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +140 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT2H",
-          "value": 11.111111111111111
+          "validTime": "date:now +142 hours / PT2H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +145 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT2H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +146 hours / PT2H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +150 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +154 hours / PT1H",
           "value": 21.666666666666668
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
-          "value": 22.777777777777779
+          "validTime": "date:now +155 hours / PT2H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
+          "validTime": "date:now +159 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +161 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +162 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT2H",
-          "value": 16.111111111111111
+          "validTime": "date:now +163 hours / PT2H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT3H",
+          "validTime": "date:now +165 hours / PT3H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT2H",
+          "validTime": "date:now +168 hours / PT2H",
           "value": 15
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT2H",
+          "validTime": "date:now +170 hours / PT2H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +173 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +174 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +175 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +177 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +178 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT2H",
+          "validTime": "date:now +179 hours / PT2H",
           "value": 24.444444444444443
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
-          "value": 23.888888888888889
+          "validTime": "date:now +181 hours / PT1H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +182 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +183 hours / PT1H",
           "value": 21.666666666666668
         }
       ]
@@ -2504,559 +2504,559 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-20T10:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +1 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +7 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT2H",
-          "value": 11.111111111111111
+          "validTime": "date:now +13 hours / PT2H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +15 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +17 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +20 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT2H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +22 hours / PT2H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT2H",
+          "validTime": "date:now +24 hours / PT2H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT4H",
-          "value": 16.111111111111111
+          "validTime": "date:now +33 hours / PT4H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT2H",
-          "value": 11.111111111111111
+          "validTime": "date:now +41 hours / PT2H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT3H",
+          "validTime": "date:now +43 hours / PT3H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
+          "validTime": "date:now +46 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +47 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT2H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +48 hours / PT2H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT2H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +50 hours / PT2H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT3H",
-          "value": 17.222222222222221
+          "validTime": "date:now +58 hours / PT3H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT3H",
+          "validTime": "date:now +64 hours / PT3H",
           "value": 15
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT2H",
+          "validTime": "date:now +67 hours / PT2H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT2H",
-          "value": 13.888888888888889
+          "validTime": "date:now +69 hours / PT2H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT3H",
-          "value": 11.111111111111111
+          "validTime": "date:now +75 hours / PT3H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +79 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +80 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT2H",
+          "validTime": "date:now +81 hours / PT2H",
           "value": 15
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +83 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +84 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +88 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +89 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +90 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT2H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +93 hours / PT2H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +95 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT2H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +96 hours / PT2H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT2H",
+          "validTime": "date:now +98 hours / PT2H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +106 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +107 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT1H",
+          "validTime": "date:now +108 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
+          "validTime": "date:now +109 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
+          "validTime": "date:now +111 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +112 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +113 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +114 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +115 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +116 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +118 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT2H",
+          "validTime": "date:now +120 hours / PT2H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +124 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +127 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +129 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT2H",
+          "validTime": "date:now +130 hours / PT2H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +134 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +137 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT2H",
+          "validTime": "date:now +138 hours / PT2H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT2H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +140 hours / PT2H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT3H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +142 hours / PT3H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +145 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT2H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +146 hours / PT2H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
+          "validTime": "date:now +151 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +152 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT2H",
-          "value": 18.888888888888889
+          "validTime": "date:now +154 hours / PT2H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT1H",
+          "validTime": "date:now +156 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +159 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT2H",
+          "validTime": "date:now +161 hours / PT2H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT9H",
-          "value": 13.888888888888889
+          "validTime": "date:now +163 hours / PT9H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
+          "validTime": "date:now +173 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +174 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +175 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +176 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT3H",
+          "validTime": "date:now +178 hours / PT3H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +182 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +183 hours / PT1H",
           "value": 18.333333333333332
         }
       ]
@@ -3065,63 +3065,63 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/P2DT12H",
+          "validTime": "date:now +0 hours / P2DT12H",
           "value": null
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/P2DT22H",
+          "validTime": "date:now +61 hours / P2DT22H",
           "value": null
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT2H",
-          "value": 21.111111111111111
+          "validTime": "date:now +131 hours / PT2H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT21H",
+          "validTime": "date:now +133 hours / PT21H",
           "value": null
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +154 hours / PT1H",
           "value": 21.666666666666668
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
-          "value": 22.777777777777779
+          "validTime": "date:now +155 hours / PT2H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT19H",
+          "validTime": "date:now +158 hours / PT19H",
           "value": null
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +177 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +178 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT2H",
+          "validTime": "date:now +179 hours / PT2H",
           "value": 24.444444444444443
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
-          "value": 23.888888888888889
+          "validTime": "date:now +181 hours / PT1H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +182 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +183 hours / PT1H",
           "value": 21.666666666666668
         }
       ]
@@ -3130,215 +3130,215 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T10:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +2 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT11H",
+          "validTime": "date:now +6 hours / PT11H",
           "value": null
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +20 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +22 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +23 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT2H",
+          "validTime": "date:now +24 hours / PT2H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT2H",
+          "validTime": "date:now +26 hours / PT2H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT19H",
+          "validTime": "date:now +30 hours / PT19H",
           "value": null
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +49 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
+          "validTime": "date:now +50 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +51 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/P1DT14H",
+          "validTime": "date:now +52 hours / P1DT14H",
           "value": null
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +90 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +91 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +94 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +95 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +96 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
+          "validTime": "date:now +97 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT2H",
+          "validTime": "date:now +98 hours / PT2H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT11H",
+          "validTime": "date:now +103 hours / PT11H",
           "value": null
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +114 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +115 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +117 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +120 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +122 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT19H",
+          "validTime": "date:now +126 hours / PT19H",
           "value": null
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +145 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT2H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +146 hours / PT2H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/P1DT11H",
+          "validTime": "date:now +149 hours / P1DT11H",
           "value": null
         }
       ]
@@ -3347,243 +3347,243 @@
       "uom": "wmoUnit:percent",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-20T10:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 46
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 51
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 54
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 34
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 24
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 17
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 11
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 8
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 7
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 8
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT3H",
+          "validTime": "date:now +14 hours / PT3H",
           "value": 12
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 11
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT4H",
+          "validTime": "date:now +19 hours / PT4H",
           "value": 8
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": 9
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT2H",
+          "validTime": "date:now +25 hours / PT2H",
           "value": 7
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
+          "validTime": "date:now +27 hours / PT2H",
           "value": 9
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 9
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 13
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 16
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +33 hours / PT1H",
           "value": 18
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 22
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 27
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 31
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 46
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT3H",
+          "validTime": "date:now +39 hours / PT3H",
           "value": 48
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT3H",
+          "validTime": "date:now +42 hours / PT3H",
           "value": 67
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT3H",
+          "validTime": "date:now +45 hours / PT3H",
           "value": 27
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT3H",
+          "validTime": "date:now +48 hours / PT3H",
           "value": 20
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT3H",
+          "validTime": "date:now +51 hours / PT3H",
           "value": 58
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT3H",
+          "validTime": "date:now +54 hours / PT3H",
           "value": 57
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT3H",
+          "validTime": "date:now +57 hours / PT3H",
           "value": 62
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT3H",
+          "validTime": "date:now +60 hours / PT3H",
           "value": 70
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT3H",
+          "validTime": "date:now +63 hours / PT3H",
           "value": 85
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT9H",
+          "validTime": "date:now +66 hours / PT9H",
           "value": 82
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +75 hours / PT6H",
           "value": 56
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT6H",
+          "validTime": "date:now +81 hours / PT6H",
           "value": 4
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +87 hours / PT6H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT12H",
+          "validTime": "date:now +93 hours / PT12H",
           "value": 2
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT6H",
+          "validTime": "date:now +105 hours / PT6H",
           "value": 6
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT6H",
+          "validTime": "date:now +111 hours / PT6H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT6H",
+          "validTime": "date:now +117 hours / PT6H",
           "value": 3
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT6H",
+          "validTime": "date:now +123 hours / PT6H",
           "value": 4
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT6H",
+          "validTime": "date:now +129 hours / PT6H",
           "value": 5
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT6H",
+          "validTime": "date:now +135 hours / PT6H",
           "value": 14
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT6H",
+          "validTime": "date:now +141 hours / PT6H",
           "value": 27
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT6H",
+          "validTime": "date:now +147 hours / PT6H",
           "value": 33
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT6H",
+          "validTime": "date:now +153 hours / PT6H",
           "value": 34
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT6H",
+          "validTime": "date:now +159 hours / PT6H",
           "value": 57
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT6H",
+          "validTime": "date:now +165 hours / PT6H",
           "value": 69
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT6H",
+          "validTime": "date:now +171 hours / PT6H",
           "value": 73
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +177 hours / PT6H",
           "value": 70
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT6H",
+          "validTime": "date:now +183 hours / PT6H",
           "value": 76
         },
         {
-          "validTime": "2024-02-28T06:00:00+00:00/PT6H",
+          "validTime": "date:now +189 hours / PT6H",
           "value": 0
         }
       ]
@@ -3592,315 +3592,315 @@
       "uom": "wmoUnit:degree_(angle)",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 200
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 100
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 150
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT2H",
+          "validTime": "date:now +4 hours / PT2H",
           "value": 140
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT2H",
+          "validTime": "date:now +8 hours / PT2H",
           "value": 240
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 260
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 350
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 120
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +19 hours / PT1H",
           "value": 130
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT3H",
+          "validTime": "date:now +20 hours / PT3H",
           "value": 140
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT2H",
+          "validTime": "date:now +23 hours / PT2H",
           "value": 130
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +25 hours / PT1H",
           "value": 120
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 130
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 120
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 130
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 140
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 150
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 170
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT5H",
+          "validTime": "date:now +33 hours / PT5H",
           "value": 180
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT6H",
+          "validTime": "date:now +38 hours / PT6H",
           "value": 170
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT8H",
+          "validTime": "date:now +44 hours / PT8H",
           "value": 180
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT3H",
+          "validTime": "date:now +53 hours / PT3H",
           "value": 200
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT9H",
+          "validTime": "date:now +56 hours / PT9H",
           "value": 210
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT2H",
+          "validTime": "date:now +65 hours / PT2H",
           "value": 220
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT2H",
+          "validTime": "date:now +68 hours / PT2H",
           "value": 240
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT2H",
+          "validTime": "date:now +75 hours / PT2H",
           "value": 320
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT3H",
+          "validTime": "date:now +77 hours / PT3H",
           "value": 330
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT3H",
+          "validTime": "date:now +80 hours / PT3H",
           "value": 320
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT6H",
+          "validTime": "date:now +83 hours / PT6H",
           "value": 310
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT3H",
+          "validTime": "date:now +89 hours / PT3H",
           "value": 320
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT3H",
+          "validTime": "date:now +92 hours / PT3H",
           "value": 310
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT3H",
+          "validTime": "date:now +95 hours / PT3H",
           "value": 300
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT3H",
+          "validTime": "date:now +101 hours / PT3H",
           "value": 300
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT9H",
+          "validTime": "date:now +104 hours / PT9H",
           "value": 310
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT3H",
+          "validTime": "date:now +113 hours / PT3H",
           "value": 320
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +120 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 210
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 180
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 170
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT2H",
+          "validTime": "date:now +126 hours / PT2H",
           "value": 200
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT3H",
+          "validTime": "date:now +128 hours / PT3H",
           "value": 210
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT3H",
+          "validTime": "date:now +131 hours / PT3H",
           "value": 220
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT5H",
+          "validTime": "date:now +135 hours / PT5H",
           "value": 200
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT9H",
+          "validTime": "date:now +140 hours / PT9H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT6H",
+          "validTime": "date:now +149 hours / PT6H",
           "value": 220
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
+          "validTime": "date:now +155 hours / PT2H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
+          "validTime": "date:now +157 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT5H",
+          "validTime": "date:now +159 hours / PT5H",
           "value": 180
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT6H",
+          "validTime": "date:now +164 hours / PT6H",
           "value": 190
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT3H",
+          "validTime": "date:now +170 hours / PT3H",
           "value": 180
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT9H",
+          "validTime": "date:now +173 hours / PT9H",
           "value": 190
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT2H",
+          "validTime": "date:now +182 hours / PT2H",
           "value": 180
         }
       ]
@@ -3909,344 +3909,344 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT3H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +3 hours / PT3H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT10H",
+          "validTime": "date:now +6 hours / PT10H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT6H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +18 hours / PT6H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT3H",
+          "validTime": "date:now +24 hours / PT3H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT3H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +27 hours / PT3H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT3H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +30 hours / PT3H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT2H",
+          "validTime": "date:now +33 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT3H",
+          "validTime": "date:now +35 hours / PT3H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +40 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +41 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +43 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT6H",
+          "validTime": "date:now +44 hours / PT6H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT3H",
-          "value": 24.076000000000001
+          "validTime": "date:now +50 hours / PT3H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +53 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +54 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +56 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT2H",
-          "value": 37.039999999999999
+          "validTime": "date:now +57 hours / PT2H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +59 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +61 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT2H",
-          "value": 29.632000000000001
+          "validTime": "date:now +62 hours / PT2H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT2H",
-          "value": 31.484000000000002
+          "validTime": "date:now +64 hours / PT2H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +66 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +70 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +71 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +72 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT6H",
+          "validTime": "date:now +73 hours / PT6H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +79 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT4H",
-          "value": 25.928000000000001
+          "validTime": "date:now +81 hours / PT4H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +85 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT2H",
+          "validTime": "date:now +87 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT2H",
+          "validTime": "date:now +89 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT2H",
+          "validTime": "date:now +91 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +93 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +94 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT5H",
+          "validTime": "date:now +96 hours / PT5H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +101 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +104 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +105 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT2H",
-          "value": 27.780000000000001
+          "validTime": "date:now +106 hours / PT2H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +108 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
+          "validTime": "date:now +111 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +113 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +114 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT2H",
+          "validTime": "date:now +115 hours / PT2H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT2H",
+          "validTime": "date:now +117 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT5H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +119 hours / PT5H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT6H",
+          "validTime": "date:now +128 hours / PT6H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT3H",
+          "validTime": "date:now +134 hours / PT3H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT6H",
+          "validTime": "date:now +137 hours / PT6H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT3H",
+          "validTime": "date:now +143 hours / PT3H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT6H",
-          "value": 16.667999999999999
+          "validTime": "date:now +146 hours / PT6H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT3H",
+          "validTime": "date:now +152 hours / PT3H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
+          "validTime": "date:now +155 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT2H",
+          "validTime": "date:now +157 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +159 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
+          "validTime": "date:now +161 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +162 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
+          "validTime": "date:now +163 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT3H",
-          "value": 24.076000000000001
+          "validTime": "date:now +164 hours / PT3H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT4H",
+          "validTime": "date:now +167 hours / PT4H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +171 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +172 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT2H",
-          "value": 27.780000000000001
+          "validTime": "date:now +174 hours / PT2H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT3H",
-          "value": 29.632000000000001
+          "validTime": "date:now +176 hours / PT3H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT3H",
-          "value": 31.484000000000002
+          "validTime": "date:now +179 hours / PT3H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT2H",
-          "value": 29.632000000000001
+          "validTime": "date:now +182 hours / PT2H",
+          "value": 29.632
         }
       ]
     },
@@ -4254,435 +4254,435 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT2H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +0 hours / PT2H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT5H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +6 hours / PT5H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT4H",
+          "validTime": "date:now +11 hours / PT4H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +15 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT6H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +16 hours / PT6H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT5H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +22 hours / PT5H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT4H",
+          "validTime": "date:now +31 hours / PT4H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT3H",
+          "validTime": "date:now +35 hours / PT3H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +40 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +41 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +42 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +43 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT7H",
-          "value": 33.335999999999999
+          "validTime": "date:now +44 hours / PT7H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +51 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT2H",
-          "value": 37.039999999999999
+          "validTime": "date:now +52 hours / PT2H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +56 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
-          "value": 55.560000000000002
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 55.56
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
-          "value": 53.707999999999998
+          "validTime": "date:now +58 hours / PT1H",
+          "value": 53.708
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +59 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT3H",
-          "value": 46.299999999999997
+          "validTime": "date:now +61 hours / PT3H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +64 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT2H",
-          "value": 50.003999999999998
+          "validTime": "date:now +65 hours / PT2H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +67 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +71 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +72 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT6H",
-          "value": 33.335999999999999
+          "validTime": "date:now +73 hours / PT6H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT2H",
-          "value": 35.188000000000002
+          "validTime": "date:now +79 hours / PT2H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +81 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT3H",
-          "value": 38.892000000000003
+          "validTime": "date:now +82 hours / PT3H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +85 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +86 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +87 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT2H",
-          "value": 31.484000000000002
+          "validTime": "date:now +89 hours / PT2H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +91 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +93 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +94 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +95 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +96 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT3H",
+          "validTime": "date:now +97 hours / PT3H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +103 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +104 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +106 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
+          "validTime": "date:now +107 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +108 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +110 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +112 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +113 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +114 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +116 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT5H",
-          "value": 14.816000000000001
+          "validTime": "date:now +118 hours / PT5H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +127 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT5H",
-          "value": 31.484000000000002
+          "validTime": "date:now +129 hours / PT5H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT6H",
-          "value": 29.632000000000001
+          "validTime": "date:now +134 hours / PT6H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT3H",
-          "value": 31.484000000000002
+          "validTime": "date:now +140 hours / PT3H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +143 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +144 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +145 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT3H",
-          "value": 24.076000000000001
+          "validTime": "date:now +146 hours / PT3H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT3H",
-          "value": 25.928000000000001
+          "validTime": "date:now +149 hours / PT3H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT2H",
-          "value": 27.780000000000001
+          "validTime": "date:now +152 hours / PT2H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +154 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
-          "value": 31.484000000000002
+          "validTime": "date:now +155 hours / PT2H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT2H",
-          "value": 29.632000000000001
+          "validTime": "date:now +157 hours / PT2H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT2H",
-          "value": 27.780000000000001
+          "validTime": "date:now +159 hours / PT2H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +161 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +162 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +163 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +164 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT2H",
-          "value": 37.039999999999999
+          "validTime": "date:now +165 hours / PT2H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT5H",
-          "value": 35.188000000000002
+          "validTime": "date:now +167 hours / PT5H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +172 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +173 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT2H",
-          "value": 42.595999999999997
+          "validTime": "date:now +175 hours / PT2H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +178 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT3H",
-          "value": 48.152000000000001
+          "validTime": "date:now +179 hours / PT3H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +182 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +183 hours / PT1H",
           "value": 44.448
         }
       ]
@@ -4690,7 +4690,7 @@
     "weather": {
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": [
             {
               "coverage": null,
@@ -4705,7 +4705,7 @@
           ]
         },
         {
-          "validTime": "2024-02-20T10:00:00+00:00/PT3H",
+          "validTime": "date:now +1 hours / PT3H",
           "value": [
             {
               "coverage": "widespread",
@@ -4720,7 +4720,7 @@
           ]
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": [
             {
               "coverage": "areas",
@@ -4735,7 +4735,7 @@
           ]
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/P2DT10H",
+          "validTime": "date:now +5 hours / P2DT10H",
           "value": [
             {
               "coverage": null,
@@ -4750,7 +4750,7 @@
           ]
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +63 hours / PT6H",
           "value": [
             {
               "coverage": "definite",
@@ -4775,7 +4775,7 @@
           ]
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +69 hours / PT6H",
           "value": [
             {
               "coverage": "likely",
@@ -4800,7 +4800,7 @@
           ]
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/P4DT12H",
+          "validTime": "date:now +75 hours / P4DT12H",
           "value": [
             {
               "coverage": null,
@@ -4815,7 +4815,7 @@
           ]
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT12H",
+          "validTime": "date:now +183 hours / PT12H",
           "value": [
             {
               "coverage": "chance",
@@ -4838,55 +4838,55 @@
       "uom": "wmoUnit:percent",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/P2DT3H",
+          "validTime": "date:now +0 hours / P2DT3H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
+          "validTime": "date:now +51 hours / PT6H",
           "value": 1
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +57 hours / PT6H",
           "value": 13
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +63 hours / PT6H",
           "value": 89
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +69 hours / PT6H",
           "value": 60
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +75 hours / PT6H",
           "value": 2
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/P2DT6H",
+          "validTime": "date:now +81 hours / P2DT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT6H",
+          "validTime": "date:now +135 hours / PT6H",
           "value": 1
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/P1D",
+          "validTime": "date:now +141 hours / P1D",
           "value": 2
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT6H",
+          "validTime": "date:now +165 hours / PT6H",
           "value": 6
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT6H",
+          "validTime": "date:now +171 hours / PT6H",
           "value": 7
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +177 hours / PT6H",
           "value": 12
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT12H",
+          "validTime": "date:now +183 hours / PT12H",
           "value": 29
         }
       ]
@@ -4895,135 +4895,135 @@
       "uom": "wmoUnit:mm",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT6H",
+          "validTime": "date:now +3 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +9 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
+          "validTime": "date:now +15 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT6H",
+          "validTime": "date:now +21 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +27 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +33 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +39 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT6H",
+          "validTime": "date:now +45 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
+          "validTime": "date:now +51 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +57 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +63 hours / PT6H",
           "value": 2.794
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +69 hours / PT6H",
           "value": 1.524
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +75 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT6H",
+          "validTime": "date:now +81 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +87 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT6H",
+          "validTime": "date:now +93 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT6H",
+          "validTime": "date:now +99 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT6H",
+          "validTime": "date:now +105 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT6H",
+          "validTime": "date:now +111 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT6H",
+          "validTime": "date:now +117 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT6H",
+          "validTime": "date:now +123 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT6H",
+          "validTime": "date:now +129 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT6H",
+          "validTime": "date:now +135 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT6H",
+          "validTime": "date:now +141 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT6H",
+          "validTime": "date:now +147 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT6H",
+          "validTime": "date:now +153 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT6H",
+          "validTime": "date:now +159 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT6H",
+          "validTime": "date:now +165 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT6H",
+          "validTime": "date:now +171 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +177 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT6H",
+          "validTime": "date:now +183 hours / PT6H",
           "value": 0.254
         },
         {
-          "validTime": "2024-02-28T06:00:00+00:00/PT6H",
+          "validTime": "date:now +189 hours / PT6H",
           "value": 0
         }
       ]
@@ -5032,127 +5032,127 @@
       "uom": "wmoUnit:mm",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT6H",
+          "validTime": "date:now +3 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +9 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
+          "validTime": "date:now +15 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT6H",
+          "validTime": "date:now +21 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +27 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +33 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +39 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT6H",
+          "validTime": "date:now +45 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
+          "validTime": "date:now +51 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +57 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +63 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +69 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +75 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT6H",
+          "validTime": "date:now +81 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +87 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT6H",
+          "validTime": "date:now +93 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT6H",
+          "validTime": "date:now +99 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT6H",
+          "validTime": "date:now +105 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT6H",
+          "validTime": "date:now +111 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT6H",
+          "validTime": "date:now +117 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT6H",
+          "validTime": "date:now +123 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT6H",
+          "validTime": "date:now +129 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT6H",
+          "validTime": "date:now +135 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT6H",
+          "validTime": "date:now +141 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT6H",
+          "validTime": "date:now +147 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT6H",
+          "validTime": "date:now +153 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT6H",
+          "validTime": "date:now +159 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT6H",
+          "validTime": "date:now +165 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT6H",
+          "validTime": "date:now +171 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +177 hours / PT6H",
           "value": 0
         }
       ]
@@ -5161,127 +5161,127 @@
       "uom": "wmoUnit:mm",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT6H",
+          "validTime": "date:now +3 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +9 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
+          "validTime": "date:now +15 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT6H",
+          "validTime": "date:now +21 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +27 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +33 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +39 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT6H",
+          "validTime": "date:now +45 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
+          "validTime": "date:now +51 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +57 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +63 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +69 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +75 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT6H",
+          "validTime": "date:now +81 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +87 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT6H",
+          "validTime": "date:now +93 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT6H",
+          "validTime": "date:now +99 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT6H",
+          "validTime": "date:now +105 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT6H",
+          "validTime": "date:now +111 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT6H",
+          "validTime": "date:now +117 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT6H",
+          "validTime": "date:now +123 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT6H",
+          "validTime": "date:now +129 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT6H",
+          "validTime": "date:now +135 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT6H",
+          "validTime": "date:now +141 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT6H",
+          "validTime": "date:now +147 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT6H",
+          "validTime": "date:now +153 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT6H",
+          "validTime": "date:now +159 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT6H",
+          "validTime": "date:now +165 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT6H",
+          "validTime": "date:now +171 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +177 hours / PT6H",
           "value": 0
         }
       ]
@@ -5293,7 +5293,7 @@
       "uom": "wmoUnit:m",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/P1DT15H",
+          "validTime": "date:now +0 hours / P1DT15H",
           "value": -30.48
         }
       ]
@@ -5302,8 +5302,8 @@
       "uom": "wmoUnit:m",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/P1DT15H",
-          "value": 16093.440000000001
+          "validTime": "date:now +0 hours / P1DT15H",
+          "value": 16093.44
         }
       ]
     },
@@ -5311,124 +5311,124 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT6H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +2 hours / PT6H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT6H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +8 hours / PT6H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT3H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +14 hours / PT3H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT6H",
+          "validTime": "date:now +17 hours / PT6H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT2H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +23 hours / PT2H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT2H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +25 hours / PT2H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT5H",
+          "validTime": "date:now +27 hours / PT5H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +34 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT2H",
+          "validTime": "date:now +36 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT3H",
+          "validTime": "date:now +38 hours / PT3H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT3H",
+          "validTime": "date:now +41 hours / PT3H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT6H",
+          "validTime": "date:now +44 hours / PT6H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +50 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +52 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +53 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +54 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT6H",
-          "value": 38.892000000000003
+          "validTime": "date:now +55 hours / PT6H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +61 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT3H",
-          "value": 31.484000000000002
+          "validTime": "date:now +63 hours / PT3H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +66 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +70 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +71 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT4H",
-          "value": 24.076000000000001
+          "validTime": "date:now +72 hours / PT4H",
+          "value": 24.076
         }
       ]
     },
@@ -5436,171 +5436,171 @@
       "uom": "wmoUnit:degree_(angle)",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T10:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 110
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 150
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT2H",
+          "validTime": "date:now +11 hours / PT2H",
           "value": 290
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 320
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 110
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +19 hours / PT1H",
           "value": 120
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
+          "validTime": "date:now +20 hours / PT1H",
           "value": 130
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT5H",
+          "validTime": "date:now +21 hours / PT5H",
           "value": 140
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT2H",
+          "validTime": "date:now +26 hours / PT2H",
           "value": 130
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 140
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 150
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 170
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 180
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT5H",
+          "validTime": "date:now +33 hours / PT5H",
           "value": 190
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT9H",
+          "validTime": "date:now +38 hours / PT9H",
           "value": 180
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT5H",
+          "validTime": "date:now +47 hours / PT5H",
           "value": 190
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT3H",
+          "validTime": "date:now +53 hours / PT3H",
           "value": 210
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT3H",
+          "validTime": "date:now +56 hours / PT3H",
           "value": 220
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT3H",
+          "validTime": "date:now +59 hours / PT3H",
           "value": 210
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT3H",
+          "validTime": "date:now +62 hours / PT3H",
           "value": 220
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT3H",
+          "validTime": "date:now +65 hours / PT3H",
           "value": 230
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT2H",
+          "validTime": "date:now +68 hours / PT2H",
           "value": 240
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT2H",
+          "validTime": "date:now +72 hours / PT2H",
           "value": 300
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 330
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 340
         }
       ]
@@ -5609,308 +5609,308 @@
       "uom": "wmoUnit:m",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 111.8616
         },
         {
-          "validTime": "2024-02-20T10:00:00+00:00/PT1H",
-          "value": 105.15600000000001
+          "validTime": "date:now +1 hours / PT1H",
+          "value": 105.156
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 100.8888
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
-          "value": 104.85120000000001
+          "validTime": "date:now +3 hours / PT1H",
+          "value": 104.8512
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
-          "value": 51.816000000000003
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 51.816
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
-          "value": 46.329599999999999
+          "validTime": "date:now +5 hours / PT1H",
+          "value": 46.3296
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 180.13679999999999
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 180.1368
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 599.54160000000002
+          "validTime": "date:now +7 hours / PT1H",
+          "value": 599.5416
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
-          "value": 1123.1880000000001
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 1123.188
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 1573.9872
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 1874.8248000000001
+          "validTime": "date:now +10 hours / PT1H",
+          "value": 1874.8248
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
-          "value": 2002.2311999999999
+          "validTime": "date:now +11 hours / PT1H",
+          "value": 2002.2312
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 1884.8832
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
-          "value": 1371.5999999999999
+          "validTime": "date:now +13 hours / PT1H",
+          "value": 1371.6
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
-          "value": 696.77279999999996
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 696.7728
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 142.0368
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 6.4008000000000003
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 6.4008
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
-          "value": 50.292000000000002
+          "validTime": "date:now +17 hours / PT1H",
+          "value": 50.292
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 142.6464
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
-          "value": 132.58799999999999
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 132.588
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
+          "validTime": "date:now +20 hours / PT1H",
           "value": 119.7864
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
-          "value": 109.11839999999999
+          "validTime": "date:now +21 hours / PT1H",
+          "value": 109.1184
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
-          "value": 104.85120000000001
+          "validTime": "date:now +22 hours / PT1H",
+          "value": 104.8512
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
-          "value": 103.63200000000001
+          "validTime": "date:now +23 hours / PT1H",
+          "value": 103.632
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
-          "value": 103.93680000000001
+          "validTime": "date:now +24 hours / PT1H",
+          "value": 103.9368
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
-          "value": 98.755200000000002
+          "validTime": "date:now +25 hours / PT1H",
+          "value": 98.7552
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
-          "value": 97.231200000000001
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 97.2312
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
-          "value": 104.85120000000001
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 104.8512
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 79.857600000000005
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 79.8576
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 90.220799999999997
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 90.2208
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 195.3768
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 501.70080000000002
+          "validTime": "date:now +31 hours / PT1H",
+          "value": 501.7008
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 872.03279999999995
+          "validTime": "date:now +32 hours / PT1H",
+          "value": 872.0328
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 1171.9559999999999
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 1171.956
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 1318.8696
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 1337.1576
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 1214.9328
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 897.33119999999997
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 897.3312
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 497.73840000000001
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 497.7384
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
-          "value": 173.12639999999999
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 173.1264
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 88.087199999999996
+          "validTime": "date:now +40 hours / PT1H",
+          "value": 88.0872
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 110.33759999999999
+          "validTime": "date:now +41 hours / PT1H",
+          "value": 110.3376
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 164.89680000000001
+          "validTime": "date:now +42 hours / PT1H",
+          "value": 164.8968
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
-          "value": 165.50640000000001
+          "validTime": "date:now +43 hours / PT1H",
+          "value": 165.5064
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
-          "value": 167.63999999999999
+          "validTime": "date:now +44 hours / PT1H",
+          "value": 167.64
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
-          "value": 170.99279999999999
+          "validTime": "date:now +45 hours / PT1H",
+          "value": 170.9928
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
-          "value": 175.25999999999999
+          "validTime": "date:now +46 hours / PT1H",
+          "value": 175.26
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
-          "value": 179.83199999999999
+          "validTime": "date:now +47 hours / PT1H",
+          "value": 179.832
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
+          "validTime": "date:now +48 hours / PT1H",
           "value": 184.0992
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
-          "value": 162.76320000000001
+          "validTime": "date:now +49 hours / PT1H",
+          "value": 162.7632
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
-          "value": 153.92400000000001
+          "validTime": "date:now +50 hours / PT1H",
+          "value": 153.924
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
+          "validTime": "date:now +51 hours / PT1H",
           "value": 191.1096
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
-          "value": 308.76240000000001
+          "validTime": "date:now +52 hours / PT1H",
+          "value": 308.7624
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 471.8304
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": 644.95680000000004
+          "validTime": "date:now +54 hours / PT1H",
+          "value": 644.9568
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
-          "value": 804.06240000000003
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 804.0624
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 951.5856
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 1068.0192
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 1191.1584
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 1254.252
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 1202.7408
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 944.2704
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 603.50400000000002
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 603.504
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
-          "value": 314.55360000000002
+          "validTime": "date:now +63 hours / PT1H",
+          "value": 314.5536
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 216.71279999999999
+          "validTime": "date:now +64 hours / PT1H",
+          "value": 216.7128
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
-          "value": 203.30160000000001
+          "validTime": "date:now +65 hours / PT1H",
+          "value": 203.3016
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
-          "value": 220.06559999999999
+          "validTime": "date:now +66 hours / PT1H",
+          "value": 220.0656
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 196.596
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +68 hours / PT1H",
           "value": 184.7088
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 191.1096
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 246.2784
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 303.88560000000001
+          "validTime": "date:now +71 hours / PT1H",
+          "value": 303.8856
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
-          "value": 318.82080000000002
+          "validTime": "date:now +72 hours / PT1H",
+          "value": 318.8208
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
-          "value": 267.61439999999999
+          "validTime": "date:now +73 hours / PT1H",
+          "value": 267.6144
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
-          "value": 357.22559999999999
+          "validTime": "date:now +74 hours / PT1H",
+          "value": 357.2256
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
-          "value": 461.16239999999999
+          "validTime": "date:now +75 hours / PT1H",
+          "value": 461.1624
         }
       ]
     },
@@ -5920,11 +5920,11 @@
     "lightningActivityLevel": {
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/P2DT15H",
+          "validTime": "date:now +0 hours / P2DT15H",
           "value": 1
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT12H",
+          "validTime": "date:now +63 hours / PT12H",
           "value": 2
         }
       ]
@@ -5933,288 +5933,288 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT14H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +3 hours / PT14H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT7H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +18 hours / PT7H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT4H",
+          "validTime": "date:now +25 hours / PT4H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT3H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +29 hours / PT3H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT4H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +32 hours / PT4H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT2H",
+          "validTime": "date:now +36 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT2H",
+          "validTime": "date:now +39 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +42 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +43 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT7H",
+          "validTime": "date:now +45 hours / PT7H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT2H",
+          "validTime": "date:now +52 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +56 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT2H",
-          "value": 29.632000000000001
+          "validTime": "date:now +57 hours / PT2H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +59 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +60 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT3H",
-          "value": 24.076000000000001
+          "validTime": "date:now +62 hours / PT3H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT4H",
-          "value": 25.928000000000001
+          "validTime": "date:now +65 hours / PT4H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT4H",
+          "validTime": "date:now +72 hours / PT4H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +76 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT2H",
+          "validTime": "date:now +78 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT6H",
+          "validTime": "date:now +80 hours / PT6H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT2H",
+          "validTime": "date:now +86 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT3H",
-          "value": 16.667999999999999
+          "validTime": "date:now +88 hours / PT3H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +91 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT2H",
+          "validTime": "date:now +93 hours / PT2H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT2H",
+          "validTime": "date:now +95 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT2H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +97 hours / PT2H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT3H",
+          "validTime": "date:now +99 hours / PT3H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +103 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT2H",
+          "validTime": "date:now +106 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT2H",
+          "validTime": "date:now +108 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +112 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT2H",
+          "validTime": "date:now +114 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT2H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +116 hours / PT2H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT6H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +118 hours / PT6H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +124 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +127 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT5H",
-          "value": 16.667999999999999
+          "validTime": "date:now +129 hours / PT5H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT3H",
-          "value": 14.816000000000001
+          "validTime": "date:now +134 hours / PT3H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT6H",
-          "value": 16.667999999999999
+          "validTime": "date:now +137 hours / PT6H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT3H",
-          "value": 14.816000000000001
+          "validTime": "date:now +143 hours / PT3H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT6H",
+          "validTime": "date:now +146 hours / PT6H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT3H",
-          "value": 14.816000000000001
+          "validTime": "date:now +152 hours / PT3H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +155 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +157 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT2H",
+          "validTime": "date:now +159 hours / PT2H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +161 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +162 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT8H",
+          "validTime": "date:now +164 hours / PT8H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT2H",
+          "validTime": "date:now +172 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT2H",
+          "validTime": "date:now +174 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT4H",
-          "value": 24.076000000000001
+          "validTime": "date:now +176 hours / PT4H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +180 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT3H",
-          "value": 24.076000000000001
+          "validTime": "date:now +181 hours / PT3H",
+          "value": 24.076
         }
       ]
     },
@@ -6222,307 +6222,307 @@
       "uom": "wmoUnit:degree_(angle)",
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 200
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 100
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 150
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT2H",
+          "validTime": "date:now +4 hours / PT2H",
           "value": 140
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT2H",
+          "validTime": "date:now +8 hours / PT2H",
           "value": 240
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 260
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 350
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 120
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +19 hours / PT1H",
           "value": 130
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT3H",
+          "validTime": "date:now +20 hours / PT3H",
           "value": 140
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT3H",
+          "validTime": "date:now +23 hours / PT3H",
           "value": 130
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT2H",
+          "validTime": "date:now +26 hours / PT2H",
           "value": 120
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 130
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 140
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 150
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 170
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT5H",
+          "validTime": "date:now +33 hours / PT5H",
           "value": 180
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT6H",
+          "validTime": "date:now +38 hours / PT6H",
           "value": 170
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT8H",
+          "validTime": "date:now +44 hours / PT8H",
           "value": 180
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT3H",
+          "validTime": "date:now +53 hours / PT3H",
           "value": 200
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT9H",
+          "validTime": "date:now +56 hours / PT9H",
           "value": 210
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT2H",
+          "validTime": "date:now +65 hours / PT2H",
           "value": 220
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT2H",
+          "validTime": "date:now +68 hours / PT2H",
           "value": 240
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT2H",
+          "validTime": "date:now +75 hours / PT2H",
           "value": 320
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT3H",
+          "validTime": "date:now +77 hours / PT3H",
           "value": 330
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT3H",
+          "validTime": "date:now +80 hours / PT3H",
           "value": 320
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT6H",
+          "validTime": "date:now +83 hours / PT6H",
           "value": 310
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT3H",
+          "validTime": "date:now +89 hours / PT3H",
           "value": 320
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT3H",
+          "validTime": "date:now +92 hours / PT3H",
           "value": 310
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT3H",
+          "validTime": "date:now +95 hours / PT3H",
           "value": 300
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT3H",
+          "validTime": "date:now +101 hours / PT3H",
           "value": 300
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT9H",
+          "validTime": "date:now +104 hours / PT9H",
           "value": 310
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT3H",
+          "validTime": "date:now +113 hours / PT3H",
           "value": 320
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +120 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 210
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 180
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 170
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT2H",
+          "validTime": "date:now +126 hours / PT2H",
           "value": 200
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT3H",
+          "validTime": "date:now +128 hours / PT3H",
           "value": 210
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT3H",
+          "validTime": "date:now +131 hours / PT3H",
           "value": 220
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT5H",
+          "validTime": "date:now +135 hours / PT5H",
           "value": 200
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT9H",
+          "validTime": "date:now +140 hours / PT9H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT6H",
+          "validTime": "date:now +149 hours / PT6H",
           "value": 220
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
+          "validTime": "date:now +155 hours / PT2H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
+          "validTime": "date:now +157 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT5H",
+          "validTime": "date:now +159 hours / PT5H",
           "value": 180
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT6H",
+          "validTime": "date:now +164 hours / PT6H",
           "value": 190
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT3H",
+          "validTime": "date:now +170 hours / PT3H",
           "value": 180
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT9H",
+          "validTime": "date:now +173 hours / PT9H",
           "value": 190
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT2H",
+          "validTime": "date:now +182 hours / PT2H",
           "value": 180
         }
       ]
@@ -6557,187 +6557,187 @@
     "dispersionIndex": {
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT8H",
+          "validTime": "date:now +0 hours / PT8H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 26
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 34
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 41
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 30
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 13
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 1
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT7H",
+          "validTime": "date:now +18 hours / PT7H",
           "value": 2
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT7H",
+          "validTime": "date:now +25 hours / PT7H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +33 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT2H",
+          "validTime": "date:now +35 hours / PT2H",
           "value": 60
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 46
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 24
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 9
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT2H",
+          "validTime": "date:now +40 hours / PT2H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT2H",
+          "validTime": "date:now +42 hours / PT2H",
           "value": 1
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT6H",
+          "validTime": "date:now +44 hours / PT6H",
           "value": 12
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT2H",
+          "validTime": "date:now +50 hours / PT2H",
           "value": 13
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 23
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 31
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 32
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 26
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 19
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 21
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +68 hours / PT1H",
           "value": 18
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 16
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 14
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT3H",
+          "validTime": "date:now +72 hours / PT3H",
           "value": 13
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 17
         }
       ]
@@ -6793,75 +6793,75 @@
     "lowVisibilityOccurrenceRiskIndex": {
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": 4
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT3H",
+          "validTime": "date:now +3 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT3H",
+          "validTime": "date:now +6 hours / PT3H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT3H",
+          "validTime": "date:now +9 hours / PT3H",
           "value": 1
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT6H",
+          "validTime": "date:now +12 hours / PT6H",
           "value": 2
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT6H",
+          "validTime": "date:now +18 hours / PT6H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT3H",
+          "validTime": "date:now +24 hours / PT3H",
           "value": 4
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT3H",
+          "validTime": "date:now +27 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT3H",
+          "validTime": "date:now +30 hours / PT3H",
           "value": 2
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +33 hours / PT6H",
           "value": 1
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT3H",
+          "validTime": "date:now +39 hours / PT3H",
           "value": 2
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT6H",
+          "validTime": "date:now +42 hours / PT6H",
           "value": 3
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT6H",
+          "validTime": "date:now +48 hours / PT6H",
           "value": 4
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT3H",
+          "validTime": "date:now +54 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +57 hours / PT6H",
           "value": 1
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT3H",
+          "validTime": "date:now +63 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT3H",
+          "validTime": "date:now +66 hours / PT3H",
           "value": 4
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +69 hours / PT6H",
           "value": 5
         }
       ]
@@ -6869,43 +6869,43 @@
     "stability": {
       "values": [
         {
-          "validTime": "2024-02-20T09:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 6
         },
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT11H",
+          "validTime": "date:now +2 hours / PT11H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT13H",
+          "validTime": "date:now +13 hours / PT13H",
           "value": 6
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT11H",
+          "validTime": "date:now +26 hours / PT11H",
           "value": 2
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT5H",
+          "validTime": "date:now +37 hours / PT5H",
           "value": 6
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT3H",
+          "validTime": "date:now +42 hours / PT3H",
           "value": 4
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT5H",
+          "validTime": "date:now +45 hours / PT5H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT3H",
+          "validTime": "date:now +50 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT21H",
+          "validTime": "date:now +53 hours / PT21H",
           "value": 4
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT2H",
+          "validTime": "date:now +74 hours / PT2H",
           "value": 3
         }
       ]

--- a/tests/api/data/testing/gridpoints/FGZ/74,89.json
+++ b/tests/api/data/testing/gridpoints/FGZ/74,89.json
@@ -38,591 +38,591 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +9 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +11 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT2H",
+          "validTime": "date:now +12 hours / PT2H",
           "value": 10
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT2H",
+          "validTime": "date:now +17 hours / PT2H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT2H",
+          "validTime": "date:now +19 hours / PT2H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT2H",
+          "validTime": "date:now +21 hours / PT2H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +23 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +24 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
+          "validTime": "date:now +25 hours / PT2H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT3H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +32 hours / PT3H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +40 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +43 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
+          "validTime": "date:now +44 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
+          "validTime": "date:now +45 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +46 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
+          "validTime": "date:now +47 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +48 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT3H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +49 hours / PT3H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +52 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +56 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT3H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +58 hours / PT3H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +61 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +63 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +65 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +66 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT2H",
+          "validTime": "date:now +68 hours / PT2H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +73 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +74 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +75 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +78 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +79 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +80 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
+          "validTime": "date:now +82 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT2H",
-          "value": 11.111111111111111
+          "validTime": "date:now +83 hours / PT2H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +86 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +87 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
+          "validTime": "date:now +89 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +94 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT3H",
+          "validTime": "date:now +95 hours / PT3H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT2H",
+          "validTime": "date:now +98 hours / PT2H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +100 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT4H",
+          "validTime": "date:now +105 hours / PT4H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +110 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +112 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +113 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +114 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT2H",
+          "validTime": "date:now +116 hours / PT2H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
+          "validTime": "date:now +120 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT3H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +121 hours / PT3H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
+          "validTime": "date:now +128 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT3H",
+          "validTime": "date:now +129 hours / PT3H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +134 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +137 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +138 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT2H",
+          "validTime": "date:now +140 hours / PT2H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +142 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +143 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +145 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
+          "validTime": "date:now +146 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +147 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +149 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT3H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +153 hours / PT3H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +156 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
+          "validTime": "date:now +157 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +158 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
+          "validTime": "date:now +159 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +161 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT4H",
+          "validTime": "date:now +162 hours / PT4H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +166 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
+          "validTime": "date:now +167 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
+          "validTime": "date:now +168 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT3H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +170 hours / PT3H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
+          "validTime": "date:now +173 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
+          "validTime": "date:now +175 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +176 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +177 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT2H",
+          "validTime": "date:now +178 hours / PT2H",
           "value": 5
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +180 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 3.3333333333333335
         }
       ]
@@ -631,347 +631,347 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +0 hours / PT2H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT3H",
+          "validTime": "date:now +2 hours / PT3H",
           "value": -5
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +5 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +7 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +8 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +10 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +11 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT3H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +12 hours / PT3H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT2H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +15 hours / PT2H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT2H",
+          "validTime": "date:now +17 hours / PT2H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +19 hours / PT1H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT7H",
-          "value": -7.7777777777777777
+          "validTime": "date:now +20 hours / PT7H",
+          "value": -7.777777777777778
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +27 hours / PT1H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +28 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +29 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +33 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT5H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +34 hours / PT5H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +40 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +43 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
+          "validTime": "date:now +44 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
+          "validTime": "date:now +45 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +46 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
+          "validTime": "date:now +47 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +48 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT3H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +49 hours / PT3H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +52 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT3H",
+          "validTime": "date:now +53 hours / PT3H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT2H",
+          "validTime": "date:now +56 hours / PT2H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT5H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +58 hours / PT5H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT2H",
+          "validTime": "date:now +63 hours / PT2H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +65 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +66 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT2H",
+          "validTime": "date:now +67 hours / PT2H",
           "value": -5
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT3H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +69 hours / PT3H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT4H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +72 hours / PT4H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +76 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT2H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +78 hours / PT2H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +81 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +82 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT3H",
+          "validTime": "date:now +83 hours / PT3H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT2H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +86 hours / PT2H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT2H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +88 hours / PT2H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT6H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +90 hours / PT6H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT3H",
+          "validTime": "date:now +96 hours / PT3H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +99 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +100 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT2H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +102 hours / PT2H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT2H",
+          "validTime": "date:now +104 hours / PT2H",
           "value": -5
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT2H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +106 hours / PT2H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +108 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT2H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +109 hours / PT2H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT9H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +111 hours / PT9H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT6H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +120 hours / PT6H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT3H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +126 hours / PT3H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT4H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +129 hours / PT4H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +133 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT2H",
+          "validTime": "date:now +134 hours / PT2H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT13H",
+          "validTime": "date:now +136 hours / PT13H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT2H",
+          "validTime": "date:now +149 hours / PT2H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT2H",
+          "validTime": "date:now +151 hours / PT2H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT5H",
+          "validTime": "date:now +153 hours / PT5H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT2H",
+          "validTime": "date:now +158 hours / PT2H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT2H",
+          "validTime": "date:now +160 hours / PT2H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT3H",
+          "validTime": "date:now +162 hours / PT3H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT2H",
+          "validTime": "date:now +165 hours / PT2H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT2H",
+          "validTime": "date:now +167 hours / PT2H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +170 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +171 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT2H",
+          "validTime": "date:now +172 hours / PT2H",
           "value": -5
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT2H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +174 hours / PT2H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +177 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +178 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT3H",
+          "validTime": "date:now +179 hours / PT3H",
           "value": -6.666666666666667
         }
       ]
@@ -980,36 +980,36 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT13H",
-          "value": 11.111111111111111
+          "validTime": "date:now +0 hours / PT13H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT13H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +24 hours / PT13H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT13H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +48 hours / PT13H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT13H",
-          "value": 11.111111111111111
+          "validTime": "date:now +72 hours / PT13H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT13H",
+          "validTime": "date:now +96 hours / PT13H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT13H",
+          "validTime": "date:now +120 hours / PT13H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT13H",
+          "validTime": "date:now +144 hours / PT13H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT13H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +168 hours / PT13H",
+          "value": 5.555555555555555
         }
       ]
     },
@@ -1017,40 +1017,40 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT5H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +0 hours / PT5H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT14H",
+          "validTime": "date:now +15 hours / PT14H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT14H",
+          "validTime": "date:now +39 hours / PT14H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT14H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +63 hours / PT14H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT14H",
+          "validTime": "date:now +87 hours / PT14H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT14H",
+          "validTime": "date:now +111 hours / PT14H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT14H",
+          "validTime": "date:now +135 hours / PT14H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT14H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +159 hours / PT14H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-28T02:00:00+00:00/PT14H",
-          "value": -8.3333333333333339
+          "validTime": "date:now +183 hours / PT14H",
+          "value": -8.333333333333334
         }
       ]
     },
@@ -1058,595 +1058,595 @@
       "uom": "wmoUnit:percent",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 85
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 88
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 47
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 36
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 32
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT2H",
+          "validTime": "date:now +12 hours / PT2H",
           "value": 33
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 48
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT3H",
+          "validTime": "date:now +17 hours / PT3H",
           "value": 52
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
+          "validTime": "date:now +20 hours / PT1H",
           "value": 49
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT2H",
+          "validTime": "date:now +21 hours / PT2H",
           "value": 51
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
+          "validTime": "date:now +25 hours / PT2H",
           "value": 60
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT2H",
+          "validTime": "date:now +30 hours / PT2H",
           "value": 64
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +33 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 82
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 89
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 97
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT13H",
+          "validTime": "date:now +40 hours / PT13H",
           "value": 100
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 91
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 47
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 74
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT2H",
+          "validTime": "date:now +66 hours / PT2H",
           "value": 75
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +68 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 77
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 83
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT2H",
+          "validTime": "date:now +74 hours / PT2H",
           "value": 87
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 54
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
+          "validTime": "date:now +79 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": 37
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
+          "validTime": "date:now +82 hours / PT1H",
           "value": 30
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
+          "validTime": "date:now +83 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 28
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 30
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 35
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
+          "validTime": "date:now +89 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT2H",
+          "validTime": "date:now +90 hours / PT2H",
           "value": 58
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
+          "validTime": "date:now +92 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT4H",
+          "validTime": "date:now +94 hours / PT4H",
           "value": 66
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 36
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 31
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT1H",
+          "validTime": "date:now +106 hours / PT1H",
           "value": 28
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
+          "validTime": "date:now +107 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +108 hours / PT1H",
           "value": 30
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
+          "validTime": "date:now +109 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
+          "validTime": "date:now +111 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
+          "validTime": "date:now +114 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 62
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
+          "validTime": "date:now +120 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 54
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 37
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
+          "validTime": "date:now +128 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT3H",
+          "validTime": "date:now +129 hours / PT3H",
           "value": 31
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +132 hours / PT1H",
           "value": 34
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 37
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": 62
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +138 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT1H",
+          "validTime": "date:now +140 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +142 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +143 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
+          "validTime": "date:now +145 hours / PT1H",
           "value": 85
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
+          "validTime": "date:now +146 hours / PT1H",
           "value": 89
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +147 hours / PT1H",
           "value": 90
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 88
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +151 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +152 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT2H",
+          "validTime": "date:now +154 hours / PT2H",
           "value": 55
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +156 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
+          "validTime": "date:now +157 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
+          "validTime": "date:now +159 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 85
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT2H",
+          "validTime": "date:now +161 hours / PT2H",
           "value": 89
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT4H",
+          "validTime": "date:now +163 hours / PT4H",
           "value": 88
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
+          "validTime": "date:now +167 hours / PT1H",
           "value": 91
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
+          "validTime": "date:now +168 hours / PT1H",
           "value": 94
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": 96
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT2H",
+          "validTime": "date:now +170 hours / PT2H",
           "value": 97
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 92
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
+          "validTime": "date:now +173 hours / PT1H",
           "value": 82
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
+          "validTime": "date:now +175 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": 54
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": 48
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT2H",
+          "validTime": "date:now +178 hours / PT2H",
           "value": 44
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 48
         }
       ]
@@ -1655,607 +1655,607 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +0 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +2 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +4 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +9 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +11 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT2H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +12 hours / PT2H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT2H",
+          "validTime": "date:now +17 hours / PT2H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT3H",
+          "validTime": "date:now +19 hours / PT3H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
+          "validTime": "date:now +22 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +25 hours / PT2H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": -7.7777777777777777
+          "validTime": "date:now +27 hours / PT1H",
+          "value": -7.777777777777778
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +28 hours / PT1H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +29 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT2H",
+          "validTime": "date:now +33 hours / PT2H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +39 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT2H",
+          "validTime": "date:now +40 hours / PT2H",
           "value": -5
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT3H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +42 hours / PT3H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +45 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +46 hours / PT1H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
-          "value": -8.3333333333333339
+          "validTime": "date:now +47 hours / PT1H",
+          "value": -8.333333333333334
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
+          "validTime": "date:now +48 hours / PT1H",
           "value": -10
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT2H",
+          "validTime": "date:now +49 hours / PT2H",
           "value": -10.555555555555555
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +51 hours / PT1H",
           "value": -10
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": -8.3333333333333339
+          "validTime": "date:now +52 hours / PT1H",
+          "value": -8.333333333333334
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +54 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT3H",
+          "validTime": "date:now +58 hours / PT3H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +66 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT2H",
+          "validTime": "date:now +67 hours / PT2H",
           "value": -5
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT2H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +69 hours / PT2H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +71 hours / PT1H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
-          "value": -7.7777777777777777
+          "validTime": "date:now +72 hours / PT1H",
+          "value": -7.777777777777778
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
-          "value": -8.3333333333333339
+          "validTime": "date:now +73 hours / PT1H",
+          "value": -8.333333333333334
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
-          "value": -8.8888888888888893
+          "validTime": "date:now +74 hours / PT1H",
+          "value": -8.88888888888889
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
-          "value": -8.3333333333333339
+          "validTime": "date:now +75 hours / PT1H",
+          "value": -8.333333333333334
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +77 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +78 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +79 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +81 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
+          "validTime": "date:now +82 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT2H",
-          "value": 11.111111111111111
+          "validTime": "date:now +83 hours / PT2H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +85 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
+          "validTime": "date:now +89 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +92 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +93 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +94 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT3H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +95 hours / PT3H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT2H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +98 hours / PT2H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +103 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT4H",
+          "validTime": "date:now +105 hours / PT4H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +113 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +114 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +120 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +122 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +124 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +125 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
+          "validTime": "date:now +128 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT3H",
+          "validTime": "date:now +129 hours / PT3H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +134 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +138 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT2H",
+          "validTime": "date:now +140 hours / PT2H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +142 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +143 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +144 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
+          "validTime": "date:now +145 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT3H",
-          "value": -7.7777777777777777
+          "validTime": "date:now +146 hours / PT3H",
+          "value": -7.777777777777778
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +149 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +151 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +152 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT3H",
+          "validTime": "date:now +153 hours / PT3H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +156 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +157 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +159 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +160 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +161 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
+          "validTime": "date:now +162 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT2H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +163 hours / PT2H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT2H",
-          "value": -7.7777777777777777
+          "validTime": "date:now +165 hours / PT2H",
+          "value": -7.777777777777778
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
-          "value": -8.8888888888888893
+          "validTime": "date:now +167 hours / PT1H",
+          "value": -8.88888888888889
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
-          "value": -9.4444444444444446
+          "validTime": "date:now +168 hours / PT1H",
+          "value": -9.444444444444445
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": -10.555555555555555
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
+          "validTime": "date:now +170 hours / PT1H",
           "value": -11.666666666666666
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
+          "validTime": "date:now +171 hours / PT1H",
           "value": -12.222222222222221
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": -11.666666666666666
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": -9.4444444444444446
+          "validTime": "date:now +173 hours / PT1H",
+          "value": -9.444444444444445
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +175 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT2H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +178 hours / PT2H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": -2.2222222222222223
         }
       ]
@@ -2267,7 +2267,7 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/P7DT14H",
+          "validTime": "date:now +0 hours / P7DT14H",
           "value": null
         }
       ]
@@ -2276,583 +2276,583 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +0 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +2 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +4 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +9 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": null
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT2H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +12 hours / PT2H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT2H",
+          "validTime": "date:now +17 hours / PT2H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT3H",
+          "validTime": "date:now +19 hours / PT3H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
+          "validTime": "date:now +22 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +25 hours / PT2H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": -7.7777777777777777
+          "validTime": "date:now +27 hours / PT1H",
+          "value": -7.777777777777778
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +28 hours / PT1H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +29 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT2H",
+          "validTime": "date:now +33 hours / PT2H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +39 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT2H",
+          "validTime": "date:now +40 hours / PT2H",
           "value": -5
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT3H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +42 hours / PT3H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +45 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +46 hours / PT1H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
-          "value": -8.3333333333333339
+          "validTime": "date:now +47 hours / PT1H",
+          "value": -8.333333333333334
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
+          "validTime": "date:now +48 hours / PT1H",
           "value": -10
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT2H",
+          "validTime": "date:now +49 hours / PT2H",
           "value": -10.555555555555555
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +51 hours / PT1H",
           "value": -10
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": -8.3333333333333339
+          "validTime": "date:now +52 hours / PT1H",
+          "value": -8.333333333333334
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +54 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT3H",
+          "validTime": "date:now +58 hours / PT3H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +66 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT2H",
+          "validTime": "date:now +67 hours / PT2H",
           "value": -5
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT2H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +69 hours / PT2H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +71 hours / PT1H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
-          "value": -7.7777777777777777
+          "validTime": "date:now +72 hours / PT1H",
+          "value": -7.777777777777778
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
-          "value": -8.3333333333333339
+          "validTime": "date:now +73 hours / PT1H",
+          "value": -8.333333333333334
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
-          "value": -8.8888888888888893
+          "validTime": "date:now +74 hours / PT1H",
+          "value": -8.88888888888889
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
-          "value": -8.3333333333333339
+          "validTime": "date:now +75 hours / PT1H",
+          "value": -8.333333333333334
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +77 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +78 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +79 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +81 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT3H",
+          "validTime": "date:now +82 hours / PT3H",
           "value": null
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +85 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
+          "validTime": "date:now +89 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +92 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +93 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +94 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT3H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +95 hours / PT3H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT2H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +98 hours / PT2H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +103 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT6H",
+          "validTime": "date:now +104 hours / PT6H",
           "value": null
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +113 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +114 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
-          "value": -4.4444444444444446
+          "validTime": "date:now +120 hours / PT1H",
+          "value": -4.444444444444445
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +122 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +124 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +125 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT5H",
+          "validTime": "date:now +128 hours / PT5H",
           "value": null
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +134 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +138 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": -2.7777777777777777
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT2H",
+          "validTime": "date:now +140 hours / PT2H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +142 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +143 hours / PT1H",
           "value": -5
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +144 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
+          "validTime": "date:now +145 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT3H",
-          "value": -7.7777777777777777
+          "validTime": "date:now +146 hours / PT3H",
+          "value": -7.777777777777778
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +149 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": -3.3333333333333335
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +151 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +152 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT3H",
+          "validTime": "date:now +153 hours / PT3H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +156 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +157 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": -1.6666666666666667
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +159 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
-          "value": -5.5555555555555554
+          "validTime": "date:now +160 hours / PT1H",
+          "value": -5.555555555555555
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
-          "value": -6.1111111111111107
+          "validTime": "date:now +161 hours / PT1H",
+          "value": -6.111111111111111
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
+          "validTime": "date:now +162 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT2H",
-          "value": -7.2222222222222223
+          "validTime": "date:now +163 hours / PT2H",
+          "value": -7.222222222222222
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT2H",
-          "value": -7.7777777777777777
+          "validTime": "date:now +165 hours / PT2H",
+          "value": -7.777777777777778
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
-          "value": -8.8888888888888893
+          "validTime": "date:now +167 hours / PT1H",
+          "value": -8.88888888888889
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
-          "value": -9.4444444444444446
+          "validTime": "date:now +168 hours / PT1H",
+          "value": -9.444444444444445
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": -10.555555555555555
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
+          "validTime": "date:now +170 hours / PT1H",
           "value": -11.666666666666666
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
+          "validTime": "date:now +171 hours / PT1H",
           "value": -12.222222222222221
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": -11.666666666666666
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": -9.4444444444444446
+          "validTime": "date:now +173 hours / PT1H",
+          "value": -9.444444444444445
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": -6.666666666666667
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": -3.8888888888888888
+          "validTime": "date:now +175 hours / PT1H",
+          "value": -3.888888888888889
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": -2.2222222222222223
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT2H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +178 hours / PT2H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": -1.1111111111111112
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": -2.2222222222222223
         }
       ]
@@ -2861,575 +2861,575 @@
       "uom": "wmoUnit:percent",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 79
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 77
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 79
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 51
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 36
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +19 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
+          "validTime": "date:now +20 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
+          "validTime": "date:now +22 hours / PT1H",
           "value": 88
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": 41
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +25 hours / PT6H",
           "value": 47
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +31 hours / PT6H",
           "value": 69
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT2H",
+          "validTime": "date:now +37 hours / PT2H",
           "value": 62
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT2H",
+          "validTime": "date:now +41 hours / PT2H",
           "value": 65
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +43 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
+          "validTime": "date:now +44 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
+          "validTime": "date:now +45 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
+          "validTime": "date:now +46 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT2H",
+          "validTime": "date:now +47 hours / PT2H",
           "value": 56
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
+          "validTime": "date:now +49 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT2H",
+          "validTime": "date:now +50 hours / PT2H",
           "value": 56
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 22
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 28
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT4H",
+          "validTime": "date:now +58 hours / PT4H",
           "value": 38
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 37
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 35
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 34
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 32
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 31
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +68 hours / PT1H",
           "value": 31
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 35
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT3H",
+          "validTime": "date:now +71 hours / PT3H",
           "value": 34
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": 48
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 36
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT4H",
+          "validTime": "date:now +79 hours / PT4H",
           "value": 31
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
+          "validTime": "date:now +83 hours / PT1H",
           "value": 30
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 28
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 27
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 32
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 37
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
+          "validTime": "date:now +89 hours / PT1H",
           "value": 47
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
+          "validTime": "date:now +92 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 62
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT4H",
+          "validTime": "date:now +94 hours / PT4H",
           "value": 65
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 62
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT1H",
+          "validTime": "date:now +106 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
+          "validTime": "date:now +107 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +108 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
+          "validTime": "date:now +109 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT2H",
+          "validTime": "date:now +110 hours / PT2H",
           "value": 73
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 74
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
+          "validTime": "date:now +114 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT4H",
+          "validTime": "date:now +118 hours / PT4H",
           "value": 75
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 83
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
+          "validTime": "date:now +128 hours / PT1H",
           "value": 74
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
+          "validTime": "date:now +129 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT1H",
+          "validTime": "date:now +130 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
+          "validTime": "date:now +131 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +132 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT2H",
+          "validTime": "date:now +138 hours / PT2H",
           "value": 60
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT1H",
+          "validTime": "date:now +140 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +142 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +143 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
+          "validTime": "date:now +145 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
+          "validTime": "date:now +146 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +147 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +151 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +152 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT4H",
+          "validTime": "date:now +154 hours / PT4H",
           "value": 65
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
+          "validTime": "date:now +159 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
+          "validTime": "date:now +161 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
+          "validTime": "date:now +162 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT1H",
+          "validTime": "date:now +163 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-27T07:00:00+00:00/PT1H",
+          "validTime": "date:now +164 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT1H",
+          "validTime": "date:now +165 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT1H",
+          "validTime": "date:now +166 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
+          "validTime": "date:now +167 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
+          "validTime": "date:now +168 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
+          "validTime": "date:now +170 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
+          "validTime": "date:now +171 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT2H",
+          "validTime": "date:now +173 hours / PT2H",
           "value": 58
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +175 hours / PT6H",
           "value": 59
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 27
         }
       ]
@@ -3438,243 +3438,243 @@
       "uom": "wmoUnit:degree_(angle)",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 260
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT2H",
+          "validTime": "date:now +2 hours / PT2H",
           "value": 250
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT9H",
+          "validTime": "date:now +6 hours / PT9H",
           "value": 220
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT4H",
+          "validTime": "date:now +15 hours / PT4H",
           "value": 230
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +19 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT2H",
+          "validTime": "date:now +20 hours / PT2H",
           "value": 230
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT9H",
+          "validTime": "date:now +22 hours / PT9H",
           "value": 220
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT4H",
+          "validTime": "date:now +31 hours / PT4H",
           "value": 230
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT6H",
+          "validTime": "date:now +35 hours / PT6H",
           "value": 240
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT4H",
+          "validTime": "date:now +41 hours / PT4H",
           "value": 250
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT2H",
+          "validTime": "date:now +45 hours / PT2H",
           "value": 260
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT2H",
+          "validTime": "date:now +47 hours / PT2H",
           "value": 270
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT2H",
+          "validTime": "date:now +49 hours / PT2H",
           "value": 280
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT2H",
+          "validTime": "date:now +51 hours / PT2H",
           "value": 290
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT3H",
+          "validTime": "date:now +55 hours / PT3H",
           "value": 320
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 330
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 350
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT3H",
+          "validTime": "date:now +61 hours / PT3H",
           "value": 20
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT8H",
+          "validTime": "date:now +64 hours / PT8H",
           "value": 30
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT3H",
+          "validTime": "date:now +72 hours / PT3H",
           "value": 40
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT2H",
+          "validTime": "date:now +76 hours / PT2H",
           "value": 60
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT2H",
+          "validTime": "date:now +79 hours / PT2H",
           "value": 80
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 90
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT2H",
+          "validTime": "date:now +82 hours / PT2H",
           "value": 100
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 90
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 100
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 90
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
+          "validTime": "date:now +89 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT2H",
+          "validTime": "date:now +92 hours / PT2H",
           "value": 30
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +94 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
+          "validTime": "date:now +95 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
+          "validTime": "date:now +96 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT1H",
+          "validTime": "date:now +97 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT3H",
+          "validTime": "date:now +101 hours / PT3H",
           "value": 230
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT15H",
+          "validTime": "date:now +106 hours / PT15H",
           "value": 220
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/P1DT2H",
+          "validTime": "date:now +121 hours / P1DT2H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT9H",
+          "validTime": "date:now +147 hours / PT9H",
           "value": 220
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT12H",
+          "validTime": "date:now +156 hours / PT12H",
           "value": 230
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT3H",
+          "validTime": "date:now +168 hours / PT3H",
           "value": 240
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT3H",
+          "validTime": "date:now +171 hours / PT3H",
           "value": 250
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT2H",
+          "validTime": "date:now +174 hours / PT2H",
           "value": 260
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT3H",
+          "validTime": "date:now +177 hours / PT3H",
           "value": 280
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT2H",
+          "validTime": "date:now +180 hours / PT2H",
           "value": 270
         }
       ]
@@ -3683,336 +3683,336 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +2 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT2H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +3 hours / PT2H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +8 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +10 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +12 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +15 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT4H",
+          "validTime": "date:now +17 hours / PT4H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT2H",
+          "validTime": "date:now +22 hours / PT2H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +24 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +25 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +31 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +32 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT2H",
-          "value": 27.780000000000001
+          "validTime": "date:now +34 hours / PT2H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +36 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +40 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT2H",
+          "validTime": "date:now +41 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +43 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT4H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +44 hours / PT4H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT6H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +48 hours / PT6H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT4H",
+          "validTime": "date:now +55 hours / PT4H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT3H",
-          "value": 14.816000000000001
+          "validTime": "date:now +59 hours / PT3H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT5H",
+          "validTime": "date:now +63 hours / PT5H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT8H",
+          "validTime": "date:now +69 hours / PT8H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +78 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +79 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT6H",
+          "validTime": "date:now +81 hours / PT6H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +87 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT8H",
-          "value": 14.816000000000001
+          "validTime": "date:now +88 hours / PT8H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT4H",
+          "validTime": "date:now +96 hours / PT4H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +101 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT2H",
+          "validTime": "date:now +102 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT2H",
+          "validTime": "date:now +105 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT3H",
-          "value": 24.076000000000001
+          "validTime": "date:now +107 hours / PT3H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT2H",
+          "validTime": "date:now +110 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT3H",
+          "validTime": "date:now +112 hours / PT3H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT6H",
+          "validTime": "date:now +115 hours / PT6H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT3H",
-          "value": 24.076000000000001
+          "validTime": "date:now +121 hours / PT3H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +124 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +127 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +128 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT3H",
-          "value": 35.188000000000002
+          "validTime": "date:now +130 hours / PT3H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT2H",
-          "value": 31.484000000000002
+          "validTime": "date:now +134 hours / PT2H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT2H",
-          "value": 29.632000000000001
+          "validTime": "date:now +136 hours / PT2H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT6H",
-          "value": 27.780000000000001
+          "validTime": "date:now +138 hours / PT6H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT4H",
-          "value": 25.928000000000001
+          "validTime": "date:now +144 hours / PT4H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +149 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +150 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT3H",
-          "value": 37.039999999999999
+          "validTime": "date:now +153 hours / PT3H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT3H",
-          "value": 35.188000000000002
+          "validTime": "date:now +156 hours / PT3H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +159 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT2H",
-          "value": 35.188000000000002
+          "validTime": "date:now +161 hours / PT2H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT5H",
-          "value": 37.039999999999999
+          "validTime": "date:now +163 hours / PT5H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT3H",
-          "value": 35.188000000000002
+          "validTime": "date:now +168 hours / PT3H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT6H",
-          "value": 33.335999999999999
+          "validTime": "date:now +171 hours / PT6H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT3H",
-          "value": 35.188000000000002
+          "validTime": "date:now +177 hours / PT3H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +180 hours / PT2H",
+          "value": 33.336
         }
       ]
     },
@@ -4020,439 +4020,439 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +0 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +3 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +5 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +7 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +9 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT2H",
-          "value": 38.892000000000003
+          "validTime": "date:now +12 hours / PT2H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +15 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT2H",
+          "validTime": "date:now +19 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +21 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +25 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT2H",
-          "value": 48.152000000000001
+          "validTime": "date:now +31 hours / PT2H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT3H",
+          "validTime": "date:now +34 hours / PT3H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +41 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +42 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +43 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT5H",
+          "validTime": "date:now +44 hours / PT5H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT3H",
+          "validTime": "date:now +49 hours / PT3H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +52 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +53 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT3H",
+          "validTime": "date:now +57 hours / PT3H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +64 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT11H",
-          "value": 14.816000000000001
+          "validTime": "date:now +65 hours / PT11H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +78 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +79 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +80 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT3H",
-          "value": 29.632000000000001
+          "validTime": "date:now +81 hours / PT3H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +84 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +85 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +86 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +87 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT7H",
+          "validTime": "date:now +89 hours / PT7H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT4H",
+          "validTime": "date:now +96 hours / PT4H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +101 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +103 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +104 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +105 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT2H",
-          "value": 37.039999999999999
+          "validTime": "date:now +106 hours / PT2H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +108 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT2H",
-          "value": 35.188000000000002
+          "validTime": "date:now +110 hours / PT2H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +112 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT6H",
-          "value": 29.632000000000001
+          "validTime": "date:now +113 hours / PT6H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT2H",
-          "value": 31.484000000000002
+          "validTime": "date:now +119 hours / PT2H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +121 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +127 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
-          "value": 53.707999999999998
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 53.708
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
-          "value": 55.560000000000002
+          "validTime": "date:now +129 hours / PT1H",
+          "value": 55.56
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT3H",
-          "value": 57.411999999999999
+          "validTime": "date:now +130 hours / PT3H",
+          "value": 57.412
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +134 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT6H",
-          "value": 42.595999999999997
+          "validTime": "date:now +135 hours / PT6H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT3H",
+          "validTime": "date:now +141 hours / PT3H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT4H",
-          "value": 38.892000000000003
+          "validTime": "date:now +144 hours / PT4H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +150 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT5H",
-          "value": 53.707999999999998
+          "validTime": "date:now +153 hours / PT5H",
+          "value": 53.708
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +158 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT3H",
-          "value": 50.003999999999998
+          "validTime": "date:now +159 hours / PT3H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +162 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT1H",
-          "value": 53.707999999999998
+          "validTime": "date:now +163 hours / PT1H",
+          "value": 53.708
         },
         {
-          "validTime": "2024-02-27T07:00:00+00:00/PT5H",
-          "value": 55.560000000000002
+          "validTime": "date:now +164 hours / PT5H",
+          "value": 55.56
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
-          "value": 53.707999999999998
+          "validTime": "date:now +169 hours / PT1H",
+          "value": 53.708
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT2H",
-          "value": 51.856000000000002
+          "validTime": "date:now +170 hours / PT2H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +172 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT3H",
-          "value": 48.152000000000001
+          "validTime": "date:now +173 hours / PT3H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +176 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +177 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT2H",
-          "value": 53.707999999999998
+          "validTime": "date:now +178 hours / PT2H",
+          "value": 53.708
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +180 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +181 hours / PT1H",
+          "value": 50.004
         }
       ]
     },
     "weather": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/P1DT1H",
+          "validTime": "date:now +0 hours / P1DT1H",
           "value": [
             {
               "coverage": null,
@@ -4467,7 +4467,7 @@
           ]
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +25 hours / PT6H",
           "value": [
             {
               "coverage": "chance",
@@ -4482,7 +4482,7 @@
           ]
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT2H",
+          "validTime": "date:now +31 hours / PT2H",
           "value": [
             {
               "coverage": "likely",
@@ -4497,7 +4497,7 @@
           ]
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT4H",
+          "validTime": "date:now +33 hours / PT4H",
           "value": [
             {
               "coverage": "likely",
@@ -4522,7 +4522,7 @@
           ]
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/P4D",
+          "validTime": "date:now +37 hours / P4D",
           "value": [
             {
               "coverage": null,
@@ -4537,7 +4537,7 @@
           ]
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT2H",
+          "validTime": "date:now +133 hours / PT2H",
           "value": [
             {
               "coverage": "slight_chance",
@@ -4552,65 +4552,10 @@
           ]
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT10H",
+          "validTime": "date:now +135 hours / PT10H",
           "value": [
             {
               "coverage": "slight_chance",
-              "weather": "rain_showers",
-              "intensity": "light",
-              "visibility": {
-                "unitCode": "wmoUnit:km",
-                "value": null
-              },
-              "attributes": []
-            },
-            {
-              "coverage": "slight_chance",
-              "weather": "snow_showers",
-              "intensity": "light",
-              "visibility": {
-                "unitCode": "wmoUnit:km",
-                "value": null
-              },
-              "attributes": []
-            }
-          ]
-        },
-        {
-          "validTime": "2024-02-26T12:00:00+00:00/PT6H",
-          "value": [
-            {
-              "coverage": "slight_chance",
-              "weather": "snow_showers",
-              "intensity": "light",
-              "visibility": {
-                "unitCode": "wmoUnit:km",
-                "value": null
-              },
-              "attributes": []
-            }
-          ]
-        },
-        {
-          "validTime": "2024-02-26T18:00:00+00:00/PT2H",
-          "value": [
-            {
-              "coverage": "chance",
-              "weather": "snow_showers",
-              "intensity": "light",
-              "visibility": {
-                "unitCode": "wmoUnit:km",
-                "value": null
-              },
-              "attributes": []
-            }
-          ]
-        },
-        {
-          "validTime": "2024-02-26T20:00:00+00:00/PT7H",
-          "value": [
-            {
-              "coverage": "chance",
               "weather": "rain_showers",
               "intensity": "light",
               "visibility": {
@@ -4620,7 +4565,7 @@
               "attributes": []
             },
             {
-              "coverage": "chance",
+              "coverage": "slight_chance",
               "weather": "snow_showers",
               "intensity": "light",
               "visibility": {
@@ -4632,7 +4577,22 @@
           ]
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT2H",
+          "validTime": "date:now +145 hours / PT6H",
+          "value": [
+            {
+              "coverage": "slight_chance",
+              "weather": "snow_showers",
+              "intensity": "light",
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "date:now +151 hours / PT2H",
           "value": [
             {
               "coverage": "chance",
@@ -4647,7 +4607,47 @@
           ]
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT7H",
+          "validTime": "date:now +153 hours / PT7H",
+          "value": [
+            {
+              "coverage": "chance",
+              "weather": "rain_showers",
+              "intensity": "light",
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            },
+            {
+              "coverage": "chance",
+              "weather": "snow_showers",
+              "intensity": "light",
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "date:now +160 hours / PT2H",
+          "value": [
+            {
+              "coverage": "chance",
+              "weather": "snow_showers",
+              "intensity": "light",
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "date:now +162 hours / PT7H",
           "value": [
             {
               "coverage": "chance",
@@ -4672,7 +4672,7 @@
           ]
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT2H",
+          "validTime": "date:now +169 hours / PT2H",
           "value": [
             {
               "coverage": "chance",
@@ -4687,7 +4687,7 @@
           ]
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT4H",
+          "validTime": "date:now +171 hours / PT4H",
           "value": [
             {
               "coverage": "chance",
@@ -4712,7 +4712,7 @@
           ]
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +175 hours / PT6H",
           "value": [
             {
               "coverage": "chance",
@@ -4727,7 +4727,7 @@
           ]
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": [
             {
               "coverage": "slight_chance",
@@ -4750,91 +4750,91 @@
       "uom": "wmoUnit:percent",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT6H",
+          "validTime": "date:now +1 hours / PT6H",
           "value": 1
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +7 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
+          "validTime": "date:now +13 hours / PT6H",
           "value": 2
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT6H",
+          "validTime": "date:now +19 hours / PT6H",
           "value": 1
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +25 hours / PT6H",
           "value": 28
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +31 hours / PT6H",
           "value": 56
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +37 hours / PT6H",
           "value": 10
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/P1DT18H",
+          "validTime": "date:now +43 hours / P1DT18H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +85 hours / PT6H",
           "value": 1
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/P1DT6H",
+          "validTime": "date:now +91 hours / P1DT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT6H",
+          "validTime": "date:now +121 hours / PT6H",
           "value": 2
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT6H",
+          "validTime": "date:now +127 hours / PT6H",
           "value": 6
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT6H",
+          "validTime": "date:now +133 hours / PT6H",
           "value": 16
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT6H",
+          "validTime": "date:now +139 hours / PT6H",
           "value": 20
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT6H",
+          "validTime": "date:now +145 hours / PT6H",
           "value": 21
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT6H",
+          "validTime": "date:now +151 hours / PT6H",
           "value": 39
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT6H",
+          "validTime": "date:now +157 hours / PT6H",
           "value": 47
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT6H",
+          "validTime": "date:now +163 hours / PT6H",
           "value": 37
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT6H",
+          "validTime": "date:now +169 hours / PT6H",
           "value": 41
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +175 hours / PT6H",
           "value": 42
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT6H",
+          "validTime": "date:now +181 hours / PT6H",
           "value": 16
         }
       ]
@@ -4843,131 +4843,131 @@
       "uom": "wmoUnit:mm",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT6H",
+          "validTime": "date:now +1 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +7 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
+          "validTime": "date:now +13 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT6H",
+          "validTime": "date:now +19 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +25 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +31 hours / PT6H",
           "value": 1.524
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +37 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT6H",
+          "validTime": "date:now +43 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
+          "validTime": "date:now +49 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +55 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +61 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +67 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +73 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT6H",
+          "validTime": "date:now +79 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +85 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT6H",
+          "validTime": "date:now +91 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT6H",
+          "validTime": "date:now +97 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT6H",
+          "validTime": "date:now +103 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT6H",
+          "validTime": "date:now +109 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT6H",
+          "validTime": "date:now +115 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT6H",
+          "validTime": "date:now +121 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT6H",
+          "validTime": "date:now +127 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT6H",
+          "validTime": "date:now +133 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT6H",
-          "value": 0.50800000000000001
+          "validTime": "date:now +139 hours / PT6H",
+          "value": 0.508
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT6H",
+          "validTime": "date:now +145 hours / PT6H",
           "value": 3.048
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT6H",
+          "validTime": "date:now +151 hours / PT6H",
           "value": 1.778
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT6H",
+          "validTime": "date:now +157 hours / PT6H",
           "value": 2.286
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT6H",
+          "validTime": "date:now +163 hours / PT6H",
           "value": 2.286
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT6H",
+          "validTime": "date:now +169 hours / PT6H",
           "value": 1.016
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
-          "value": 0.76200000000000001
+          "validTime": "date:now +175 hours / PT6H",
+          "value": 0.762
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT6H",
+          "validTime": "date:now +181 hours / PT6H",
           "value": 0
         }
       ]
@@ -4979,127 +4979,127 @@
       "uom": "wmoUnit:mm",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT6H",
+          "validTime": "date:now +1 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +7 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
+          "validTime": "date:now +13 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT6H",
+          "validTime": "date:now +19 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +25 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +31 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +37 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT6H",
+          "validTime": "date:now +43 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
+          "validTime": "date:now +49 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +55 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +61 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +67 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +73 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT6H",
+          "validTime": "date:now +79 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +85 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT6H",
+          "validTime": "date:now +91 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT6H",
+          "validTime": "date:now +97 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT6H",
+          "validTime": "date:now +103 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT6H",
+          "validTime": "date:now +109 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT6H",
+          "validTime": "date:now +115 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT6H",
+          "validTime": "date:now +121 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT6H",
+          "validTime": "date:now +127 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT6H",
+          "validTime": "date:now +133 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT6H",
+          "validTime": "date:now +139 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT6H",
-          "value": 12.699999999999999
+          "validTime": "date:now +145 hours / PT6H",
+          "value": 12.7
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT6H",
+          "validTime": "date:now +151 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT6H",
+          "validTime": "date:now +157 hours / PT6H",
           "value": 2.54
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT6H",
-          "value": 17.780000000000001
+          "validTime": "date:now +163 hours / PT6H",
+          "value": 17.78
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT6H",
+          "validTime": "date:now +169 hours / PT6H",
           "value": 10.16
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +175 hours / PT6H",
           "value": 0
         }
       ]
@@ -5108,724 +5108,724 @@
       "uom": "wmoUnit:m",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
-          "value": 2151.8879999999999
+          "validTime": "date:now +0 hours / PT1H",
+          "value": 2151.888
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
-          "value": 2143.9632000000001
+          "validTime": "date:now +1 hours / PT1H",
+          "value": 2143.9632
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 2119.884
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
-          "value": 2087.8800000000001
+          "validTime": "date:now +3 hours / PT1H",
+          "value": 2087.88
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 2072.0304000000001
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 2072.0304
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 2128.1136000000001
+          "validTime": "date:now +5 hours / PT1H",
+          "value": 2128.1136
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
-          "value": 2215.8960000000002
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 2215.896
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": 2280.2087999999999
+          "validTime": "date:now +7 hours / PT1H",
+          "value": 2280.2088
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 2303.9832000000001
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 2303.9832
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
-          "value": 2328.0623999999998
+          "validTime": "date:now +9 hours / PT1H",
+          "value": 2328.0624
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
-          "value": 2352.1415999999999
+          "validTime": "date:now +10 hours / PT1H",
+          "value": 2352.1416
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT2H",
-          "value": 2368.2959999999998
+          "validTime": "date:now +11 hours / PT2H",
+          "value": 2368.296
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
-          "value": 2328.3672000000001
+          "validTime": "date:now +13 hours / PT1H",
+          "value": 2328.3672
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 2240.2800000000002
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 2240.28
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
-          "value": 2136.0383999999999
+          "validTime": "date:now +15 hours / PT1H",
+          "value": 2136.0384
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 2088.1848
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
-          "value": 2064.1055999999999
+          "validTime": "date:now +17 hours / PT1H",
+          "value": 2064.1056
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 2023.8720000000001
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 2023.872
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +19 hours / PT1H",
           "value": 1984.248
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
-          "value": 1952.2439999999999
+          "validTime": "date:now +20 hours / PT1H",
+          "value": 1952.244
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 1936.0896
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
+          "validTime": "date:now +22 hours / PT1H",
           "value": 1928.1648
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 1920.24
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
-          "value": 1888.2360000000001
+          "validTime": "date:now +24 hours / PT1H",
+          "value": 1888.236
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
-          "value": 1848.0024000000001
+          "validTime": "date:now +25 hours / PT1H",
+          "value": 1848.0024
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 1808.0735999999999
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 1808.0736
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 1791.9192
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 1808.0735999999999
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 1808.0736
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 1840.0776000000001
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 1840.0776
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 1912.0103999999999
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 1912.0104
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 1991.8679999999999
+          "validTime": "date:now +31 hours / PT1H",
+          "value": 1991.868
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
-          "value": 2076.2975999999999
+          "validTime": "date:now +32 hours / PT1H",
+          "value": 2076.2976
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 2153.4119999999998
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 2153.412
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 2207.9712
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 2229.9168
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 2226.5639999999999
+          "validTime": "date:now +36 hours / PT1H",
+          "value": 2226.564
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 2207.9712
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 2185.4160000000002
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 2185.416
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 2154.0216
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 2119.884
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
-          "value": 2087.5752000000002
+          "validTime": "date:now +41 hours / PT1H",
+          "value": 2087.5752
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
-          "value": 2056.7903999999999
+          "validTime": "date:now +42 hours / PT1H",
+          "value": 2056.7904
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +43 hours / PT1H",
           "value": 2032.1016
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
-          "value": 2019.6048000000001
+          "validTime": "date:now +44 hours / PT1H",
+          "value": 2019.6048
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
-          "value": 2011.6800000000001
+          "validTime": "date:now +45 hours / PT1H",
+          "value": 2011.68
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
-          "value": 2000.0976000000001
+          "validTime": "date:now +46 hours / PT1H",
+          "value": 2000.0976
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
-          "value": 1974.1895999999999
+          "validTime": "date:now +47 hours / PT1H",
+          "value": 1974.1896
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
-          "value": 1944.9287999999999
+          "validTime": "date:now +48 hours / PT1H",
+          "value": 1944.9288
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
-          "value": 1919.9351999999999
+          "validTime": "date:now +49 hours / PT1H",
+          "value": 1919.9352
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +50 hours / PT1H",
           "value": 1899.5136
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
-          "value": 1889.4552000000001
+          "validTime": "date:now +51 hours / PT1H",
+          "value": 1889.4552
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 1895.856
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
-          "value": 1922.3735999999999
+          "validTime": "date:now +53 hours / PT1H",
+          "value": 1922.3736
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": 1965.0455999999999
+          "validTime": "date:now +54 hours / PT1H",
+          "value": 1965.0456
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
-          "value": 2015.9472000000001
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 2015.9472
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
-          "value": 2071.4207999999999
+          "validTime": "date:now +56 hours / PT1H",
+          "value": 2071.4208
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 2128.1136000000001
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 2128.1136
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 2175.9672
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
-          "value": 2214.9816000000001
+          "validTime": "date:now +59 hours / PT1H",
+          "value": 2214.9816
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 2238.4512
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
-          "value": 2239.9751999999999
+          "validTime": "date:now +61 hours / PT1H",
+          "value": 2239.9752
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 2214.3719999999998
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 2214.372
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 2169.8712
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 2119.884
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
-          "value": 2073.8591999999999
+          "validTime": "date:now +65 hours / PT1H",
+          "value": 2073.8592
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": 2031.1872000000001
+          "validTime": "date:now +66 hours / PT1H",
+          "value": 2031.1872
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
-          "value": 2000.0976000000001
+          "validTime": "date:now +67 hours / PT1H",
+          "value": 2000.0976
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 1992.7824000000001
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 1992.7824
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 1994.9159999999999
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 1994.916
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
-          "value": 1991.8679999999999
+          "validTime": "date:now +70 hours / PT1H",
+          "value": 1991.868
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 1965.96
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
-          "value": 1933.3463999999999
+          "validTime": "date:now +72 hours / PT1H",
+          "value": 1933.3464
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
-          "value": 1904.0856000000001
+          "validTime": "date:now +73 hours / PT1H",
+          "value": 1904.0856
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
-          "value": 1881.5304000000001
+          "validTime": "date:now +74 hours / PT1H",
+          "value": 1881.5304
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 1869.0336
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": 1872.0816
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
-          "value": 1893.7224000000001
+          "validTime": "date:now +77 hours / PT1H",
+          "value": 1893.7224
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
-          "value": 1930.9079999999999
+          "validTime": "date:now +78 hours / PT1H",
+          "value": 1930.908
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 1976.0183999999999
+          "validTime": "date:now +79 hours / PT1H",
+          "value": 1976.0184
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
-          "value": 2022.6528000000001
+          "validTime": "date:now +80 hours / PT1H",
+          "value": 2022.6528
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 2072.3352
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
+          "validTime": "date:now +82 hours / PT1H",
           "value": 2119.884
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
-          "value": 2167.7375999999999
+          "validTime": "date:now +83 hours / PT1H",
+          "value": 2167.7376
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
-          "value": 2207.6664000000001
+          "validTime": "date:now +84 hours / PT1H",
+          "value": 2207.6664
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT2H",
-          "value": 2232.0504000000001
+          "validTime": "date:now +85 hours / PT2H",
+          "value": 2232.0504
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
-          "value": 2217.4200000000001
+          "validTime": "date:now +87 hours / PT1H",
+          "value": 2217.42
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
-          "value": 2200.0464000000002
+          "validTime": "date:now +88 hours / PT1H",
+          "value": 2200.0464
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
-          "value": 2193.3407999999999
+          "validTime": "date:now +89 hours / PT1H",
+          "value": 2193.3408
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
-          "value": 2188.4639999999999
+          "validTime": "date:now +90 hours / PT1H",
+          "value": 2188.464
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
-          "value": 2183.8919999999998
+          "validTime": "date:now +91 hours / PT1H",
+          "value": 2183.892
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": 2178.1008000000002
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 2178.1008
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
-          "value": 2172.6143999999999
+          "validTime": "date:now +93 hours / PT1H",
+          "value": 2172.6144
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
-          "value": 2168.0423999999998
+          "validTime": "date:now +94 hours / PT1H",
+          "value": 2168.0424
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
-          "value": 2164.3847999999998
+          "validTime": "date:now +95 hours / PT1H",
+          "value": 2164.3848
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
-          "value": 2161.6415999999999
+          "validTime": "date:now +96 hours / PT1H",
+          "value": 2161.6416
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT1H",
-          "value": 2159.8128000000002
+          "validTime": "date:now +97 hours / PT1H",
+          "value": 2159.8128
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
-          "value": 2154.9360000000001
+          "validTime": "date:now +98 hours / PT1H",
+          "value": 2154.936
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
-          "value": 2153.1071999999999
+          "validTime": "date:now +99 hours / PT1H",
+          "value": 2153.1072
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 2159.8128000000002
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 2159.8128
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
-          "value": 2179.0151999999998
+          "validTime": "date:now +101 hours / PT1H",
+          "value": 2179.0152
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
-          "value": 2207.0567999999998
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 2207.0568
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
-          "value": 2239.9751999999999
+          "validTime": "date:now +103 hours / PT1H",
+          "value": 2239.9752
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 2275.0272
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
-          "value": 2310.9935999999998
+          "validTime": "date:now +105 hours / PT1H",
+          "value": 2310.9936
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT1H",
-          "value": 2343.9119999999998
+          "validTime": "date:now +106 hours / PT1H",
+          "value": 2343.912
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
-          "value": 2375.3063999999999
+          "validTime": "date:now +107 hours / PT1H",
+          "value": 2375.3064
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
-          "value": 2398.7759999999998
+          "validTime": "date:now +108 hours / PT1H",
+          "value": 2398.776
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 2407.9200000000001
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 2407.92
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
-          "value": 2396.3375999999998
+          "validTime": "date:now +110 hours / PT1H",
+          "value": 2396.3376
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 2371.6487999999999
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 2371.6488
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
-          "value": 2343.9119999999998
+          "validTime": "date:now +112 hours / PT1H",
+          "value": 2343.912
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
-          "value": 2324.7096000000001
+          "validTime": "date:now +113 hours / PT1H",
+          "value": 2324.7096
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
-          "value": 2306.4216000000001
+          "validTime": "date:now +114 hours / PT1H",
+          "value": 2306.4216
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
-          "value": 2288.1336000000001
+          "validTime": "date:now +115 hours / PT1H",
+          "value": 2288.1336
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
-          "value": 2269.5408000000002
+          "validTime": "date:now +116 hours / PT1H",
+          "value": 2269.5408
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 2250.6432
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
-          "value": 2232.0504000000001
+          "validTime": "date:now +118 hours / PT1H",
+          "value": 2232.0504
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
-          "value": 2210.7143999999998
+          "validTime": "date:now +119 hours / PT1H",
+          "value": 2210.7144
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
-          "value": 2190.9023999999999
+          "validTime": "date:now +120 hours / PT1H",
+          "value": 2190.9024
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 2175.9672
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
-          "value": 2164.3847999999998
+          "validTime": "date:now +122 hours / PT1H",
+          "value": 2164.3848
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 2160.4223999999999
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 2160.4224
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": 2168.0423999999998
+          "validTime": "date:now +124 hours / PT1H",
+          "value": 2168.0424
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 2190.2928000000002
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 2190.2928
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 2221.9920000000002
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 2221.992
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
-          "value": 2255.8247999999999
+          "validTime": "date:now +127 hours / PT1H",
+          "value": 2255.8248
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
-          "value": 2285.3904000000002
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 2285.3904
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
+          "validTime": "date:now +129 hours / PT1H",
           "value": 2312.8224
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT1H",
+          "validTime": "date:now +130 hours / PT1H",
           "value": 2335.9872
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
+          "validTime": "date:now +131 hours / PT1H",
           "value": 2356.7136
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 2371.0392000000002
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 2371.0392
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 2375.9160000000002
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 2375.916
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
-          "value": 2369.8200000000002
+          "validTime": "date:now +134 hours / PT1H",
+          "value": 2369.82
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
-          "value": 2354.8847999999998
+          "validTime": "date:now +135 hours / PT1H",
+          "value": 2354.8848
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 2335.9872
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
-          "value": 2319.5279999999998
+          "validTime": "date:now +137 hours / PT1H",
+          "value": 2319.528
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +138 hours / PT1H",
           "value": 2300.6304
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 2279.904
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT1H",
-          "value": 2257.6536000000001
+          "validTime": "date:now +140 hours / PT1H",
+          "value": 2257.6536
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 2233.5744
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +142 hours / PT1H",
           "value": 2207.9712
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
-          "value": 2179.9295999999999
+          "validTime": "date:now +143 hours / PT1H",
+          "value": 2179.9296
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
-          "value": 2151.8879999999999
+          "validTime": "date:now +144 hours / PT1H",
+          "value": 2151.888
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
-          "value": 2128.1136000000001
+          "validTime": "date:now +145 hours / PT1H",
+          "value": 2128.1136
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
-          "value": 2107.9967999999999
+          "validTime": "date:now +146 hours / PT1H",
+          "value": 2107.9968
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
-          "value": 2093.9760000000001
+          "validTime": "date:now +147 hours / PT1H",
+          "value": 2093.976
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
-          "value": 2087.8800000000001
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 2087.88
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 2090.0136000000002
+          "validTime": "date:now +149 hours / PT1H",
+          "value": 2090.0136
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 2099.1576
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
-          "value": 2111.9591999999998
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 2111.9592
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 2125.3703999999998
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 2125.3704
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
-          "value": 2139.6959999999999
+          "validTime": "date:now +153 hours / PT1H",
+          "value": 2139.696
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT1H",
-          "value": 2151.8879999999999
+          "validTime": "date:now +154 hours / PT1H",
+          "value": 2151.888
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
+          "validTime": "date:now +155 hours / PT1H",
           "value": 2162.556
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
-          "value": 2168.9567999999999
+          "validTime": "date:now +156 hours / PT1H",
+          "value": 2168.9568
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
-          "value": 2168.0423999999998
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 2168.0424
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
-          "value": 2158.2887999999998
+          "validTime": "date:now +158 hours / PT1H",
+          "value": 2158.2888
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
-          "value": 2141.2199999999998
+          "validTime": "date:now +159 hours / PT1H",
+          "value": 2141.22
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 2119.884
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
+          "validTime": "date:now +161 hours / PT1H",
           "value": 2100.3768
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
-          "value": 2076.9072000000001
+          "validTime": "date:now +162 hours / PT1H",
+          "value": 2076.9072
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT1H",
+          "validTime": "date:now +163 hours / PT1H",
           "value": 2047.9512
         },
         {
-          "validTime": "2024-02-27T07:00:00+00:00/PT1H",
-          "value": 2012.2896000000001
+          "validTime": "date:now +164 hours / PT1H",
+          "value": 2012.2896
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT1H",
-          "value": 1971.1415999999999
+          "validTime": "date:now +165 hours / PT1H",
+          "value": 1971.1416
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT1H",
-          "value": 1927.8599999999999
+          "validTime": "date:now +166 hours / PT1H",
+          "value": 1927.86
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
-          "value": 1885.7976000000001
+          "validTime": "date:now +167 hours / PT1H",
+          "value": 1885.7976
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
+          "validTime": "date:now +168 hours / PT1H",
           "value": 1842.8208
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
-          "value": 1799.8440000000001
+          "validTime": "date:now +169 hours / PT1H",
+          "value": 1799.844
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
-          "value": 1750.1615999999999
+          "validTime": "date:now +170 hours / PT1H",
+          "value": 1750.1616
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
-          "value": 1704.4416000000001
+          "validTime": "date:now +171 hours / PT1H",
+          "value": 1704.4416
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 1671.828
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": 1660.5504000000001
+          "validTime": "date:now +173 hours / PT1H",
+          "value": 1660.5504
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": 1663.2936
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": 1672.1328000000001
+          "validTime": "date:now +175 hours / PT1H",
+          "value": 1672.1328
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
-          "value": 1679.4480000000001
+          "validTime": "date:now +176 hours / PT1H",
+          "value": 1679.448
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
-          "value": 1688.5920000000001
+          "validTime": "date:now +177 hours / PT1H",
+          "value": 1688.592
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT1H",
-          "value": 1695.9072000000001
+          "validTime": "date:now +178 hours / PT1H",
+          "value": 1695.9072
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
+          "validTime": "date:now +179 hours / PT1H",
           "value": 1698.0408
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 1697.7360000000001
+          "validTime": "date:now +180 hours / PT1H",
+          "value": 1697.736
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
-          "value": 1695.9072000000001
+          "validTime": "date:now +181 hours / PT1H",
+          "value": 1695.9072
         }
       ]
     },
@@ -5833,79 +5833,79 @@
       "uom": "wmoUnit:m",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT4H",
-          "value": 60.960000000000001
+          "validTime": "date:now +0 hours / PT4H",
+          "value": 60.96
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT8H",
-          "value": 76.200000000000003
+          "validTime": "date:now +4 hours / PT8H",
+          "value": 76.2
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
-          "value": 60.960000000000001
+          "validTime": "date:now +12 hours / PT1H",
+          "value": 60.96
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
-          "value": 76.200000000000003
+          "validTime": "date:now +13 hours / PT1H",
+          "value": 76.2
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT11H",
-          "value": 60.960000000000001
+          "validTime": "date:now +14 hours / PT11H",
+          "value": 60.96
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT5H",
+          "validTime": "date:now +25 hours / PT5H",
           "value": 30.48
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 24.384
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 18.288
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 15.24
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT2H",
+          "validTime": "date:now +33 hours / PT2H",
           "value": 12.192
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 9.1440000000000001
+          "validTime": "date:now +35 hours / PT1H",
+          "value": 9.144
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 6.0960000000000001
+          "validTime": "date:now +36 hours / PT1H",
+          "value": 6.096
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
-          "value": 4.5720000000000001
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 4.572
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT2H",
-          "value": 2.1335999999999999
+          "validTime": "date:now +38 hours / PT2H",
+          "value": 2.1336
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 3.048
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
-          "value": 9.1440000000000001
+          "validTime": "date:now +41 hours / PT1H",
+          "value": 9.144
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": 15.24
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
-          "value": 21.335999999999999
+          "validTime": "date:now +43 hours / PT1H",
+          "value": 21.336
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT3H",
+          "validTime": "date:now +44 hours / PT3H",
           "value": 24.384
         }
       ]
@@ -5917,428 +5917,428 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +3 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +7 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +9 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +10 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT2H",
-          "value": 35.188000000000002
+          "validTime": "date:now +11 hours / PT2H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +13 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +16 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT5H",
+          "validTime": "date:now +18 hours / PT5H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +23 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +25 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT2H",
+          "validTime": "date:now +26 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +32 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT2H",
-          "value": 35.188000000000002
+          "validTime": "date:now +34 hours / PT2H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +36 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +40 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT2H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +43 hours / PT2H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT3H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +45 hours / PT3H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT10H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +48 hours / PT10H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +58 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT2H",
+          "validTime": "date:now +59 hours / PT2H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +61 hours / PT1H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +63 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT10H",
+          "validTime": "date:now +64 hours / PT10H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +75 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +77 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
+          "validTime": "date:now +79 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT3H",
+          "validTime": "date:now +80 hours / PT3H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT3H",
-          "value": 16.667999999999999
+          "validTime": "date:now +83 hours / PT3H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT9H",
-          "value": 14.816000000000001
+          "validTime": "date:now +86 hours / PT9H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT3H",
+          "validTime": "date:now +95 hours / PT3H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +98 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT2H",
+          "validTime": "date:now +101 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT3H",
+          "validTime": "date:now +103 hours / PT3H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT5H",
+          "validTime": "date:now +106 hours / PT5H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT3H",
+          "validTime": "date:now +111 hours / PT3H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT4H",
+          "validTime": "date:now +114 hours / PT4H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT4H",
-          "value": 24.076000000000001
+          "validTime": "date:now +118 hours / PT4H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +122 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +124 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +127 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +129 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +130 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
-          "value": 53.707999999999998
+          "validTime": "date:now +131 hours / PT1H",
+          "value": 53.708
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 55.560000000000002
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 55.56
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 57.411999999999999
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 57.412
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
-          "value": 53.707999999999998
+          "validTime": "date:now +134 hours / PT1H",
+          "value": 53.708
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +135 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +136 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +137 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +138 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT8H",
-          "value": 27.780000000000001
+          "validTime": "date:now +139 hours / PT8H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT2H",
-          "value": 29.632000000000001
+          "validTime": "date:now +147 hours / PT2H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +149 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +150 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +153 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +154 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
+          "validTime": "date:now +155 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT2H",
-          "value": 42.595999999999997
+          "validTime": "date:now +156 hours / PT2H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +159 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +160 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +161 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT3H",
-          "value": 51.856000000000002
+          "validTime": "date:now +162 hours / PT3H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +165 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT2H",
-          "value": 48.152000000000001
+          "validTime": "date:now +166 hours / PT2H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +168 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT2H",
-          "value": 42.595999999999997
+          "validTime": "date:now +170 hours / PT2H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +173 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +174 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +175 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +176 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +177 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +178 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
+          "validTime": "date:now +179 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +181 hours / PT1H",
+          "value": 14.816
         }
       ]
     },
@@ -6346,279 +6346,279 @@
       "uom": "wmoUnit:degree_(angle)",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT5H",
+          "validTime": "date:now +0 hours / PT5H",
           "value": 260
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +7 hours / PT6H",
           "value": 220
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 210
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT3H",
+          "validTime": "date:now +15 hours / PT3H",
           "value": 230
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT2H",
+          "validTime": "date:now +18 hours / PT2H",
           "value": 240
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT2H",
+          "validTime": "date:now +20 hours / PT2H",
           "value": 230
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT8H",
+          "validTime": "date:now +22 hours / PT8H",
           "value": 220
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT3H",
+          "validTime": "date:now +30 hours / PT3H",
           "value": 230
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT3H",
+          "validTime": "date:now +33 hours / PT3H",
           "value": 240
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT4H",
+          "validTime": "date:now +36 hours / PT4H",
           "value": 250
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT4H",
+          "validTime": "date:now +41 hours / PT4H",
           "value": 250
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT3H",
+          "validTime": "date:now +45 hours / PT3H",
           "value": 260
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
+          "validTime": "date:now +48 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
+          "validTime": "date:now +49 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT6H",
+          "validTime": "date:now +50 hours / PT6H",
           "value": 270
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 330
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT2H",
+          "validTime": "date:now +61 hours / PT2H",
           "value": 20
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT8H",
+          "validTime": "date:now +63 hours / PT8H",
           "value": 30
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT4H",
+          "validTime": "date:now +71 hours / PT4H",
           "value": 40
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT2H",
+          "validTime": "date:now +76 hours / PT2H",
           "value": 60
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT5H",
+          "validTime": "date:now +79 hours / PT5H",
           "value": 80
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT2H",
+          "validTime": "date:now +84 hours / PT2H",
           "value": 90
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT2H",
+          "validTime": "date:now +88 hours / PT2H",
           "value": 60
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
+          "validTime": "date:now +92 hours / PT1H",
           "value": 30
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +94 hours / PT1H",
           "value": 350
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
+          "validTime": "date:now +95 hours / PT1H",
           "value": 330
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
+          "validTime": "date:now +96 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT1H",
+          "validTime": "date:now +97 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 290
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT6H",
+          "validTime": "date:now +102 hours / PT6H",
           "value": 230
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT3H",
+          "validTime": "date:now +108 hours / PT3H",
           "value": 240
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT2H",
+          "validTime": "date:now +111 hours / PT2H",
           "value": 230
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT6H",
+          "validTime": "date:now +113 hours / PT6H",
           "value": 220
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT3H",
+          "validTime": "date:now +119 hours / PT3H",
           "value": 210
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT4H",
+          "validTime": "date:now +122 hours / PT4H",
           "value": 220
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT3H",
+          "validTime": "date:now +126 hours / PT3H",
           "value": 230
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT6H",
+          "validTime": "date:now +129 hours / PT6H",
           "value": 220
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT9H",
+          "validTime": "date:now +135 hours / PT9H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT10H",
+          "validTime": "date:now +144 hours / PT10H",
           "value": 220
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT8H",
+          "validTime": "date:now +154 hours / PT8H",
           "value": 230
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT3H",
+          "validTime": "date:now +162 hours / PT3H",
           "value": 240
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT1H",
+          "validTime": "date:now +165 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT1H",
+          "validTime": "date:now +166 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
+          "validTime": "date:now +167 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT2H",
+          "validTime": "date:now +168 hours / PT2H",
           "value": 280
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT2H",
+          "validTime": "date:now +170 hours / PT2H",
           "value": 290
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT2H",
+          "validTime": "date:now +173 hours / PT2H",
           "value": 310
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT2H",
+          "validTime": "date:now +175 hours / PT2H",
           "value": 320
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT3H",
+          "validTime": "date:now +177 hours / PT3H",
           "value": 310
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT2H",
+          "validTime": "date:now +180 hours / PT2H",
           "value": 300
         }
       ]
@@ -6627,727 +6627,727 @@
       "uom": "wmoUnit:m",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 23.1648
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
-          "value": 22.250399999999999
+          "validTime": "date:now +1 hours / PT1H",
+          "value": 22.2504
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 24.384
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
-          "value": 26.822399999999998
+          "validTime": "date:now +3 hours / PT1H",
+          "value": 26.8224
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 29.2608
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 191.4144
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
-          "value": 353.87279999999998
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 353.8728
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": 516.02639999999997
+          "validTime": "date:now +7 hours / PT1H",
+          "value": 516.0264
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 595.27440000000001
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 595.2744
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
-          "value": 674.52239999999995
+          "validTime": "date:now +9 hours / PT1H",
+          "value": 674.5224
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 753.7704
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
-          "value": 676.04639999999995
+          "validTime": "date:now +11 hours / PT1H",
+          "value": 676.0464
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
-          "value": 598.32240000000002
+          "validTime": "date:now +12 hours / PT1H",
+          "value": 598.3224
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
-          "value": 520.90319999999997
+          "validTime": "date:now +13 hours / PT1H",
+          "value": 520.9032
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 356.00639999999999
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 356.0064
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 191.4144
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
-          "value": 26.822399999999998
+          "validTime": "date:now +16 hours / PT1H",
+          "value": 26.8224
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
-          "value": 26.517600000000002
+          "validTime": "date:now +17 hours / PT1H",
+          "value": 26.5176
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 26.212800000000001
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 26.2128
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
-          "value": 25.908000000000001
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 25.908
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
-          "value": 27.736799999999999
+          "validTime": "date:now +20 hours / PT1H",
+          "value": 27.7368
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 29.5656
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
-          "value": 31.394400000000001
+          "validTime": "date:now +22 hours / PT1H",
+          "value": 31.3944
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
-          "value": 27.736799999999999
+          "validTime": "date:now +23 hours / PT1H",
+          "value": 27.7368
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": 24.384
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
-          "value": 21.031199999999998
+          "validTime": "date:now +25 hours / PT1H",
+          "value": 21.0312
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 28.346399999999999
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 28.3464
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 35.6616
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 42.976799999999997
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 42.9768
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 249.32640000000001
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 249.3264
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 455.67599999999999
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 455.676
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 662.33040000000005
+          "validTime": "date:now +31 hours / PT1H",
+          "value": 662.3304
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
-          "value": 700.12559999999996
+          "validTime": "date:now +32 hours / PT1H",
+          "value": 700.1256
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 737.92079999999999
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 737.9208
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
-          "value": 775.71600000000001
+          "validTime": "date:now +34 hours / PT1H",
+          "value": 775.716
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 768.096
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 760.1712
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
-          "value": 752.55119999999999
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 752.5512
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 526.99919999999997
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 526.9992
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 301.44720000000001
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 301.4472
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 75.590400000000002
+          "validTime": "date:now +40 hours / PT1H",
+          "value": 75.5904
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
-          "value": 67.360799999999998
+          "validTime": "date:now +41 hours / PT1H",
+          "value": 67.3608
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": 59.1312
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
-          "value": 50.901600000000002
+          "validTime": "date:now +43 hours / PT1H",
+          "value": 50.9016
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
-          "value": 49.072800000000001
+          "validTime": "date:now +44 hours / PT1H",
+          "value": 49.0728
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
+          "validTime": "date:now +45 hours / PT1H",
           "value": 47.5488
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
-          "value": 46.024799999999999
+          "validTime": "date:now +46 hours / PT1H",
+          "value": 46.0248
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
-          "value": 43.891199999999998
+          "validTime": "date:now +47 hours / PT1H",
+          "value": 43.8912
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
-          "value": 41.757599999999996
+          "validTime": "date:now +48 hours / PT1H",
+          "value": 41.7576
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
-          "value": 39.928800000000003
+          "validTime": "date:now +49 hours / PT1H",
+          "value": 39.9288
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
-          "value": 88.696799999999996
+          "validTime": "date:now +50 hours / PT1H",
+          "value": 88.6968
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +51 hours / PT1H",
           "value": 137.4648
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 185.928
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
-          "value": 465.12479999999999
+          "validTime": "date:now +53 hours / PT1H",
+          "value": 465.1248
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": 744.01679999999999
+          "validTime": "date:now +54 hours / PT1H",
+          "value": 744.0168
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 1022.9088
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 1188.1104
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 1353.0072
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 1518.2088000000001
+          "validTime": "date:now +58 hours / PT1H",
+          "value": 1518.2088
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
-          "value": 1485.9000000000001
+          "validTime": "date:now +59 hours / PT1H",
+          "value": 1485.9
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 1453.5912000000001
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 1453.5912
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
-          "value": 1421.2824000000001
+          "validTime": "date:now +61 hours / PT1H",
+          "value": 1421.2824
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 957.6816
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
-          "value": 494.08080000000001
+          "validTime": "date:now +63 hours / PT1H",
+          "value": 494.0808
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 30.48
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 29.2608
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": 28.041599999999999
+          "validTime": "date:now +66 hours / PT1H",
+          "value": 28.0416
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
-          "value": 26.822399999999998
+          "validTime": "date:now +67 hours / PT1H",
+          "value": 26.8224
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 28.041599999999999
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 28.0416
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 28.956
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 30.1752
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 29.2608
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
-          "value": 28.346399999999999
+          "validTime": "date:now +72 hours / PT1H",
+          "value": 28.3464
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
-          "value": 27.431999999999999
+          "validTime": "date:now +73 hours / PT1H",
+          "value": 27.432
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 150.5712
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
-          "value": 273.40559999999999
+          "validTime": "date:now +75 hours / PT1H",
+          "value": 273.4056
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
-          "value": 396.54480000000001
+          "validTime": "date:now +76 hours / PT1H",
+          "value": 396.5448
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
-          "value": 519.68399999999997
+          "validTime": "date:now +77 hours / PT1H",
+          "value": 519.684
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
-          "value": 642.82320000000004
+          "validTime": "date:now +78 hours / PT1H",
+          "value": 642.8232
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
+          "validTime": "date:now +79 hours / PT1H",
           "value": 765.9624
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
-          "value": 733.65359999999998
+          "validTime": "date:now +80 hours / PT1H",
+          "value": 733.6536
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
-          "value": 703.17359999999996
+          "validTime": "date:now +81 hours / PT1H",
+          "value": 703.1736
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
-          "value": 672.69359999999995
+          "validTime": "date:now +82 hours / PT1H",
+          "value": 672.6936
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
-          "value": 642.21360000000004
+          "validTime": "date:now +83 hours / PT1H",
+          "value": 642.2136
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
-          "value": 612.03840000000002
+          "validTime": "date:now +84 hours / PT1H",
+          "value": 612.0384
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
-          "value": 581.55840000000001
+          "validTime": "date:now +85 hours / PT1H",
+          "value": 581.5584
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
-          "value": 489.20400000000001
+          "validTime": "date:now +86 hours / PT1H",
+          "value": 489.204
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
-          "value": 396.84960000000001
+          "validTime": "date:now +87 hours / PT1H",
+          "value": 396.8496
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
-          "value": 304.49520000000001
+          "validTime": "date:now +88 hours / PT1H",
+          "value": 304.4952
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
-          "value": 212.14080000000001
+          "validTime": "date:now +89 hours / PT1H",
+          "value": 212.1408
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 119.4816
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
-          "value": 27.127199999999998
+          "validTime": "date:now +91 hours / PT1H",
+          "value": 27.1272
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": 26.517600000000002
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 26.5176
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
-          "value": 25.603200000000001
+          "validTime": "date:now +93 hours / PT1H",
+          "value": 25.6032
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
-          "value": 24.688800000000001
+          "validTime": "date:now +94 hours / PT1H",
+          "value": 24.6888
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
+          "validTime": "date:now +95 hours / PT1H",
           "value": 24.0792
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
+          "validTime": "date:now +96 hours / PT1H",
           "value": 23.1648
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT1H",
-          "value": 22.250399999999999
+          "validTime": "date:now +97 hours / PT1H",
+          "value": 22.2504
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
-          "value": 174.34559999999999
+          "validTime": "date:now +98 hours / PT1H",
+          "value": 174.3456
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
-          "value": 326.13600000000002
+          "validTime": "date:now +99 hours / PT1H",
+          "value": 326.136
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 478.2312
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
-          "value": 630.32640000000004
+          "validTime": "date:now +101 hours / PT1H",
+          "value": 630.3264
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
-          "value": 782.11680000000001
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 782.1168
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
-          "value": 934.21199999999999
+          "validTime": "date:now +103 hours / PT1H",
+          "value": 934.212
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
-          "value": 897.63599999999997
+          "validTime": "date:now +104 hours / PT1H",
+          "value": 897.636
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
-          "value": 861.05999999999995
+          "validTime": "date:now +105 hours / PT1H",
+          "value": 861.06
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT1H",
-          "value": 824.48400000000004
+          "validTime": "date:now +106 hours / PT1H",
+          "value": 824.484
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
-          "value": 787.60320000000002
+          "validTime": "date:now +107 hours / PT1H",
+          "value": 787.6032
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
-          "value": 751.02719999999999
+          "validTime": "date:now +108 hours / PT1H",
+          "value": 751.0272
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 714.45119999999997
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 714.4512
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
-          "value": 600.15120000000002
+          "validTime": "date:now +110 hours / PT1H",
+          "value": 600.1512
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 486.15600000000001
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 486.156
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
-          "value": 371.85599999999999
+          "validTime": "date:now +112 hours / PT1H",
+          "value": 371.856
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
-          "value": 257.55599999999998
+          "validTime": "date:now +113 hours / PT1H",
+          "value": 257.556
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
+          "validTime": "date:now +114 hours / PT1H",
           "value": 143.256
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": 29.2608
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 28.956
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
-          "value": 28.651199999999999
+          "validTime": "date:now +117 hours / PT1H",
+          "value": 28.6512
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
-          "value": 28.346399999999999
+          "validTime": "date:now +118 hours / PT1H",
+          "value": 28.3464
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT2H",
-          "value": 28.041599999999999
+          "validTime": "date:now +119 hours / PT2H",
+          "value": 28.0416
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
-          "value": 27.736799999999999
+          "validTime": "date:now +121 hours / PT1H",
+          "value": 27.7368
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
-          "value": 201.77760000000001
+          "validTime": "date:now +122 hours / PT1H",
+          "value": 201.7776
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 375.8184
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": 549.85919999999999
+          "validTime": "date:now +124 hours / PT1H",
+          "value": 549.8592
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 724.20479999999998
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 724.2048
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 898.24559999999997
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 898.2456
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 1072.2864
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
+          "validTime": "date:now +128 hours / PT1H",
           "value": 1074.7248
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
+          "validTime": "date:now +129 hours / PT1H",
           "value": 1077.1632
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT1H",
+          "validTime": "date:now +130 hours / PT1H",
           "value": 1079.6016
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
+          "validTime": "date:now +131 hours / PT1H",
           "value": 1082.04
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +132 hours / PT1H",
           "value": 1084.4784
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 1086.9168
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
-          "value": 916.22879999999998
+          "validTime": "date:now +134 hours / PT1H",
+          "value": 916.2288
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
-          "value": 745.54079999999999
+          "validTime": "date:now +135 hours / PT1H",
+          "value": 745.5408
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 574.8528
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
-          "value": 404.16480000000001
+          "validTime": "date:now +137 hours / PT1H",
+          "value": 404.1648
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +138 hours / PT1H",
           "value": 233.4768
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
-          "value": 62.788800000000002
+          "validTime": "date:now +139 hours / PT1H",
+          "value": 62.7888
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT1H",
-          "value": 90.220799999999997
+          "validTime": "date:now +140 hours / PT1H",
+          "value": 90.2208
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 117.9576
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +142 hours / PT1H",
           "value": 145.6944
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
-          "value": 173.43119999999999
+          "validTime": "date:now +143 hours / PT1H",
+          "value": 173.4312
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
-          "value": 201.16800000000001
+          "validTime": "date:now +144 hours / PT1H",
+          "value": 201.168
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
-          "value": 228.59999999999999
+          "validTime": "date:now +145 hours / PT1H",
+          "value": 228.6
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
-          "value": 265.48079999999999
+          "validTime": "date:now +146 hours / PT1H",
+          "value": 265.4808
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
-          "value": 302.05680000000001
+          "validTime": "date:now +147 hours / PT1H",
+          "value": 302.0568
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
-          "value": 338.93759999999997
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 338.9376
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 375.5136
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
-          "value": 412.39440000000002
+          "validTime": "date:now +150 hours / PT1H",
+          "value": 412.3944
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
-          "value": 448.97039999999998
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 448.9704
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 420.31920000000002
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 420.3192
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
-          "value": 391.66800000000001
+          "validTime": "date:now +153 hours / PT1H",
+          "value": 391.668
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT1H",
-          "value": 363.01679999999999
+          "validTime": "date:now +154 hours / PT1H",
+          "value": 363.0168
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
-          "value": 334.36559999999997
+          "validTime": "date:now +155 hours / PT1H",
+          "value": 334.3656
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
-          "value": 305.71440000000001
+          "validTime": "date:now +156 hours / PT1H",
+          "value": 305.7144
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
-          "value": 277.06319999999999
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 277.0632
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
-          "value": 265.78559999999999
+          "validTime": "date:now +158 hours / PT1H",
+          "value": 265.7856
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
-          "value": 254.20320000000001
+          "validTime": "date:now +159 hours / PT1H",
+          "value": 254.2032
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 242.9256
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
+          "validTime": "date:now +161 hours / PT1H",
           "value": 231.3432
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
-          "value": 220.06559999999999
+          "validTime": "date:now +162 hours / PT1H",
+          "value": 220.0656
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT1H",
-          "value": 208.78800000000001
+          "validTime": "date:now +163 hours / PT1H",
+          "value": 208.788
         },
         {
-          "validTime": "2024-02-27T07:00:00+00:00/PT1H",
-          "value": 224.94239999999999
+          "validTime": "date:now +164 hours / PT1H",
+          "value": 224.9424
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT1H",
+          "validTime": "date:now +165 hours / PT1H",
           "value": 241.0968
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT1H",
-          "value": 257.25119999999998
+          "validTime": "date:now +166 hours / PT1H",
+          "value": 257.2512
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
-          "value": 273.40559999999999
+          "validTime": "date:now +167 hours / PT1H",
+          "value": 273.4056
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
+          "validTime": "date:now +168 hours / PT1H",
           "value": 289.56
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
-          "value": 305.71440000000001
+          "validTime": "date:now +169 hours / PT1H",
+          "value": 305.7144
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
-          "value": 402.94560000000001
+          "validTime": "date:now +170 hours / PT1H",
+          "value": 402.9456
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
-          "value": 500.48160000000001
+          "validTime": "date:now +171 hours / PT1H",
+          "value": 500.4816
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
-          "value": 597.71280000000002
+          "validTime": "date:now +172 hours / PT1H",
+          "value": 597.7128
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": 695.24879999999996
+          "validTime": "date:now +173 hours / PT1H",
+          "value": 695.2488
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
-          "value": 792.48000000000002
+          "validTime": "date:now +174 hours / PT1H",
+          "value": 792.48
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": 890.01599999999996
+          "validTime": "date:now +175 hours / PT1H",
+          "value": 890.016
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
-          "value": 836.67600000000004
+          "validTime": "date:now +176 hours / PT1H",
+          "value": 836.676
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
-          "value": 783.33600000000001
+          "validTime": "date:now +177 hours / PT1H",
+          "value": 783.336
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT1H",
-          "value": 729.99599999999998
+          "validTime": "date:now +178 hours / PT1H",
+          "value": 729.996
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
-          "value": 676.96079999999995
+          "validTime": "date:now +179 hours / PT1H",
+          "value": 676.9608
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 623.62080000000003
+          "validTime": "date:now +180 hours / PT1H",
+          "value": 623.6208
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 570.2808
         }
       ]
@@ -7355,71 +7355,71 @@
     "hainesIndex": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT8H",
+          "validTime": "date:now +1 hours / PT8H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT5H",
+          "validTime": "date:now +9 hours / PT5H",
           "value": 2
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT4H",
+          "validTime": "date:now +14 hours / PT4H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT5H",
+          "validTime": "date:now +18 hours / PT5H",
           "value": 4
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT2H",
+          "validTime": "date:now +23 hours / PT2H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/P2DT2H",
+          "validTime": "date:now +25 hours / P2DT2H",
           "value": 2
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT4H",
+          "validTime": "date:now +75 hours / PT4H",
           "value": 3
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT3H",
+          "validTime": "date:now +79 hours / PT3H",
           "value": 4
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT7H",
+          "validTime": "date:now +82 hours / PT7H",
           "value": 3
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT5H",
+          "validTime": "date:now +89 hours / PT5H",
           "value": 2
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT16H",
+          "validTime": "date:now +94 hours / PT16H",
           "value": 3
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT13H",
+          "validTime": "date:now +110 hours / PT13H",
           "value": 4
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT3H",
+          "validTime": "date:now +123 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/P1DT16H",
+          "validTime": "date:now +126 hours / P1DT16H",
           "value": 2
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT7H",
+          "validTime": "date:now +166 hours / PT7H",
           "value": 3
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT9H",
+          "validTime": "date:now +173 hours / PT9H",
           "value": 2
         }
       ]
@@ -7427,7 +7427,7 @@
     "lightningActivityLevel": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/P7DT14H",
+          "validTime": "date:now +0 hours / P7DT14H",
           "value": 1
         }
       ]
@@ -7436,280 +7436,280 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +0 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +2 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT2H",
+          "validTime": "date:now +3 hours / PT2H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +5 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +7 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
+          "validTime": "date:now +8 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT2H",
+          "validTime": "date:now +12 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT5H",
+          "validTime": "date:now +16 hours / PT5H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +21 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT3H",
+          "validTime": "date:now +22 hours / PT3H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
+          "validTime": "date:now +25 hours / PT2H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +31 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT2H",
+          "validTime": "date:now +34 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT2H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +41 hours / PT2H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +43 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT4H",
+          "validTime": "date:now +44 hours / PT4H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT6H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +48 hours / PT6H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +54 hours / PT1H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT8H",
+          "validTime": "date:now +55 hours / PT8H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT5H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +63 hours / PT5H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT8H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +69 hours / PT8H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT2H",
+          "validTime": "date:now +77 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT2H",
+          "validTime": "date:now +79 hours / PT2H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT6H",
-          "value": 14.816000000000001
+          "validTime": "date:now +81 hours / PT6H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT13H",
+          "validTime": "date:now +88 hours / PT13H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +102 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +104 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT7H",
+          "validTime": "date:now +105 hours / PT7H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT3H",
-          "value": 16.667999999999999
+          "validTime": "date:now +112 hours / PT3H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT9H",
+          "validTime": "date:now +115 hours / PT9H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT2H",
+          "validTime": "date:now +124 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT3H",
-          "value": 25.928000000000001
+          "validTime": "date:now +127 hours / PT3H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT3H",
-          "value": 27.780000000000001
+          "validTime": "date:now +130 hours / PT3H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT3H",
-          "value": 25.928000000000001
+          "validTime": "date:now +133 hours / PT3H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +136 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT6H",
+          "validTime": "date:now +138 hours / PT6H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT4H",
+          "validTime": "date:now +144 hours / PT4H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +149 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +150 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT3H",
-          "value": 29.632000000000001
+          "validTime": "date:now +153 hours / PT3H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT3H",
-          "value": 27.780000000000001
+          "validTime": "date:now +156 hours / PT3H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +159 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT2H",
-          "value": 27.780000000000001
+          "validTime": "date:now +161 hours / PT2H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT5H",
-          "value": 29.632000000000001
+          "validTime": "date:now +163 hours / PT5H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT3H",
-          "value": 27.780000000000001
+          "validTime": "date:now +168 hours / PT3H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT6H",
-          "value": 25.928000000000001
+          "validTime": "date:now +171 hours / PT6H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT3H",
-          "value": 27.780000000000001
+          "validTime": "date:now +177 hours / PT3H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +180 hours / PT2H",
+          "value": 25.928
         }
       ]
     },
@@ -7717,243 +7717,243 @@
       "uom": "wmoUnit:degree_(angle)",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 260
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT2H",
+          "validTime": "date:now +2 hours / PT2H",
           "value": 250
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT9H",
+          "validTime": "date:now +6 hours / PT9H",
           "value": 220
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT4H",
+          "validTime": "date:now +15 hours / PT4H",
           "value": 230
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +19 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT2H",
+          "validTime": "date:now +20 hours / PT2H",
           "value": 230
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT9H",
+          "validTime": "date:now +22 hours / PT9H",
           "value": 220
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT4H",
+          "validTime": "date:now +31 hours / PT4H",
           "value": 230
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT6H",
+          "validTime": "date:now +35 hours / PT6H",
           "value": 240
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT4H",
+          "validTime": "date:now +41 hours / PT4H",
           "value": 250
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT2H",
+          "validTime": "date:now +45 hours / PT2H",
           "value": 260
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT2H",
+          "validTime": "date:now +47 hours / PT2H",
           "value": 270
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT2H",
+          "validTime": "date:now +49 hours / PT2H",
           "value": 280
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT2H",
+          "validTime": "date:now +51 hours / PT2H",
           "value": 290
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT3H",
+          "validTime": "date:now +55 hours / PT3H",
           "value": 320
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 330
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 350
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT3H",
+          "validTime": "date:now +61 hours / PT3H",
           "value": 20
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT8H",
+          "validTime": "date:now +64 hours / PT8H",
           "value": 30
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT3H",
+          "validTime": "date:now +72 hours / PT3H",
           "value": 40
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT2H",
+          "validTime": "date:now +76 hours / PT2H",
           "value": 60
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT2H",
+          "validTime": "date:now +79 hours / PT2H",
           "value": 80
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 90
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT2H",
+          "validTime": "date:now +82 hours / PT2H",
           "value": 100
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 90
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 100
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 90
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
+          "validTime": "date:now +89 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT2H",
+          "validTime": "date:now +92 hours / PT2H",
           "value": 30
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +94 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
+          "validTime": "date:now +95 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
+          "validTime": "date:now +96 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT1H",
+          "validTime": "date:now +97 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT3H",
+          "validTime": "date:now +101 hours / PT3H",
           "value": 230
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT15H",
+          "validTime": "date:now +106 hours / PT15H",
           "value": 220
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/P1DT2H",
+          "validTime": "date:now +121 hours / P1DT2H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT9H",
+          "validTime": "date:now +147 hours / PT9H",
           "value": 220
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT12H",
+          "validTime": "date:now +156 hours / PT12H",
           "value": 230
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT3H",
+          "validTime": "date:now +168 hours / PT3H",
           "value": 240
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT3H",
+          "validTime": "date:now +171 hours / PT3H",
           "value": 250
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT2H",
+          "validTime": "date:now +174 hours / PT2H",
           "value": 260
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT3H",
+          "validTime": "date:now +177 hours / PT3H",
           "value": 280
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT2H",
+          "validTime": "date:now +180 hours / PT2H",
           "value": 270
         }
       ]
@@ -8030,43 +8030,43 @@
     "probabilityOfThunder": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/P1DT7H",
+          "validTime": "date:now +0 hours / P1DT7H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +31 hours / PT6H",
           "value": 4
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +37 hours / PT6H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/P3DT12H",
+          "validTime": "date:now +43 hours / P3DT12H",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/P1D",
+          "validTime": "date:now +127 hours / P1D",
           "value": 1
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT6H",
+          "validTime": "date:now +151 hours / PT6H",
           "value": 3
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT6H",
+          "validTime": "date:now +157 hours / PT6H",
           "value": 4
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT6H",
+          "validTime": "date:now +163 hours / PT6H",
           "value": 2
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT6H",
+          "validTime": "date:now +169 hours / PT6H",
           "value": 1
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT6H",
+          "validTime": "date:now +175 hours / PT6H",
           "value": 2
         }
       ]
@@ -8077,203 +8077,203 @@
     "atmosphericDispersionIndex": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 7
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT2H",
+          "validTime": "date:now +2 hours / PT2H",
           "value": 6
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 17
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT2H",
+          "validTime": "date:now +7 hours / PT2H",
           "value": 32
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 16
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 12
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT3H",
+          "validTime": "date:now +16 hours / PT3H",
           "value": 8
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT4H",
+          "validTime": "date:now +19 hours / PT4H",
           "value": 7
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 8
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT2H",
+          "validTime": "date:now +24 hours / PT2H",
           "value": 9
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 13
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 14
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 37
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 54
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +33 hours / PT1H",
           "value": 51
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 49
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 47
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 18
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 11
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 8
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 7
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT2H",
+          "validTime": "date:now +43 hours / PT2H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT3H",
+          "validTime": "date:now +45 hours / PT3H",
           "value": 4
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT3H",
+          "validTime": "date:now +48 hours / PT3H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT2H",
+          "validTime": "date:now +51 hours / PT2H",
           "value": 7
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 12
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 19
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 26
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 27
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 28
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 16
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 12
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT11H",
+          "validTime": "date:now +63 hours / PT11H",
           "value": 6
         }
       ]
@@ -8281,83 +8281,83 @@
     "lowVisibilityOccurrenceRiskIndex": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": 4
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT7H",
+          "validTime": "date:now +7 hours / PT7H",
           "value": 1
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT11H",
+          "validTime": "date:now +14 hours / PT11H",
           "value": 2
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT5H",
+          "validTime": "date:now +25 hours / PT5H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT4H",
+          "validTime": "date:now +30 hours / PT4H",
           "value": 1
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT4H",
+          "validTime": "date:now +34 hours / PT4H",
           "value": 3
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT3H",
+          "validTime": "date:now +40 hours / PT3H",
           "value": 8
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT8H",
+          "validTime": "date:now +43 hours / PT8H",
           "value": 9
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT2H",
+          "validTime": "date:now +51 hours / PT2H",
           "value": 8
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT8H",
+          "validTime": "date:now +55 hours / PT8H",
           "value": 2
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT3H",
+          "validTime": "date:now +63 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT8H",
+          "validTime": "date:now +66 hours / PT8H",
           "value": 4
         }
       ]
@@ -8365,103 +8365,103 @@
     "stability": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": 5
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT3H",
+          "validTime": "date:now +7 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 4
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT2H",
+          "validTime": "date:now +13 hours / PT2H",
           "value": 4
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT6H",
+          "validTime": "date:now +15 hours / PT6H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT2H",
+          "validTime": "date:now +21 hours / PT2H",
           "value": 4
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT3H",
+          "validTime": "date:now +24 hours / PT3H",
           "value": 6
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT3H",
+          "validTime": "date:now +28 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT8H",
+          "validTime": "date:now +31 hours / PT8H",
           "value": 4
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT5H",
+          "validTime": "date:now +39 hours / PT5H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT4H",
+          "validTime": "date:now +44 hours / PT4H",
           "value": 6
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT3H",
+          "validTime": "date:now +48 hours / PT3H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +51 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT2H",
+          "validTime": "date:now +52 hours / PT2H",
           "value": 3
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT5H",
+          "validTime": "date:now +54 hours / PT5H",
           "value": 2
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT2H",
+          "validTime": "date:now +59 hours / PT2H",
           "value": 3
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT12H",
+          "validTime": "date:now +62 hours / PT12H",
           "value": 6
         }
       ]

--- a/tests/api/data/testing/gridpoints/LZK/83,73.json
+++ b/tests/api/data/testing/gridpoints/LZK/83,73.json
@@ -38,651 +38,651 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +3 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +5 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +13 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT2H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +20 hours / PT2H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +22 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT2H",
+          "validTime": "date:now +23 hours / PT2H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +25 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 21.666666666666668
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +35 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT2H",
+          "validTime": "date:now +40 hours / PT2H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT2H",
-          "value": 16.111111111111111
+          "validTime": "date:now +42 hours / PT2H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT2H",
+          "validTime": "date:now +44 hours / PT2H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT2H",
+          "validTime": "date:now +46 hours / PT2H",
           "value": 15
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT4H",
+          "validTime": "date:now +48 hours / PT4H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +52 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +56 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT2H",
+          "validTime": "date:now +58 hours / PT2H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT2H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +70 hours / PT2H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT2H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +72 hours / PT2H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT2H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +74 hours / PT2H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +79 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +80 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT2H",
-          "value": 18.888888888888889
+          "validTime": "date:now +82 hours / PT2H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +89 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT2H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +92 hours / PT2H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +94 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +95 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +96 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT3H",
+          "validTime": "date:now +97 hours / PT3H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT2H",
+          "validTime": "date:now +106 hours / PT2H",
           "value": 20
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +108 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +114 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +117 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +118 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +119 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +120 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT2H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +121 hours / PT2H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +129 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT2H",
+          "validTime": "date:now +130 hours / PT2H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +136 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +138 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT1H",
+          "validTime": "date:now +140 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT2H",
-          "value": 13.888888888888889
+          "validTime": "date:now +142 hours / PT2H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT3H",
+          "validTime": "date:now +145 hours / PT3H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +149 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT2H",
-          "value": 23.888888888888889
+          "validTime": "date:now +154 hours / PT2H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +156 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +158 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
+          "validTime": "date:now +159 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT2H",
+          "validTime": "date:now +160 hours / PT2H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +162 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT2H",
+          "validTime": "date:now +163 hours / PT2H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT2H",
-          "value": 17.777777777777779
+          "validTime": "date:now +165 hours / PT2H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT2H",
-          "value": 17.222222222222221
+          "validTime": "date:now +167 hours / PT2H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT3H",
+          "validTime": "date:now +169 hours / PT3H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
+          "validTime": "date:now +173 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +174 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +175 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +176 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT2H",
-          "value": 23.888888888888889
+          "validTime": "date:now +178 hours / PT2H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 21.666666666666668
         },
         {
-          "validTime": "2024-02-28T01:00:00+00:00/PT1H",
+          "validTime": "date:now +182 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-28T02:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +183 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-28T03:00:00+00:00/PT1H",
+          "validTime": "date:now +184 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-28T04:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +185 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-28T05:00:00+00:00/PT1H",
+          "validTime": "date:now +186 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-28T06:00:00+00:00/PT1H",
+          "validTime": "date:now +187 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-28T07:00:00+00:00/PT2H",
-          "value": 13.888888888888889
+          "validTime": "date:now +188 hours / PT2H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-28T09:00:00+00:00/PT1H",
+          "validTime": "date:now +190 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-28T10:00:00+00:00/PT1H",
+          "validTime": "date:now +191 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-28T11:00:00+00:00/PT1H",
+          "validTime": "date:now +192 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-28T12:00:00+00:00/PT1H",
+          "validTime": "date:now +193 hours / PT1H",
           "value": 11.666666666666666
         }
       ]
@@ -691,347 +691,347 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
-          "value": -0.55555555555555558
+          "validTime": "date:now +0 hours / PT1H",
+          "value": -0.5555555555555556
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +2 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT4H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +7 hours / PT4H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +11 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +12 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +13 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT3H",
+          "validTime": "date:now +14 hours / PT3H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +17 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT5H",
+          "validTime": "date:now +18 hours / PT5H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT2H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +23 hours / PT2H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +25 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT18H",
+          "validTime": "date:now +31 hours / PT18H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
+          "validTime": "date:now +49 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT2H",
+          "validTime": "date:now +50 hours / PT2H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT2H",
+          "validTime": "date:now +52 hours / PT2H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT3H",
+          "validTime": "date:now +54 hours / PT3H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT3H",
+          "validTime": "date:now +57 hours / PT3H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT2H",
+          "validTime": "date:now +60 hours / PT2H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +64 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +65 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +66 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +67 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +70 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +72 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +73 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT2H",
+          "validTime": "date:now +74 hours / PT2H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT2H",
+          "validTime": "date:now +76 hours / PT2H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT3H",
+          "validTime": "date:now +78 hours / PT3H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT3H",
+          "validTime": "date:now +81 hours / PT3H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT3H",
+          "validTime": "date:now +84 hours / PT3H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT6H",
+          "validTime": "date:now +87 hours / PT6H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT3H",
+          "validTime": "date:now +93 hours / PT3H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT2H",
+          "validTime": "date:now +96 hours / PT2H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT5H",
+          "validTime": "date:now +100 hours / PT5H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT2H",
+          "validTime": "date:now +105 hours / PT2H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
+          "validTime": "date:now +107 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +108 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT2H",
+          "validTime": "date:now +109 hours / PT2H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT6H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +111 hours / PT6H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT5H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +117 hours / PT5H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +122 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +124 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT2H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +127 hours / PT2H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT3H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +129 hours / PT3H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT9H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +132 hours / PT9H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT5H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +141 hours / PT5H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +146 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +147 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT2H",
-          "value": 13.888888888888889
+          "validTime": "date:now +151 hours / PT2H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT3H",
+          "validTime": "date:now +153 hours / PT3H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT3H",
-          "value": 13.888888888888889
+          "validTime": "date:now +156 hours / PT3H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT3H",
+          "validTime": "date:now +159 hours / PT3H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT8H",
-          "value": 13.888888888888889
+          "validTime": "date:now +162 hours / PT8H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT2H",
+          "validTime": "date:now +170 hours / PT2H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT2H",
+          "validTime": "date:now +172 hours / PT2H",
           "value": 15
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT3H",
+          "validTime": "date:now +174 hours / PT3H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT3H",
+          "validTime": "date:now +177 hours / PT3H",
           "value": 15
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT5H",
+          "validTime": "date:now +180 hours / PT5H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-28T04:00:00+00:00/PT5H",
-          "value": 13.888888888888889
+          "validTime": "date:now +185 hours / PT5H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-28T09:00:00+00:00/PT1H",
+          "validTime": "date:now +190 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-28T10:00:00+00:00/PT1H",
+          "validTime": "date:now +191 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-28T11:00:00+00:00/PT1H",
+          "validTime": "date:now +192 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-28T12:00:00+00:00/PT1H",
+          "validTime": "date:now +193 hours / PT1H",
           "value": 11.666666666666666
         }
       ]
@@ -1040,36 +1040,36 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT13H",
+          "validTime": "date:now +0 hours / PT13H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT13H",
-          "value": 22.222222222222221
+          "validTime": "date:now +24 hours / PT13H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT13H",
+          "validTime": "date:now +48 hours / PT13H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT13H",
-          "value": 18.888888888888889
+          "validTime": "date:now +72 hours / PT13H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT13H",
+          "validTime": "date:now +96 hours / PT13H",
           "value": 20
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT13H",
+          "validTime": "date:now +120 hours / PT13H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT13H",
-          "value": 23.888888888888889
+          "validTime": "date:now +144 hours / PT13H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT13H",
-          "value": 23.888888888888889
+          "validTime": "date:now +168 hours / PT13H",
+          "value": 23.88888888888889
         }
       ]
     },
@@ -1077,39 +1077,39 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT4H",
+          "validTime": "date:now +0 hours / PT4H",
           "value": 1.1111111111111112
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT14H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +14 hours / PT14H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT14H",
+          "validTime": "date:now +38 hours / PT14H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT14H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +62 hours / PT14H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT14H",
+          "validTime": "date:now +86 hours / PT14H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT14H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +110 hours / PT14H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT14H",
+          "validTime": "date:now +134 hours / PT14H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT14H",
+          "validTime": "date:now +158 hours / PT14H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-28T01:00:00+00:00/PT14H",
+          "validTime": "date:now +182 hours / PT14H",
           "value": 11.666666666666666
         }
       ]
@@ -1118,727 +1118,727 @@
       "uom": "wmoUnit:percent",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 90
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 36
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 48
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 83
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +19 hours / PT1H",
           "value": 89
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
+          "validTime": "date:now +20 hours / PT1H",
           "value": 91
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 94
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
+          "validTime": "date:now +22 hours / PT1H",
           "value": 96
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 95
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": 97
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
+          "validTime": "date:now +25 hours / PT1H",
           "value": 96
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 88
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 86
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +33 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": 77
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +43 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
+          "validTime": "date:now +44 hours / PT1H",
           "value": 79
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
+          "validTime": "date:now +45 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
+          "validTime": "date:now +46 hours / PT1H",
           "value": 82
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
+          "validTime": "date:now +47 hours / PT1H",
           "value": 83
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
+          "validTime": "date:now +48 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
+          "validTime": "date:now +49 hours / PT1H",
           "value": 83
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +50 hours / PT1H",
           "value": 85
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +51 hours / PT1H",
           "value": 87
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT2H",
+          "validTime": "date:now +58 hours / PT2H",
           "value": 51
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 74
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT2H",
+          "validTime": "date:now +67 hours / PT2H",
           "value": 77
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT2H",
+          "validTime": "date:now +69 hours / PT2H",
           "value": 76
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT3H",
+          "validTime": "date:now +71 hours / PT3H",
           "value": 75
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
+          "validTime": "date:now +74 hours / PT1H",
           "value": 74
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
+          "validTime": "date:now +76 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 51
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
+          "validTime": "date:now +79 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": 35
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT2H",
+          "validTime": "date:now +82 hours / PT2H",
           "value": 32
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 54
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
+          "validTime": "date:now +89 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
+          "validTime": "date:now +90 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
+          "validTime": "date:now +91 hours / PT1H",
           "value": 62
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
+          "validTime": "date:now +92 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +94 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
+          "validTime": "date:now +95 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
+          "validTime": "date:now +96 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT1H",
+          "validTime": "date:now +97 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 47
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 41
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 36
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 33
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT1H",
+          "validTime": "date:now +106 hours / PT1H",
           "value": 32
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
+          "validTime": "date:now +107 hours / PT1H",
           "value": 34
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +108 hours / PT1H",
           "value": 37
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
+          "validTime": "date:now +109 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
+          "validTime": "date:now +111 hours / PT1H",
           "value": 55
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
+          "validTime": "date:now +114 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
+          "validTime": "date:now +115 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
+          "validTime": "date:now +120 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 82
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 51
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
+          "validTime": "date:now +128 hours / PT1H",
           "value": 41
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
+          "validTime": "date:now +129 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT2H",
+          "validTime": "date:now +130 hours / PT2H",
           "value": 37
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +132 hours / PT1H",
           "value": 39
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 49
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
+          "validTime": "date:now +136 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
+          "validTime": "date:now +138 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT1H",
+          "validTime": "date:now +140 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +142 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +143 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
+          "validTime": "date:now +145 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
+          "validTime": "date:now +146 hours / PT1H",
           "value": 81
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +147 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 67
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +151 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +152 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT3H",
+          "validTime": "date:now +154 hours / PT3H",
           "value": 55
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
+          "validTime": "date:now +157 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
+          "validTime": "date:now +158 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
+          "validTime": "date:now +159 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 72
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT1H",
+          "validTime": "date:now +161 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
+          "validTime": "date:now +162 hours / PT1H",
           "value": 74
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT1H",
+          "validTime": "date:now +163 hours / PT1H",
           "value": 75
         },
         {
-          "validTime": "2024-02-27T07:00:00+00:00/PT1H",
+          "validTime": "date:now +164 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT1H",
+          "validTime": "date:now +165 hours / PT1H",
           "value": 78
         },
         {
-          "validTime": "2024-02-27T09:00:00+00:00/PT1H",
+          "validTime": "date:now +166 hours / PT1H",
           "value": 79
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
+          "validTime": "date:now +167 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
+          "validTime": "date:now +168 hours / PT1H",
           "value": 82
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": 83
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT1H",
+          "validTime": "date:now +170 hours / PT1H",
           "value": 86
         },
         {
-          "validTime": "2024-02-27T14:00:00+00:00/PT1H",
+          "validTime": "date:now +171 hours / PT1H",
           "value": 87
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 82
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
+          "validTime": "date:now +173 hours / PT1H",
           "value": 76
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
+          "validTime": "date:now +175 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
+          "validTime": "date:now +176 hours / PT1H",
           "value": 62
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT1H",
+          "validTime": "date:now +178 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
+          "validTime": "date:now +179 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 64
         },
         {
-          "validTime": "2024-02-28T01:00:00+00:00/PT1H",
+          "validTime": "date:now +182 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-28T02:00:00+00:00/PT1H",
+          "validTime": "date:now +183 hours / PT1H",
           "value": 80
         },
         {
-          "validTime": "2024-02-28T03:00:00+00:00/PT1H",
+          "validTime": "date:now +184 hours / PT1H",
           "value": 84
         },
         {
-          "validTime": "2024-02-28T04:00:00+00:00/PT1H",
+          "validTime": "date:now +185 hours / PT1H",
           "value": 88
         },
         {
-          "validTime": "2024-02-28T05:00:00+00:00/PT1H",
+          "validTime": "date:now +186 hours / PT1H",
           "value": 91
         },
         {
-          "validTime": "2024-02-28T06:00:00+00:00/PT1H",
+          "validTime": "date:now +187 hours / PT1H",
           "value": 95
         },
         {
-          "validTime": "2024-02-28T07:00:00+00:00/PT1H",
+          "validTime": "date:now +188 hours / PT1H",
           "value": 98
         },
         {
-          "validTime": "2024-02-28T08:00:00+00:00/PT5H",
+          "validTime": "date:now +189 hours / PT5H",
           "value": 100
         }
       ]
@@ -1847,671 +1847,671 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +5 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +8 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +13 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
+          "validTime": "date:now +20 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT2H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +21 hours / PT2H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT2H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +23 hours / PT2H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
+          "validTime": "date:now +25 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 21.666666666666668
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +35 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
+          "validTime": "date:now +37 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT2H",
+          "validTime": "date:now +40 hours / PT2H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT2H",
-          "value": 16.111111111111111
+          "validTime": "date:now +42 hours / PT2H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT2H",
+          "validTime": "date:now +44 hours / PT2H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT2H",
+          "validTime": "date:now +46 hours / PT2H",
           "value": 15
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT4H",
+          "validTime": "date:now +48 hours / PT4H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +52 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +56 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT2H",
+          "validTime": "date:now +58 hours / PT2H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +71 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +72 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +74 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +76 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +79 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +80 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT2H",
-          "value": 18.888888888888889
+          "validTime": "date:now +82 hours / PT2H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
+          "validTime": "date:now +87 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
+          "validTime": "date:now +88 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +89 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +90 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +91 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +94 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +95 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT2H",
+          "validTime": "date:now +96 hours / PT2H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT2H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +98 hours / PT2H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT1H",
+          "validTime": "date:now +104 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT2H",
+          "validTime": "date:now +106 hours / PT2H",
           "value": 20
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +108 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +109 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +111 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +114 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +115 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +116 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +118 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +120 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +121 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +124 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +129 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT2H",
+          "validTime": "date:now +130 hours / PT2H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +136 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT1H",
+          "validTime": "date:now +137 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +138 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT1H",
+          "validTime": "date:now +140 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT2H",
-          "value": 13.888888888888889
+          "validTime": "date:now +142 hours / PT2H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT3H",
+          "validTime": "date:now +145 hours / PT3H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +149 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
+          "validTime": "date:now +150 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT2H",
-          "value": 23.888888888888889
+          "validTime": "date:now +154 hours / PT2H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +156 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +158 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT1H",
+          "validTime": "date:now +159 hours / PT1H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT2H",
+          "validTime": "date:now +160 hours / PT2H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +162 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT2H",
+          "validTime": "date:now +163 hours / PT2H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT2H",
-          "value": 17.777777777777779
+          "validTime": "date:now +165 hours / PT2H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT2H",
-          "value": 17.222222222222221
+          "validTime": "date:now +167 hours / PT2H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT3H",
+          "validTime": "date:now +169 hours / PT3H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
+          "validTime": "date:now +173 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +174 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +175 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +176 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT2H",
-          "value": 23.888888888888889
+          "validTime": "date:now +178 hours / PT2H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 21.666666666666668
         },
         {
-          "validTime": "2024-02-28T01:00:00+00:00/PT1H",
+          "validTime": "date:now +182 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-28T02:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +183 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-28T03:00:00+00:00/PT1H",
+          "validTime": "date:now +184 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-28T04:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +185 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-28T05:00:00+00:00/PT1H",
+          "validTime": "date:now +186 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-28T06:00:00+00:00/PT1H",
+          "validTime": "date:now +187 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-28T07:00:00+00:00/PT2H",
-          "value": 13.888888888888889
+          "validTime": "date:now +188 hours / PT2H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-28T09:00:00+00:00/PT1H",
+          "validTime": "date:now +190 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-28T10:00:00+00:00/PT1H",
+          "validTime": "date:now +191 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-28T11:00:00+00:00/PT1H",
+          "validTime": "date:now +192 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-28T12:00:00+00:00/PT1H",
+          "validTime": "date:now +193 hours / PT1H",
           "value": 11.666666666666666
         }
       ]
@@ -2520,567 +2520,567 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
-          "value": 0.55555555555555558
+          "validTime": "date:now +1 hours / PT1H",
+          "value": 0.5555555555555556
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +3 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +5 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT2H",
-          "value": 16.111111111111111
+          "validTime": "date:now +9 hours / PT2H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +15 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +17 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT3H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +20 hours / PT3H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT2H",
+          "validTime": "date:now +23 hours / PT2H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +25 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +31 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT3H",
+          "validTime": "date:now +32 hours / PT3H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +35 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT4H",
+          "validTime": "date:now +40 hours / PT4H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT4H",
-          "value": 13.888888888888889
+          "validTime": "date:now +44 hours / PT4H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT4H",
+          "validTime": "date:now +48 hours / PT4H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +54 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT3H",
+          "validTime": "date:now +57 hours / PT3H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +61 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": 11.111111111111111
+          "validTime": "date:now +66 hours / PT1H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT2H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +70 hours / PT2H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT2H",
+          "validTime": "date:now +72 hours / PT2H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +74 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +76 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT1H",
+          "validTime": "date:now +77 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT1H",
+          "validTime": "date:now +78 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +79 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT3H",
+          "validTime": "date:now +80 hours / PT3H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +83 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT1H",
+          "validTime": "date:now +86 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT1H",
-          "value": 9.4444444444444446
+          "validTime": "date:now +87 hours / PT1H",
+          "value": 9.444444444444445
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +88 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-24T04:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +89 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT2H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +90 hours / PT2H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT3H",
+          "validTime": "date:now +92 hours / PT3H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +95 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +96 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT2H",
+          "validTime": "date:now +97 hours / PT2H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +99 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
+          "validTime": "date:now +101 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
+          "validTime": "date:now +102 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT1H",
+          "validTime": "date:now +103 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-24T19:00:00+00:00/PT3H",
+          "validTime": "date:now +104 hours / PT3H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
+          "validTime": "date:now +107 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +108 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
+          "validTime": "date:now +109 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
+          "validTime": "date:now +111 hours / PT1H",
           "value": 10.555555555555555
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT2H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +113 hours / PT2H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-25T06:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +115 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +116 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT2H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +117 hours / PT2H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT3H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +120 hours / PT3H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": 8.8888888888888893
+          "validTime": "date:now +124 hours / PT1H",
+          "value": 8.88888888888889
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT2H",
+          "validTime": "date:now +129 hours / PT2H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT2H",
-          "value": 17.777777777777779
+          "validTime": "date:now +131 hours / PT2H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT1H",
+          "validTime": "date:now +134 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT1H",
+          "validTime": "date:now +135 hours / PT1H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +136 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT2H",
+          "validTime": "date:now +137 hours / PT2H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT2H",
+          "validTime": "date:now +140 hours / PT2H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT3H",
+          "validTime": "date:now +142 hours / PT3H",
           "value": 11.666666666666666
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT2H",
-          "value": 11.111111111111111
+          "validTime": "date:now +145 hours / PT2H",
+          "value": 11.11111111111111
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +147 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
-          "value": 13.888888888888889
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
+          "validTime": "date:now +149 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +150 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +151 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +152 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT2H",
+          "validTime": "date:now +153 hours / PT2H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
+          "validTime": "date:now +155 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +156 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
-          "value": 18.888888888888889
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 18.88888888888889
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT2H",
-          "value": 17.777777777777779
+          "validTime": "date:now +158 hours / PT2H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT2H",
-          "value": 17.222222222222221
+          "validTime": "date:now +160 hours / PT2H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT1H",
+          "validTime": "date:now +162 hours / PT1H",
           "value": 16.666666666666668
         },
         {
-          "validTime": "2024-02-27T06:00:00+00:00/PT4H",
-          "value": 16.111111111111111
+          "validTime": "date:now +163 hours / PT4H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT5H",
+          "validTime": "date:now +167 hours / PT5H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +172 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": 17.777777777777779
+          "validTime": "date:now +173 hours / PT1H",
+          "value": 17.77777777777778
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT4H",
+          "validTime": "date:now +175 hours / PT4H",
           "value": 20.555555555555557
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
+          "validTime": "date:now +179 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": 19.444444444444443
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 18.333333333333332
         },
         {
-          "validTime": "2024-02-28T01:00:00+00:00/PT1H",
-          "value": 17.222222222222221
+          "validTime": "date:now +182 hours / PT1H",
+          "value": 17.22222222222222
         },
         {
-          "validTime": "2024-02-28T02:00:00+00:00/PT1H",
-          "value": 16.111111111111111
+          "validTime": "date:now +183 hours / PT1H",
+          "value": 16.11111111111111
         },
         {
-          "validTime": "2024-02-28T03:00:00+00:00/PT1H",
+          "validTime": "date:now +184 hours / PT1H",
           "value": 15.555555555555555
         },
         {
-          "validTime": "2024-02-28T04:00:00+00:00/PT1H",
+          "validTime": "date:now +185 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-28T05:00:00+00:00/PT2H",
+          "validTime": "date:now +186 hours / PT2H",
           "value": 14.444444444444445
         },
         {
-          "validTime": "2024-02-28T07:00:00+00:00/PT2H",
-          "value": 13.888888888888889
+          "validTime": "date:now +188 hours / PT2H",
+          "value": 13.88888888888889
         },
         {
-          "validTime": "2024-02-28T09:00:00+00:00/PT1H",
+          "validTime": "date:now +190 hours / PT1H",
           "value": 13.333333333333334
         },
         {
-          "validTime": "2024-02-28T10:00:00+00:00/PT1H",
+          "validTime": "date:now +191 hours / PT1H",
           "value": 12.777777777777779
         },
         {
-          "validTime": "2024-02-28T11:00:00+00:00/PT1H",
+          "validTime": "date:now +192 hours / PT1H",
           "value": 12.222222222222221
         },
         {
-          "validTime": "2024-02-28T12:00:00+00:00/PT1H",
+          "validTime": "date:now +193 hours / PT1H",
           "value": 11.666666666666666
         }
       ]
@@ -3089,135 +3089,135 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/P1DT9H",
+          "validTime": "date:now +0 hours / P1DT9H",
           "value": null
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 21.666666666666668
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +35 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT19H",
+          "validTime": "date:now +36 hours / PT19H",
           "value": null
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +56 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT2H",
+          "validTime": "date:now +58 hours / PT2H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/P2DT19H",
+          "validTime": "date:now +61 hours / P2DT19H",
           "value": null
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +128 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +129 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT2H",
+          "validTime": "date:now +130 hours / PT2H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT17H",
+          "validTime": "date:now +134 hours / PT17H",
           "value": null
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +151 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT2H",
-          "value": 23.888888888888889
+          "validTime": "date:now +154 hours / PT2H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +156 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +157 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +158 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT15H",
+          "validTime": "date:now +159 hours / PT15H",
           "value": null
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
-          "value": 21.111111111111111
+          "validTime": "date:now +174 hours / PT1H",
+          "value": 21.11111111111111
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
-          "value": 22.222222222222221
+          "validTime": "date:now +175 hours / PT1H",
+          "value": 22.22222222222222
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT1H",
-          "value": 22.777777777777779
+          "validTime": "date:now +176 hours / PT1H",
+          "value": 22.77777777777778
         },
         {
-          "validTime": "2024-02-27T20:00:00+00:00/PT1H",
+          "validTime": "date:now +177 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT2H",
-          "value": 23.888888888888889
+          "validTime": "date:now +178 hours / PT2H",
+          "value": 23.88888888888889
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": 23.333333333333332
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
+          "validTime": "date:now +181 hours / PT1H",
           "value": 21.666666666666668
         },
         {
-          "validTime": "2024-02-28T01:00:00+00:00/PT12H",
+          "validTime": "date:now +182 hours / PT12H",
           "value": null
         }
       ]
@@ -3226,175 +3226,175 @@
       "uom": "wmoUnit:degC",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 2.2222222222222223
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 1.6666666666666667
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 2.7777777777777777
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +5 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT12H",
+          "validTime": "date:now +6 hours / PT12H",
           "value": null
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
-          "value": 8.3333333333333339
+          "validTime": "date:now +18 hours / PT1H",
+          "value": 8.333333333333334
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +19 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
+          "validTime": "date:now +20 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT2H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +21 hours / PT2H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT2H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +23 hours / PT2H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
+          "validTime": "date:now +25 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/P1DT17H",
+          "validTime": "date:now +28 hours / P1DT17H",
           "value": null
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +71 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +72 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +74 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-23T14:00:00+00:00/PT1H",
+          "validTime": "date:now +75 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T15:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +76 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-23T16:00:00+00:00/PT14H",
+          "validTime": "date:now +77 hours / PT14H",
           "value": null
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT1H",
-          "value": 7.7777777777777777
+          "validTime": "date:now +91 hours / PT1H",
+          "value": 7.777777777777778
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +92 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
-          "value": 6.1111111111111107
+          "validTime": "date:now +94 hours / PT1H",
+          "value": 6.111111111111111
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +95 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT2H",
+          "validTime": "date:now +96 hours / PT2H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT2H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +98 hours / PT2H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +100 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT15H",
+          "validTime": "date:now +101 hours / PT15H",
           "value": null
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
-          "value": 7.2222222222222223
+          "validTime": "date:now +116 hours / PT1H",
+          "value": 7.222222222222222
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 6.666666666666667
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
-          "value": 5.5555555555555554
+          "validTime": "date:now +118 hours / PT1H",
+          "value": 5.555555555555555
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
-          "value": 4.4444444444444446
+          "validTime": "date:now +120 hours / PT1H",
+          "value": 4.444444444444445
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +121 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 3.3333333333333335
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 3.8888888888888888
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 3.888888888888889
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/P2DT22H",
+          "validTime": "date:now +124 hours / P2DT22H",
           "value": null
         }
       ]
@@ -3403,575 +3403,575 @@
       "uom": "wmoUnit:percent",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 1
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT2H",
+          "validTime": "date:now +2 hours / PT2H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 1
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT2H",
+          "validTime": "date:now +5 hours / PT2H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT3H",
+          "validTime": "date:now +7 hours / PT3H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 1
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
+          "validTime": "date:now +14 hours / PT1H",
           "value": 2
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 11
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 8
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 11
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT2H",
+          "validTime": "date:now +18 hours / PT2H",
           "value": 13
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
+          "validTime": "date:now +20 hours / PT1H",
           "value": 12
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
+          "validTime": "date:now +22 hours / PT1H",
           "value": 16
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 31
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": 24
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
+          "validTime": "date:now +25 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 48
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 51
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
+          "validTime": "date:now +32 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
+          "validTime": "date:now +33 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT2H",
+          "validTime": "date:now +36 hours / PT2H",
           "value": 81
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
+          "validTime": "date:now +38 hours / PT1H",
           "value": 79
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
+          "validTime": "date:now +39 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 21
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
+          "validTime": "date:now +42 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT1H",
+          "validTime": "date:now +43 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT1H",
+          "validTime": "date:now +44 hours / PT1H",
           "value": 48
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
+          "validTime": "date:now +45 hours / PT1H",
           "value": 53
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
+          "validTime": "date:now +46 hours / PT1H",
           "value": 57
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
+          "validTime": "date:now +47 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
+          "validTime": "date:now +48 hours / PT1H",
           "value": 65
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
+          "validTime": "date:now +49 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
+          "validTime": "date:now +50 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
+          "validTime": "date:now +51 hours / PT1H",
           "value": 63
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
+          "validTime": "date:now +52 hours / PT1H",
           "value": 60
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 59
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT4H",
+          "validTime": "date:now +55 hours / PT4H",
           "value": 57
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 51
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 38
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 30
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 21
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
+          "validTime": "date:now +64 hours / PT1H",
           "value": 13
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 11
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
+          "validTime": "date:now +66 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 8
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
+          "validTime": "date:now +68 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
+          "validTime": "date:now +69 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT2H",
+          "validTime": "date:now +70 hours / PT2H",
           "value": 2
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT7H",
+          "validTime": "date:now +72 hours / PT7H",
           "value": 3
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT1H",
+          "validTime": "date:now +79 hours / PT1H",
           "value": 2
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT1H",
+          "validTime": "date:now +81 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T21:00:00+00:00/PT1H",
+          "validTime": "date:now +82 hours / PT1H",
           "value": 7
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
+          "validTime": "date:now +83 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
+          "validTime": "date:now +85 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT2H",
+          "validTime": "date:now +86 hours / PT2H",
           "value": 3
         },
         {
-          "validTime": "2024-02-24T03:00:00+00:00/PT2H",
+          "validTime": "date:now +88 hours / PT2H",
           "value": 2
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT2H",
+          "validTime": "date:now +90 hours / PT2H",
           "value": 1
         },
         {
-          "validTime": "2024-02-24T07:00:00+00:00/PT1H",
+          "validTime": "date:now +92 hours / PT1H",
           "value": 2
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT1H",
+          "validTime": "date:now +93 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-24T09:00:00+00:00/PT1H",
+          "validTime": "date:now +94 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-24T10:00:00+00:00/PT2H",
+          "validTime": "date:now +95 hours / PT2H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT1H",
+          "validTime": "date:now +97 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-24T13:00:00+00:00/PT1H",
+          "validTime": "date:now +98 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-24T14:00:00+00:00/PT1H",
+          "validTime": "date:now +99 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT8H",
+          "validTime": "date:now +100 hours / PT8H",
           "value": 3
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT2H",
+          "validTime": "date:now +108 hours / PT2H",
           "value": 4
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
+          "validTime": "date:now +111 hours / PT1H",
           "value": 6
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT2H",
+          "validTime": "date:now +112 hours / PT2H",
           "value": 7
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT2H",
+          "validTime": "date:now +114 hours / PT2H",
           "value": 8
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT1H",
+          "validTime": "date:now +116 hours / PT1H",
           "value": 10
         },
         {
-          "validTime": "2024-02-25T08:00:00+00:00/PT1H",
+          "validTime": "date:now +117 hours / PT1H",
           "value": 12
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
+          "validTime": "date:now +118 hours / PT1H",
           "value": 14
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT1H",
+          "validTime": "date:now +119 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT1H",
+          "validTime": "date:now +120 hours / PT1H",
           "value": 16
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
+          "validTime": "date:now +121 hours / PT1H",
           "value": 18
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
+          "validTime": "date:now +122 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
+          "validTime": "date:now +123 hours / PT1H",
           "value": 22
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 24
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 23
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
+          "validTime": "date:now +126 hours / PT1H",
           "value": 21
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT1H",
+          "validTime": "date:now +127 hours / PT1H",
           "value": 20
         },
         {
-          "validTime": "2024-02-25T19:00:00+00:00/PT2H",
+          "validTime": "date:now +128 hours / PT2H",
           "value": 19
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT1H",
+          "validTime": "date:now +130 hours / PT1H",
           "value": 18
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
+          "validTime": "date:now +131 hours / PT1H",
           "value": 19
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
+          "validTime": "date:now +132 hours / PT1H",
           "value": 21
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT2H",
+          "validTime": "date:now +133 hours / PT2H",
           "value": 22
         },
         {
-          "validTime": "2024-02-26T02:00:00+00:00/PT2H",
+          "validTime": "date:now +135 hours / PT2H",
           "value": 23
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT2H",
+          "validTime": "date:now +137 hours / PT2H",
           "value": 22
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT1H",
+          "validTime": "date:now +139 hours / PT1H",
           "value": 21
         },
         {
-          "validTime": "2024-02-26T07:00:00+00:00/PT1H",
+          "validTime": "date:now +140 hours / PT1H",
           "value": 24
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT1H",
+          "validTime": "date:now +141 hours / PT1H",
           "value": 26
         },
         {
-          "validTime": "2024-02-26T09:00:00+00:00/PT1H",
+          "validTime": "date:now +142 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-26T10:00:00+00:00/PT1H",
+          "validTime": "date:now +143 hours / PT1H",
           "value": 34
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT1H",
+          "validTime": "date:now +144 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT1H",
+          "validTime": "date:now +145 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
+          "validTime": "date:now +146 hours / PT1H",
           "value": 52
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +147 hours / PT1H",
           "value": 58
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT4H",
+          "validTime": "date:now +148 hours / PT4H",
           "value": 64
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
+          "validTime": "date:now +152 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT1H",
+          "validTime": "date:now +153 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-26T21:00:00+00:00/PT1H",
+          "validTime": "date:now +154 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-26T22:00:00+00:00/PT1H",
+          "validTime": "date:now +155 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
+          "validTime": "date:now +156 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT2H",
+          "validTime": "date:now +157 hours / PT2H",
           "value": 66
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT8H",
+          "validTime": "date:now +159 hours / PT8H",
           "value": 65
         },
         {
-          "validTime": "2024-02-27T10:00:00+00:00/PT1H",
+          "validTime": "date:now +167 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
+          "validTime": "date:now +168 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT1H",
+          "validTime": "date:now +169 hours / PT1H",
           "value": 73
         },
         {
-          "validTime": "2024-02-27T13:00:00+00:00/PT2H",
+          "validTime": "date:now +170 hours / PT2H",
           "value": 72
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
+          "validTime": "date:now +172 hours / PT1H",
           "value": 71
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
+          "validTime": "date:now +173 hours / PT1H",
           "value": 70
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
+          "validTime": "date:now +174 hours / PT1H",
           "value": 69
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT1H",
+          "validTime": "date:now +175 hours / PT1H",
           "value": 68
         },
         {
-          "validTime": "2024-02-27T19:00:00+00:00/PT2H",
+          "validTime": "date:now +176 hours / PT2H",
           "value": 67
         },
         {
-          "validTime": "2024-02-27T21:00:00+00:00/PT1H",
+          "validTime": "date:now +178 hours / PT1H",
           "value": 66
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
+          "validTime": "date:now +179 hours / PT1H",
           "value": 61
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
+          "validTime": "date:now +180 hours / PT1H",
           "value": 56
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT2H",
+          "validTime": "date:now +181 hours / PT2H",
           "value": 51
         },
         {
-          "validTime": "2024-02-28T02:00:00+00:00/PT1H",
+          "validTime": "date:now +183 hours / PT1H",
           "value": 50
         },
         {
-          "validTime": "2024-02-28T03:00:00+00:00/PT1H",
+          "validTime": "date:now +184 hours / PT1H",
           "value": 49
         },
         {
-          "validTime": "2024-02-28T04:00:00+00:00/PT1H",
+          "validTime": "date:now +185 hours / PT1H",
           "value": 48
         },
         {
-          "validTime": "2024-02-28T05:00:00+00:00/PT1H",
+          "validTime": "date:now +186 hours / PT1H",
           "value": 47
         },
         {
-          "validTime": "2024-02-28T06:00:00+00:00/PT2H",
+          "validTime": "date:now +187 hours / PT2H",
           "value": 46
         },
         {
-          "validTime": "2024-02-28T08:00:00+00:00/PT1H",
+          "validTime": "date:now +189 hours / PT1H",
           "value": 45
         },
         {
-          "validTime": "2024-02-28T09:00:00+00:00/PT1H",
+          "validTime": "date:now +190 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-28T10:00:00+00:00/PT1H",
+          "validTime": "date:now +191 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-28T11:00:00+00:00/PT1H",
+          "validTime": "date:now +192 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-28T12:00:00+00:00/PT1H",
+          "validTime": "date:now +193 hours / PT1H",
           "value": 41
         }
       ]
@@ -3980,267 +3980,267 @@
       "uom": "wmoUnit:degree_(angle)",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 140
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 130
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 210
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 180
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT2H",
+          "validTime": "date:now +14 hours / PT2H",
           "value": 150
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT4H",
+          "validTime": "date:now +17 hours / PT4H",
           "value": 150
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT5H",
+          "validTime": "date:now +22 hours / PT5H",
           "value": 150
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 170
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT3H",
+          "validTime": "date:now +30 hours / PT3H",
           "value": 210
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT3H",
+          "validTime": "date:now +33 hours / PT3H",
           "value": 200
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT4H",
+          "validTime": "date:now +36 hours / PT4H",
           "value": 190
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT7H",
+          "validTime": "date:now +42 hours / PT7H",
           "value": 200
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT4H",
+          "validTime": "date:now +49 hours / PT4H",
           "value": 210
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT2H",
+          "validTime": "date:now +54 hours / PT2H",
           "value": 230
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT2H",
+          "validTime": "date:now +57 hours / PT2H",
           "value": 250
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 320
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT3H",
+          "validTime": "date:now +63 hours / PT3H",
           "value": 330
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT3H",
+          "validTime": "date:now +66 hours / PT3H",
           "value": 340
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT9H",
+          "validTime": "date:now +69 hours / PT9H",
           "value": 330
         },
         {
-          "validTime": "2024-02-23T17:00:00+00:00/PT3H",
+          "validTime": "date:now +78 hours / PT3H",
           "value": 320
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT2H",
+          "validTime": "date:now +81 hours / PT2H",
           "value": 310
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
+          "validTime": "date:now +83 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT3H",
+          "validTime": "date:now +84 hours / PT3H",
           "value": 290
         },
         {
-          "validTime": "2024-02-24T02:00:00+00:00/PT3H",
+          "validTime": "date:now +87 hours / PT3H",
           "value": 280
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT3H",
+          "validTime": "date:now +90 hours / PT3H",
           "value": 270
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT3H",
+          "validTime": "date:now +93 hours / PT3H",
           "value": 280
         },
         {
-          "validTime": "2024-02-24T11:00:00+00:00/PT9H",
+          "validTime": "date:now +96 hours / PT9H",
           "value": 290
         },
         {
-          "validTime": "2024-02-24T20:00:00+00:00/PT1H",
+          "validTime": "date:now +105 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-24T21:00:00+00:00/PT1H",
+          "validTime": "date:now +106 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT1H",
+          "validTime": "date:now +107 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-24T23:00:00+00:00/PT1H",
+          "validTime": "date:now +108 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT1H",
+          "validTime": "date:now +109 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-25T01:00:00+00:00/PT1H",
+          "validTime": "date:now +110 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-25T02:00:00+00:00/PT1H",
+          "validTime": "date:now +111 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT1H",
+          "validTime": "date:now +112 hours / PT1H",
           "value": 180
         },
         {
-          "validTime": "2024-02-25T04:00:00+00:00/PT1H",
+          "validTime": "date:now +113 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-25T05:00:00+00:00/PT9H",
+          "validTime": "date:now +114 hours / PT9H",
           "value": 200
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT3H",
+          "validTime": "date:now +123 hours / PT3H",
           "value": 210
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT6H",
+          "validTime": "date:now +126 hours / PT6H",
           "value": 220
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT6H",
+          "validTime": "date:now +132 hours / PT6H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T05:00:00+00:00/PT3H",
+          "validTime": "date:now +138 hours / PT3H",
           "value": 220
         },
         {
-          "validTime": "2024-02-26T08:00:00+00:00/PT3H",
+          "validTime": "date:now +141 hours / PT3H",
           "value": 210
         },
         {
-          "validTime": "2024-02-26T11:00:00+00:00/PT12H",
+          "validTime": "date:now +144 hours / PT12H",
           "value": 200
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT9H",
+          "validTime": "date:now +156 hours / PT9H",
           "value": 190
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/P1DT5H",
+          "validTime": "date:now +165 hours / P1DT5H",
           "value": 200
         }
       ]
@@ -4249,331 +4249,331 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
-          "value": 1.8520000000000001
+          "validTime": "date:now +0 hours / PT2H",
+          "value": 1.852
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +2 hours / PT1H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT2H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +5 hours / PT2H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT5H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +8 hours / PT5H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT7H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +14 hours / PT7H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT6H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +21 hours / PT6H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT2H",
+          "validTime": "date:now +30 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT4H",
+          "validTime": "date:now +32 hours / PT4H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT3H",
+          "validTime": "date:now +36 hours / PT3H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +40 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT8H",
-          "value": 25.928000000000001
+          "validTime": "date:now +41 hours / PT8H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT7H",
-          "value": 29.632000000000001
+          "validTime": "date:now +49 hours / PT7H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +56 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +58 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT3H",
+          "validTime": "date:now +59 hours / PT3H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +63 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +65 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +66 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +68 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT2H",
+          "validTime": "date:now +70 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT2H",
+          "validTime": "date:now +72 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT6H",
+          "validTime": "date:now +74 hours / PT6H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
+          "validTime": "date:now +80 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT2H",
+          "validTime": "date:now +81 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
+          "validTime": "date:now +83 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +85 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT4H",
-          "value": 14.816000000000001
+          "validTime": "date:now +86 hours / PT4H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT3H",
+          "validTime": "date:now +90 hours / PT3H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT7H",
+          "validTime": "date:now +93 hours / PT7H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +101 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT4H",
+          "validTime": "date:now +103 hours / PT4H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +107 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT3H",
-          "value": 14.816000000000001
+          "validTime": "date:now +109 hours / PT3H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT4H",
-          "value": 16.667999999999999
+          "validTime": "date:now +112 hours / PT4H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT2H",
+          "validTime": "date:now +116 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT2H",
+          "validTime": "date:now +118 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-25T11:00:00+00:00/PT3H",
+          "validTime": "date:now +120 hours / PT3H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +124 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +125 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT4H",
-          "value": 29.632000000000001
+          "validTime": "date:now +126 hours / PT4H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +130 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +131 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
+          "validTime": "date:now +133 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT3H",
+          "validTime": "date:now +134 hours / PT3H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT2H",
+          "validTime": "date:now +137 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT7H",
-          "value": 16.667999999999999
+          "validTime": "date:now +139 hours / PT7H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
+          "validTime": "date:now +146 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
+          "validTime": "date:now +147 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
+          "validTime": "date:now +148 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +149 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +151 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT3H",
-          "value": 27.780000000000001
+          "validTime": "date:now +153 hours / PT3H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT3H",
-          "value": 25.928000000000001
+          "validTime": "date:now +156 hours / PT3H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-27T02:00:00+00:00/PT3H",
-          "value": 27.780000000000001
+          "validTime": "date:now +159 hours / PT3H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-27T05:00:00+00:00/PT3H",
-          "value": 29.632000000000001
+          "validTime": "date:now +162 hours / PT3H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT3H",
-          "value": 31.484000000000002
+          "validTime": "date:now +165 hours / PT3H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT5H",
-          "value": 29.632000000000001
+          "validTime": "date:now +168 hours / PT5H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT2H",
-          "value": 31.484000000000002
+          "validTime": "date:now +173 hours / PT2H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT4H",
-          "value": 33.335999999999999
+          "validTime": "date:now +175 hours / PT4H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT2H",
-          "value": 31.484000000000002
+          "validTime": "date:now +179 hours / PT2H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +181 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-28T01:00:00+00:00/PT2H",
-          "value": 27.780000000000001
+          "validTime": "date:now +182 hours / PT2H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-28T03:00:00+00:00/PT2H",
-          "value": 25.928000000000001
+          "validTime": "date:now +184 hours / PT2H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-28T05:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +186 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-28T07:00:00+00:00/PT2H",
+          "validTime": "date:now +188 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-28T09:00:00+00:00/PT2H",
+          "validTime": "date:now +190 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-28T11:00:00+00:00/PT2H",
+          "validTime": "date:now +192 hours / PT2H",
           "value": 18.52
         }
       ]
@@ -4582,451 +4582,451 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
-          "value": 1.8520000000000001
+          "validTime": "date:now +0 hours / PT2H",
+          "value": 1.852
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +3 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +5 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +7 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +8 hours / PT2H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT3H",
+          "validTime": "date:now +10 hours / PT3H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +13 hours / PT6H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT2H",
+          "validTime": "date:now +19 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT4H",
+          "validTime": "date:now +21 hours / PT4H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +25 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT2H",
-          "value": 31.484000000000002
+          "validTime": "date:now +30 hours / PT2H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +32 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +34 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +35 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +36 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
-          "value": 29.632000000000001
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT6H",
-          "value": 42.595999999999997
+          "validTime": "date:now +40 hours / PT6H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT2H",
+          "validTime": "date:now +46 hours / PT2H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +48 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
-          "value": 48.152000000000001
+          "validTime": "date:now +49 hours / PT6H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +58 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +59 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT2H",
-          "value": 35.188000000000002
+          "validTime": "date:now +60 hours / PT2H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
+          "validTime": "date:now +63 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT3H",
-          "value": 42.595999999999997
+          "validTime": "date:now +64 hours / PT3H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT2H",
+          "validTime": "date:now +67 hours / PT2H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +70 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +71 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +73 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-23T13:00:00+00:00/PT6H",
+          "validTime": "date:now +74 hours / PT6H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T19:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +80 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-23T20:00:00+00:00/PT2H",
-          "value": 35.188000000000002
+          "validTime": "date:now +81 hours / PT2H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-23T22:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +83 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-23T23:00:00+00:00/PT1H",
+          "validTime": "date:now +84 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +85 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T01:00:00+00:00/PT4H",
-          "value": 14.816000000000001
+          "validTime": "date:now +86 hours / PT4H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T05:00:00+00:00/PT3H",
+          "validTime": "date:now +90 hours / PT3H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T08:00:00+00:00/PT7H",
+          "validTime": "date:now +93 hours / PT7H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-24T15:00:00+00:00/PT1H",
+          "validTime": "date:now +100 hours / PT1H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-24T16:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +101 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-24T17:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +102 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT4H",
+          "validTime": "date:now +103 hours / PT4H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-24T22:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +107 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T00:00:00+00:00/PT3H",
-          "value": 14.816000000000001
+          "validTime": "date:now +109 hours / PT3H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-25T03:00:00+00:00/PT4H",
-          "value": 16.667999999999999
+          "validTime": "date:now +112 hours / PT4H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-25T07:00:00+00:00/PT2H",
+          "validTime": "date:now +116 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-25T09:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +118 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-25T10:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +119 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +121 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-25T13:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +122 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-25T14:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +123 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-25T15:00:00+00:00/PT1H",
+          "validTime": "date:now +124 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-25T16:00:00+00:00/PT1H",
+          "validTime": "date:now +125 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-25T17:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +126 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-25T18:00:00+00:00/PT2H",
-          "value": 48.152000000000001
+          "validTime": "date:now +127 hours / PT2H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-25T20:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +129 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-25T21:00:00+00:00/PT1H",
+          "validTime": "date:now +130 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-25T22:00:00+00:00/PT1H",
+          "validTime": "date:now +131 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-25T23:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +132 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +133 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-26T01:00:00+00:00/PT2H",
-          "value": 33.335999999999999
+          "validTime": "date:now +134 hours / PT2H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-26T03:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +136 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-26T04:00:00+00:00/PT2H",
+          "validTime": "date:now +137 hours / PT2H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-26T06:00:00+00:00/PT7H",
-          "value": 16.667999999999999
+          "validTime": "date:now +139 hours / PT7H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-26T13:00:00+00:00/PT1H",
+          "validTime": "date:now +146 hours / PT1H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-26T14:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +147 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-26T15:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +148 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-26T16:00:00+00:00/PT1H",
-          "value": 37.039999999999999
+          "validTime": "date:now +149 hours / PT1H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-26T17:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +150 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-26T18:00:00+00:00/PT1H",
+          "validTime": "date:now +151 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-26T19:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +152 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-26T20:00:00+00:00/PT3H",
+          "validTime": "date:now +153 hours / PT3H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-26T23:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +156 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT1H",
+          "validTime": "date:now +157 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-27T01:00:00+00:00/PT2H",
-          "value": 42.595999999999997
+          "validTime": "date:now +158 hours / PT2H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-27T03:00:00+00:00/PT1H",
+          "validTime": "date:now +160 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-27T04:00:00+00:00/PT3H",
-          "value": 46.299999999999997
+          "validTime": "date:now +161 hours / PT3H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-27T07:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +164 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-27T08:00:00+00:00/PT3H",
-          "value": 50.003999999999998
+          "validTime": "date:now +165 hours / PT3H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-27T11:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +168 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT3H",
-          "value": 46.299999999999997
+          "validTime": "date:now +169 hours / PT3H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-27T15:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +172 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-27T16:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +173 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-27T17:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +174 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-27T18:00:00+00:00/PT4H",
-          "value": 53.707999999999998
+          "validTime": "date:now +175 hours / PT4H",
+          "value": 53.708
         },
         {
-          "validTime": "2024-02-27T22:00:00+00:00/PT1H",
-          "value": 51.856000000000002
+          "validTime": "date:now +179 hours / PT1H",
+          "value": 51.856
         },
         {
-          "validTime": "2024-02-27T23:00:00+00:00/PT1H",
-          "value": 50.003999999999998
+          "validTime": "date:now +180 hours / PT1H",
+          "value": 50.004
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT1H",
-          "value": 48.152000000000001
+          "validTime": "date:now +181 hours / PT1H",
+          "value": 48.152
         },
         {
-          "validTime": "2024-02-28T01:00:00+00:00/PT1H",
-          "value": 46.299999999999997
+          "validTime": "date:now +182 hours / PT1H",
+          "value": 46.3
         },
         {
-          "validTime": "2024-02-28T02:00:00+00:00/PT1H",
+          "validTime": "date:now +183 hours / PT1H",
           "value": 44.448
         },
         {
-          "validTime": "2024-02-28T03:00:00+00:00/PT1H",
-          "value": 42.595999999999997
+          "validTime": "date:now +184 hours / PT1H",
+          "value": 42.596
         },
         {
-          "validTime": "2024-02-28T04:00:00+00:00/PT1H",
+          "validTime": "date:now +185 hours / PT1H",
           "value": 40.744
         },
         {
-          "validTime": "2024-02-28T05:00:00+00:00/PT1H",
-          "value": 38.892000000000003
+          "validTime": "date:now +186 hours / PT1H",
+          "value": 38.892
         },
         {
-          "validTime": "2024-02-28T06:00:00+00:00/PT2H",
-          "value": 37.039999999999999
+          "validTime": "date:now +187 hours / PT2H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-28T08:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +189 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-28T09:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +190 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-28T10:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +191 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-28T11:00:00+00:00/PT2H",
+          "validTime": "date:now +192 hours / PT2H",
           "value": 18.52
         }
       ]
@@ -5034,7 +5034,7 @@
     "weather": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/P2DT1H",
+          "validTime": "date:now +0 hours / P2DT1H",
           "value": [
             {
               "coverage": null,
@@ -5049,7 +5049,7 @@
           ]
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT12H",
+          "validTime": "date:now +49 hours / PT12H",
           "value": [
             {
               "coverage": "chance",
@@ -5074,7 +5074,7 @@
           ]
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/P3DT12H",
+          "validTime": "date:now +61 hours / P3DT12H",
           "value": [
             {
               "coverage": null,
@@ -5089,7 +5089,7 @@
           ]
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/P1D",
+          "validTime": "date:now +145 hours / P1D",
           "value": [
             {
               "coverage": "slight_chance",
@@ -5104,7 +5104,7 @@
           ]
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/P1DT1H",
+          "validTime": "date:now +169 hours / P1DT1H",
           "value": [
             {
               "coverage": "chance",
@@ -5127,55 +5127,55 @@
       "uom": "wmoUnit:percent",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/P1DT13H",
+          "validTime": "date:now +0 hours / P1DT13H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +37 hours / PT6H",
           "value": 2
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT6H",
+          "validTime": "date:now +43 hours / PT6H",
           "value": 9
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT12H",
+          "validTime": "date:now +49 hours / PT12H",
           "value": 32
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +61 hours / PT6H",
           "value": 6
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +67 hours / PT6H",
           "value": 3
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/P2D",
+          "validTime": "date:now +73 hours / P2D",
           "value": 0
         },
         {
-          "validTime": "2024-02-25T12:00:00+00:00/PT12H",
+          "validTime": "date:now +121 hours / PT12H",
           "value": 1
         },
         {
-          "validTime": "2024-02-26T00:00:00+00:00/PT12H",
+          "validTime": "date:now +133 hours / PT12H",
           "value": 3
         },
         {
-          "validTime": "2024-02-26T12:00:00+00:00/PT12H",
+          "validTime": "date:now +145 hours / PT12H",
           "value": 17
         },
         {
-          "validTime": "2024-02-27T00:00:00+00:00/PT12H",
+          "validTime": "date:now +157 hours / PT12H",
           "value": 21
         },
         {
-          "validTime": "2024-02-27T12:00:00+00:00/PT12H",
+          "validTime": "date:now +169 hours / PT12H",
           "value": 39
         },
         {
-          "validTime": "2024-02-28T00:00:00+00:00/PT13H",
+          "validTime": "date:now +181 hours / PT13H",
           "value": 31
         }
       ]
@@ -5184,79 +5184,79 @@
       "uom": "wmoUnit:mm",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT6H",
+          "validTime": "date:now +1 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +7 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
+          "validTime": "date:now +13 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT6H",
+          "validTime": "date:now +19 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +25 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +31 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +37 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT6H",
+          "validTime": "date:now +43 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
+          "validTime": "date:now +49 hours / PT6H",
           "value": 0.254
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +55 hours / PT6H",
           "value": 0.254
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +61 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +67 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +73 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT6H",
+          "validTime": "date:now +79 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +85 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT6H",
+          "validTime": "date:now +91 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT6H",
+          "validTime": "date:now +97 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT6H",
+          "validTime": "date:now +103 hours / PT6H",
           "value": 0
         }
       ]
@@ -5265,79 +5265,79 @@
       "uom": "wmoUnit:mm",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT6H",
+          "validTime": "date:now +1 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +7 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
+          "validTime": "date:now +13 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT6H",
+          "validTime": "date:now +19 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +25 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +31 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +37 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT6H",
+          "validTime": "date:now +43 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
+          "validTime": "date:now +49 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +55 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +61 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +67 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +73 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT6H",
+          "validTime": "date:now +79 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +85 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT6H",
+          "validTime": "date:now +91 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT6H",
+          "validTime": "date:now +97 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT6H",
+          "validTime": "date:now +103 hours / PT6H",
           "value": 0
         }
       ]
@@ -5346,79 +5346,79 @@
       "uom": "wmoUnit:mm",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT6H",
+          "validTime": "date:now +1 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT6H",
+          "validTime": "date:now +7 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT6H",
+          "validTime": "date:now +13 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT6H",
+          "validTime": "date:now +19 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT6H",
+          "validTime": "date:now +25 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT6H",
+          "validTime": "date:now +31 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT6H",
+          "validTime": "date:now +37 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT6H",
+          "validTime": "date:now +43 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT6H",
+          "validTime": "date:now +49 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT6H",
+          "validTime": "date:now +55 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT6H",
+          "validTime": "date:now +61 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT6H",
+          "validTime": "date:now +67 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT6H",
+          "validTime": "date:now +73 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-23T18:00:00+00:00/PT6H",
+          "validTime": "date:now +79 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T00:00:00+00:00/PT6H",
+          "validTime": "date:now +85 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T06:00:00+00:00/PT6H",
+          "validTime": "date:now +91 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T12:00:00+00:00/PT6H",
+          "validTime": "date:now +97 hours / PT6H",
           "value": 0
         },
         {
-          "validTime": "2024-02-24T18:00:00+00:00/PT6H",
+          "validTime": "date:now +103 hours / PT6H",
           "value": 0
         }
       ]
@@ -5436,143 +5436,143 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT3H",
+          "validTime": "date:now +0 hours / PT3H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT3H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +3 hours / PT3H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT2H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +6 hours / PT2H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT2H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +8 hours / PT2H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT2H",
+          "validTime": "date:now +10 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT3H",
-          "value": 9.2599999999999998
+          "validTime": "date:now +12 hours / PT3H",
+          "value": 9.26
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
+          "validTime": "date:now +15 hours / PT1H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT2H",
+          "validTime": "date:now +16 hours / PT2H",
           "value": 12.964
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT2H",
-          "value": 14.816000000000001
+          "validTime": "date:now +18 hours / PT2H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +20 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT3H",
+          "validTime": "date:now +21 hours / PT3H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +24 hours / PT2H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +27 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +28 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 33.335999999999999
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 33.336
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +31 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT2H",
-          "value": 37.039999999999999
+          "validTime": "date:now +32 hours / PT2H",
+          "value": 37.04
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
-          "value": 35.188000000000002
+          "validTime": "date:now +34 hours / PT1H",
+          "value": 35.188
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 31.484000000000002
+          "validTime": "date:now +35 hours / PT1H",
+          "value": 31.484
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
-          "value": 27.780000000000001
+          "validTime": "date:now +36 hours / PT1H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT3H",
-          "value": 24.076000000000001
+          "validTime": "date:now +37 hours / PT3H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +40 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT2H",
-          "value": 27.780000000000001
+          "validTime": "date:now +41 hours / PT2H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT13H",
-          "value": 29.632000000000001
+          "validTime": "date:now +43 hours / PT13H",
+          "value": 29.632
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT2H",
-          "value": 27.780000000000001
+          "validTime": "date:now +56 hours / PT2H",
+          "value": 27.78
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
-          "value": 25.928000000000001
+          "validTime": "date:now +58 hours / PT1H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +59 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT3H",
+          "validTime": "date:now +60 hours / PT3H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
-          "value": 24.076000000000001
+          "validTime": "date:now +63 hours / PT1H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT5H",
-          "value": 25.928000000000001
+          "validTime": "date:now +64 hours / PT5H",
+          "value": 25.928
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT2H",
-          "value": 24.076000000000001
+          "validTime": "date:now +69 hours / PT2H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT2H",
+          "validTime": "date:now +71 hours / PT2H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 20.372
         }
       ]
@@ -5581,103 +5581,103 @@
       "uom": "wmoUnit:degree_(angle)",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 210
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT4H",
+          "validTime": "date:now +4 hours / PT4H",
           "value": 250
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT2H",
+          "validTime": "date:now +9 hours / PT2H",
           "value": 270
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT5H",
+          "validTime": "date:now +13 hours / PT5H",
           "value": 170
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT8H",
+          "validTime": "date:now +18 hours / PT8H",
           "value": 180
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 190
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT3H",
+          "validTime": "date:now +27 hours / PT3H",
           "value": 200
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT18H",
+          "validTime": "date:now +30 hours / PT18H",
           "value": 210
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT5H",
+          "validTime": "date:now +48 hours / PT5H",
           "value": 220
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT2H",
+          "validTime": "date:now +54 hours / PT2H",
           "value": 240
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 260
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 280
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 320
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 330
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT6H",
+          "validTime": "date:now +63 hours / PT6H",
           "value": 340
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT5H",
+          "validTime": "date:now +69 hours / PT5H",
           "value": 330
         }
       ]
@@ -5686,295 +5686,295 @@
       "uom": "wmoUnit:m",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
-          "value": 109.72799999999999
+          "validTime": "date:now +0 hours / PT1H",
+          "value": 109.728
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 110.9472
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
-          "value": 94.183199999999999
+          "validTime": "date:now +2 hours / PT1H",
+          "value": 94.1832
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
-          "value": 97.231200000000001
+          "validTime": "date:now +3 hours / PT1H",
+          "value": 97.2312
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
-          "value": 153.00960000000001
+          "validTime": "date:now +4 hours / PT1H",
+          "value": 153.0096
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 293.5224
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
-          "value": 485.54640000000001
+          "validTime": "date:now +6 hours / PT1H",
+          "value": 485.5464
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
-          "value": 691.28639999999996
+          "validTime": "date:now +7 hours / PT1H",
+          "value": 691.2864
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 957.072
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 1174.0896
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
-          "value": 1223.1623999999999
+          "validTime": "date:now +10 hours / PT1H",
+          "value": 1223.1624
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
-          "value": 930.85919999999999
+          "validTime": "date:now +11 hours / PT1H",
+          "value": 930.8592
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
-          "value": 502.31040000000002
+          "validTime": "date:now +12 hours / PT1H",
+          "value": 502.3104
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 135.9408
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT1H",
-          "value": 42.976799999999997
+          "validTime": "date:now +14 hours / PT1H",
+          "value": 42.9768
         },
         {
-          "validTime": "2024-02-21T02:00:00+00:00/PT1H",
-          "value": 60.960000000000001
+          "validTime": "date:now +15 hours / PT1H",
+          "value": 60.96
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT1H",
+          "validTime": "date:now +16 hours / PT1H",
           "value": 113.0808
         },
         {
-          "validTime": "2024-02-21T04:00:00+00:00/PT1H",
+          "validTime": "date:now +17 hours / PT1H",
           "value": 111.5568
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT1H",
+          "validTime": "date:now +18 hours / PT1H",
           "value": 112.776
         },
         {
-          "validTime": "2024-02-21T06:00:00+00:00/PT1H",
+          "validTime": "date:now +19 hours / PT1H",
           "value": 115.2144
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT1H",
+          "validTime": "date:now +20 hours / PT1H",
           "value": 117.0432
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT1H",
+          "validTime": "date:now +21 hours / PT1H",
           "value": 119.1768
         },
         {
-          "validTime": "2024-02-21T09:00:00+00:00/PT1H",
+          "validTime": "date:now +22 hours / PT1H",
           "value": 121.0056
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 113.0808
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
-          "value": 109.11839999999999
+          "validTime": "date:now +24 hours / PT1H",
+          "value": 109.1184
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
+          "validTime": "date:now +25 hours / PT1H",
           "value": 121.92
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 146.304
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 196.596
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 284.0736
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 443.78879999999998
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 443.7888
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 621.79200000000003
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 621.792
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 759.8664
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT1H",
-          "value": 819.91200000000003
+          "validTime": "date:now +32 hours / PT1H",
+          "value": 819.912
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT1H",
-          "value": 818.08320000000003
+          "validTime": "date:now +33 hours / PT1H",
+          "value": 818.0832
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 758.952
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
-          "value": 635.50800000000004
+          "validTime": "date:now +35 hours / PT1H",
+          "value": 635.508
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 478.2312
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT1H",
-          "value": 341.37599999999998
+          "validTime": "date:now +37 hours / PT1H",
+          "value": 341.376
         },
         {
-          "validTime": "2024-02-22T01:00:00+00:00/PT1H",
-          "value": 276.14879999999999
+          "validTime": "date:now +38 hours / PT1H",
+          "value": 276.1488
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT1H",
-          "value": 247.19280000000001
+          "validTime": "date:now +39 hours / PT1H",
+          "value": 247.1928
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT1H",
+          "validTime": "date:now +40 hours / PT1H",
           "value": 240.1824
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 238.0488
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT1H",
-          "value": 247.80240000000001
+          "validTime": "date:now +42 hours / PT1H",
+          "value": 247.8024
         },
         {
-          "validTime": "2024-02-22T06:00:00+00:00/PT2H",
-          "value": 259.38479999999998
+          "validTime": "date:now +43 hours / PT2H",
+          "value": 259.3848
         },
         {
-          "validTime": "2024-02-22T08:00:00+00:00/PT1H",
-          "value": 258.47039999999998
+          "validTime": "date:now +45 hours / PT1H",
+          "value": 258.4704
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT1H",
-          "value": 259.99439999999998
+          "validTime": "date:now +46 hours / PT1H",
+          "value": 259.9944
         },
         {
-          "validTime": "2024-02-22T10:00:00+00:00/PT1H",
-          "value": 247.49760000000001
+          "validTime": "date:now +47 hours / PT1H",
+          "value": 247.4976
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT1H",
-          "value": 249.02160000000001
+          "validTime": "date:now +48 hours / PT1H",
+          "value": 249.0216
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
+          "validTime": "date:now +49 hours / PT1H",
           "value": 290.1696
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT1H",
-          "value": 404.16480000000001
+          "validTime": "date:now +50 hours / PT1H",
+          "value": 404.1648
         },
         {
-          "validTime": "2024-02-22T14:00:00+00:00/PT1H",
-          "value": 551.99279999999999
+          "validTime": "date:now +51 hours / PT1H",
+          "value": 551.9928
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT1H",
-          "value": 693.11519999999996
+          "validTime": "date:now +52 hours / PT1H",
+          "value": 693.1152
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 766.2672
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
-          "value": 831.49440000000004
+          "validTime": "date:now +54 hours / PT1H",
+          "value": 831.4944
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
-          "value": 925.98239999999998
+          "validTime": "date:now +55 hours / PT1H",
+          "value": 925.9824
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 1186.2816
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
-          "value": 1427.0735999999999
+          "validTime": "date:now +57 hours / PT1H",
+          "value": 1427.0736
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 1489.2528
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
-          "value": 1147.5719999999999
+          "validTime": "date:now +59 hours / PT1H",
+          "value": 1147.572
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
-          "value": 654.10080000000005
+          "validTime": "date:now +60 hours / PT1H",
+          "value": 654.1008
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 235.0008
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
-          "value": 132.28319999999999
+          "validTime": "date:now +62 hours / PT1H",
+          "value": 132.2832
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT1H",
-          "value": 157.27680000000001
+          "validTime": "date:now +63 hours / PT1H",
+          "value": 157.2768
         },
         {
-          "validTime": "2024-02-23T03:00:00+00:00/PT1H",
-          "value": 217.93199999999999
+          "validTime": "date:now +64 hours / PT1H",
+          "value": 217.932
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
-          "value": 209.70240000000001
+          "validTime": "date:now +65 hours / PT1H",
+          "value": 209.7024
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT1H",
-          "value": 199.94880000000001
+          "validTime": "date:now +66 hours / PT1H",
+          "value": 199.9488
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT1H",
+          "validTime": "date:now +67 hours / PT1H",
           "value": 188.976
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT1H",
-          "value": 174.65039999999999
+          "validTime": "date:now +68 hours / PT1H",
+          "value": 174.6504
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT1H",
-          "value": 160.62960000000001
+          "validTime": "date:now +69 hours / PT1H",
+          "value": 160.6296
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT1H",
+          "validTime": "date:now +70 hours / PT1H",
           "value": 149.9616
         },
         {
-          "validTime": "2024-02-23T10:00:00+00:00/PT1H",
+          "validTime": "date:now +71 hours / PT1H",
           "value": 145.9992
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 146.6088
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 149.0472
         }
       ]
@@ -5982,23 +5982,23 @@
     "hainesIndex": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT12H",
+          "validTime": "date:now +0 hours / PT12H",
           "value": 5
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/P1DT12H",
+          "validTime": "date:now +12 hours / P1DT12H",
           "value": 4
         },
         {
-          "validTime": "2024-02-22T11:00:00+00:00/PT6H",
+          "validTime": "date:now +48 hours / PT6H",
           "value": 3
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT12H",
+          "validTime": "date:now +54 hours / PT12H",
           "value": 4
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT8H",
+          "validTime": "date:now +66 hours / PT8H",
           "value": 5
         }
       ]
@@ -6010,88 +6010,88 @@
       "uom": "wmoUnit:km_h-1",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
-          "value": 1.8520000000000001
+          "validTime": "date:now +0 hours / PT2H",
+          "value": 1.852
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT2H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +2 hours / PT2H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT2H",
+          "validTime": "date:now +4 hours / PT2H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT2H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +6 hours / PT2H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT16H",
+          "validTime": "date:now +8 hours / PT16H",
           "value": 5.556
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT2H",
-          "value": 3.7040000000000002
+          "validTime": "date:now +24 hours / PT2H",
+          "value": 3.704
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
-          "value": 7.4080000000000004
+          "validTime": "date:now +26 hours / PT1H",
+          "value": 7.408
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT2H",
+          "validTime": "date:now +27 hours / PT2H",
           "value": 11.112
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
-          "value": 14.816000000000001
+          "validTime": "date:now +29 hours / PT1H",
+          "value": 14.816
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
-          "value": 16.667999999999999
+          "validTime": "date:now +30 hours / PT1H",
+          "value": 16.668
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT9H",
+          "validTime": "date:now +31 hours / PT9H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-22T03:00:00+00:00/PT9H",
+          "validTime": "date:now +40 hours / PT9H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT7H",
-          "value": 24.076000000000001
+          "validTime": "date:now +49 hours / PT7H",
+          "value": 24.076
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT5H",
+          "validTime": "date:now +58 hours / PT5H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT2H",
+          "validTime": "date:now +63 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT1H",
+          "validTime": "date:now +65 hours / PT1H",
           "value": 22.224
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT2H",
+          "validTime": "date:now +66 hours / PT2H",
           "value": 20.372
         },
         {
-          "validTime": "2024-02-23T07:00:00+00:00/PT4H",
+          "validTime": "date:now +68 hours / PT4H",
           "value": 18.52
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT2H",
-          "value": 16.667999999999999
+          "validTime": "date:now +72 hours / PT2H",
+          "value": 16.668
         }
       ]
     },
@@ -6099,147 +6099,147 @@
       "uom": "wmoUnit:degree_(angle)",
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 140
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT1H",
+          "validTime": "date:now +1 hours / PT1H",
           "value": 130
         },
         {
-          "validTime": "2024-02-20T13:00:00+00:00/PT1H",
+          "validTime": "date:now +2 hours / PT1H",
           "value": 160
         },
         {
-          "validTime": "2024-02-20T14:00:00+00:00/PT1H",
+          "validTime": "date:now +3 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT2H",
+          "validTime": "date:now +4 hours / PT2H",
           "value": 230
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 250
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 230
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 180
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT1H",
+          "validTime": "date:now +13 hours / PT1H",
           "value": 170
         },
         {
-          "validTime": "2024-02-21T01:00:00+00:00/PT4H",
+          "validTime": "date:now +14 hours / PT4H",
           "value": 160
         },
         {
-          "validTime": "2024-02-21T05:00:00+00:00/PT3H",
+          "validTime": "date:now +18 hours / PT3H",
           "value": 150
         },
         {
-          "validTime": "2024-02-21T08:00:00+00:00/PT5H",
+          "validTime": "date:now +21 hours / PT5H",
           "value": 140
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 150
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 180
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT2H",
+          "validTime": "date:now +28 hours / PT2H",
           "value": 190
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 200
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT2H",
+          "validTime": "date:now +31 hours / PT2H",
           "value": 210
         },
         {
-          "validTime": "2024-02-21T20:00:00+00:00/PT3H",
+          "validTime": "date:now +33 hours / PT3H",
           "value": 200
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT6H",
+          "validTime": "date:now +36 hours / PT6H",
           "value": 190
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT7H",
+          "validTime": "date:now +42 hours / PT7H",
           "value": 200
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT4H",
+          "validTime": "date:now +49 hours / PT4H",
           "value": 210
         },
         {
-          "validTime": "2024-02-22T16:00:00+00:00/PT1H",
+          "validTime": "date:now +53 hours / PT1H",
           "value": 220
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT2H",
+          "validTime": "date:now +54 hours / PT2H",
           "value": 230
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 240
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT2H",
+          "validTime": "date:now +57 hours / PT2H",
           "value": 250
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 270
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 300
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 310
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 320
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT3H",
+          "validTime": "date:now +63 hours / PT3H",
           "value": 330
         },
         {
-          "validTime": "2024-02-23T05:00:00+00:00/PT3H",
+          "validTime": "date:now +66 hours / PT3H",
           "value": 340
         },
         {
-          "validTime": "2024-02-23T08:00:00+00:00/PT5H",
+          "validTime": "date:now +69 hours / PT5H",
           "value": 330
         }
       ]
@@ -6319,199 +6319,199 @@
     "davisStabilityIndex": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT3H",
+          "validTime": "date:now +1 hours / PT3H",
           "value": 6
         },
         {
-          "validTime": "2024-02-20T15:00:00+00:00/PT1H",
+          "validTime": "date:now +4 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-20T16:00:00+00:00/PT1H",
+          "validTime": "date:now +5 hours / PT1H",
           "value": 7
         },
         {
-          "validTime": "2024-02-20T17:00:00+00:00/PT1H",
+          "validTime": "date:now +6 hours / PT1H",
           "value": 8
         },
         {
-          "validTime": "2024-02-20T18:00:00+00:00/PT1H",
+          "validTime": "date:now +7 hours / PT1H",
           "value": 9
         },
         {
-          "validTime": "2024-02-20T19:00:00+00:00/PT1H",
+          "validTime": "date:now +8 hours / PT1H",
           "value": 12
         },
         {
-          "validTime": "2024-02-20T20:00:00+00:00/PT1H",
+          "validTime": "date:now +9 hours / PT1H",
           "value": 17
         },
         {
-          "validTime": "2024-02-20T21:00:00+00:00/PT1H",
+          "validTime": "date:now +10 hours / PT1H",
           "value": 19
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 11
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT3H",
+          "validTime": "date:now +13 hours / PT3H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T03:00:00+00:00/PT4H",
+          "validTime": "date:now +16 hours / PT4H",
           "value": 4
         },
         {
-          "validTime": "2024-02-21T07:00:00+00:00/PT5H",
+          "validTime": "date:now +20 hours / PT5H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT1H",
+          "validTime": "date:now +25 hours / PT1H",
           "value": 9
         },
         {
-          "validTime": "2024-02-21T13:00:00+00:00/PT1H",
+          "validTime": "date:now +26 hours / PT1H",
           "value": 11
         },
         {
-          "validTime": "2024-02-21T14:00:00+00:00/PT1H",
+          "validTime": "date:now +27 hours / PT1H",
           "value": 13
         },
         {
-          "validTime": "2024-02-21T15:00:00+00:00/PT1H",
+          "validTime": "date:now +28 hours / PT1H",
           "value": 23
         },
         {
-          "validTime": "2024-02-21T16:00:00+00:00/PT1H",
+          "validTime": "date:now +29 hours / PT1H",
           "value": 34
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT1H",
+          "validTime": "date:now +30 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-21T18:00:00+00:00/PT1H",
+          "validTime": "date:now +31 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-21T19:00:00+00:00/PT2H",
+          "validTime": "date:now +32 hours / PT2H",
           "value": 51
         },
         {
-          "validTime": "2024-02-21T21:00:00+00:00/PT1H",
+          "validTime": "date:now +34 hours / PT1H",
           "value": 44
         },
         {
-          "validTime": "2024-02-21T22:00:00+00:00/PT1H",
+          "validTime": "date:now +35 hours / PT1H",
           "value": 40
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT1H",
+          "validTime": "date:now +36 hours / PT1H",
           "value": 30
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT2H",
+          "validTime": "date:now +37 hours / PT2H",
           "value": 13
         },
         {
-          "validTime": "2024-02-22T02:00:00+00:00/PT2H",
+          "validTime": "date:now +39 hours / PT2H",
           "value": 14
         },
         {
-          "validTime": "2024-02-22T04:00:00+00:00/PT1H",
+          "validTime": "date:now +41 hours / PT1H",
           "value": 15
         },
         {
-          "validTime": "2024-02-22T05:00:00+00:00/PT2H",
+          "validTime": "date:now +42 hours / PT2H",
           "value": 16
         },
         {
-          "validTime": "2024-02-22T07:00:00+00:00/PT2H",
+          "validTime": "date:now +44 hours / PT2H",
           "value": 17
         },
         {
-          "validTime": "2024-02-22T09:00:00+00:00/PT3H",
+          "validTime": "date:now +46 hours / PT3H",
           "value": 16
         },
         {
-          "validTime": "2024-02-22T12:00:00+00:00/PT1H",
+          "validTime": "date:now +49 hours / PT1H",
           "value": 25
         },
         {
-          "validTime": "2024-02-22T13:00:00+00:00/PT2H",
+          "validTime": "date:now +50 hours / PT2H",
           "value": 33
         },
         {
-          "validTime": "2024-02-22T15:00:00+00:00/PT2H",
+          "validTime": "date:now +52 hours / PT2H",
           "value": 37
         },
         {
-          "validTime": "2024-02-22T17:00:00+00:00/PT1H",
+          "validTime": "date:now +54 hours / PT1H",
           "value": 42
         },
         {
-          "validTime": "2024-02-22T18:00:00+00:00/PT1H",
+          "validTime": "date:now +55 hours / PT1H",
           "value": 41
         },
         {
-          "validTime": "2024-02-22T19:00:00+00:00/PT1H",
+          "validTime": "date:now +56 hours / PT1H",
           "value": 48
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT1H",
+          "validTime": "date:now +57 hours / PT1H",
           "value": 46
         },
         {
-          "validTime": "2024-02-22T21:00:00+00:00/PT1H",
+          "validTime": "date:now +58 hours / PT1H",
           "value": 43
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT1H",
+          "validTime": "date:now +59 hours / PT1H",
           "value": 41
         },
         {
-          "validTime": "2024-02-22T23:00:00+00:00/PT1H",
+          "validTime": "date:now +60 hours / PT1H",
           "value": 29
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT1H",
+          "validTime": "date:now +61 hours / PT1H",
           "value": 12
         },
         {
-          "validTime": "2024-02-23T01:00:00+00:00/PT1H",
+          "validTime": "date:now +62 hours / PT1H",
           "value": 13
         },
         {
-          "validTime": "2024-02-23T02:00:00+00:00/PT2H",
+          "validTime": "date:now +63 hours / PT2H",
           "value": 14
         },
         {
-          "validTime": "2024-02-23T04:00:00+00:00/PT2H",
+          "validTime": "date:now +65 hours / PT2H",
           "value": 15
         },
         {
-          "validTime": "2024-02-23T06:00:00+00:00/PT3H",
+          "validTime": "date:now +67 hours / PT3H",
           "value": 14
         },
         {
-          "validTime": "2024-02-23T09:00:00+00:00/PT2H",
+          "validTime": "date:now +70 hours / PT2H",
           "value": 13
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 12
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 11
         }
       ]
@@ -6522,15 +6522,15 @@
     "lowVisibilityOccurrenceRiskIndex": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT2H",
+          "validTime": "date:now +0 hours / PT2H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT13H",
+          "validTime": "date:now +13 hours / PT13H",
           "value": 5
         },
         {
-          "validTime": "2024-02-22T00:00:00+00:00/PT13H",
+          "validTime": "date:now +37 hours / PT13H",
           "value": 4
         }
       ]
@@ -6538,63 +6538,63 @@
     "stability": {
       "values": [
         {
-          "validTime": "2024-02-20T11:00:00+00:00/PT1H",
+          "validTime": "date:now +0 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T12:00:00+00:00/PT10H",
+          "validTime": "date:now +1 hours / PT10H",
           "value": 2
         },
         {
-          "validTime": "2024-02-20T22:00:00+00:00/PT1H",
+          "validTime": "date:now +11 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-20T23:00:00+00:00/PT1H",
+          "validTime": "date:now +12 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T00:00:00+00:00/PT10H",
+          "validTime": "date:now +13 hours / PT10H",
           "value": 6
         },
         {
-          "validTime": "2024-02-21T10:00:00+00:00/PT1H",
+          "validTime": "date:now +23 hours / PT1H",
           "value": 5
         },
         {
-          "validTime": "2024-02-21T11:00:00+00:00/PT1H",
+          "validTime": "date:now +24 hours / PT1H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T12:00:00+00:00/PT5H",
+          "validTime": "date:now +25 hours / PT5H",
           "value": 2
         },
         {
-          "validTime": "2024-02-21T17:00:00+00:00/PT6H",
+          "validTime": "date:now +30 hours / PT6H",
           "value": 3
         },
         {
-          "validTime": "2024-02-21T23:00:00+00:00/PT21H",
+          "validTime": "date:now +36 hours / PT21H",
           "value": 4
         },
         {
-          "validTime": "2024-02-22T20:00:00+00:00/PT2H",
+          "validTime": "date:now +57 hours / PT2H",
           "value": 3
         },
         {
-          "validTime": "2024-02-22T22:00:00+00:00/PT2H",
+          "validTime": "date:now +59 hours / PT2H",
           "value": 4
         },
         {
-          "validTime": "2024-02-23T00:00:00+00:00/PT11H",
+          "validTime": "date:now +61 hours / PT11H",
           "value": 5
         },
         {
-          "validTime": "2024-02-23T11:00:00+00:00/PT1H",
+          "validTime": "date:now +72 hours / PT1H",
           "value": 4
         },
         {
-          "validTime": "2024-02-23T12:00:00+00:00/PT1H",
+          "validTime": "date:now +73 hours / PT1H",
           "value": 3
         }
       ]

--- a/tests/api/serve.js
+++ b/tests/api/serve.js
@@ -47,6 +47,13 @@ const processDates = (obj) => {
       } else {
         obj[key] = now.format();
       }
+
+      const [, duration] = value.split(" / ");
+      if (duration) {
+        obj[key] = `${obj[key]}/${duration}`;
+
+        console.log(`modified time for ${key}: ${obj[key]}`);
+      }
     }
   });
 };

--- a/tests/pages.json
+++ b/tests/pages.json
@@ -2,5 +2,13 @@
   { "name": "front page", "url": "/" },
   { "name": "login page", "url": "/user/login" },
   { "name": "location page with alerts", "url": "/point/33.521/-86.812" },
+  {
+    "name": "location page with alerts (today tab)",
+    "url": "/point/33.521/-86.812#today"
+  },
+  {
+    "name": "location page with alerts (daily tab)",
+    "url": "/point/33.521/-86.812#daily"
+  },
   { "name": "location page without alerts", "url": "/point/35.198/-111.651" }
 ]

--- a/web/modules/weather_blocks/src/Plugin/Block/HourlyPrecipitationBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/HourlyPrecipitationBlock.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\weather_blocks\Plugin\Block;
+
+/**
+ * Provides a block of the hourly forecast precipitation.
+ *
+ * @Block(
+ *   id = "weathergov_hourly_precipitation",
+ *   admin_label = @Translation("Hourly precipitation block"),
+ *   category = @Translation("weather.gov"),
+ * )
+ */
+class HourlyPrecipitationBlock extends WeatherBlockBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function build()
+    {
+        $location = $this->getLocation();
+
+        if ($location->grid) {
+            $grid = $location->grid;
+
+            try {
+                $data = $this->weatherData->getHourlyPrecipitation(
+                    $grid->wfo,
+                    $grid->x,
+                    $grid->y,
+                );
+
+                return ["periods" => array_slice($data, 0, 3)];
+            } catch (\Throwable $e) {
+                return ["error" => true];
+            }
+        }
+    }
+}

--- a/web/modules/weather_data/src/Service/Test/GetHourlyPrecipitation.php.test
+++ b/web/modules/weather_data/src/Service/Test/GetHourlyPrecipitation.php.test
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\weather_data\Service\Test;
+
+final class GetHourlyPrecipitationTest extends Base
+{
+    /**
+     * The static time used for testing
+     *
+     * @var now
+     */
+    protected $now;
+
+    /**
+     * Basic test case setup
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Following the other testing conventions,
+        // we use an established timestamp for 'now'.
+        date_default_timezone_set("America/New_York");
+        $this->now = \DateTimeImmutable::createFromFormat(
+            \DateTimeInterface::ISO8601_EXPANDED,
+            "2023-11-27T12:00:00-7:00",
+        );
+    }
+
+    public function testHappyPaht(): void
+    {
+        $this->selfMock
+            ->method("getPlaceFromGrid")
+            ->will(
+                $this->returnValueMap([
+                    [
+                        "THE WFO",
+                        17,
+                        94,
+                        false,
+                        (object) ["timezone" => "America/Phoenix"],
+                    ],
+                ]),
+            );
+
+        $this->selfMock->method("getFromWeatherAPI")->will(
+            $this->returnValueMap([
+                [
+                    "/gridpoints/THE WFO/17,94",
+                    1,
+                    75,
+                    (object) [
+                        "properties" => (object) [
+                            "quantitativePrecipitation" => (object) [
+                                "values" => [
+                                    (object) [
+                                        "validTime" =>
+                                            "2023-11-27T12:00:00+00:00/PT6H",
+                                        "value" => 19.3,
+                                    ],
+                                    (object) [
+                                        "validTime" =>
+                                            "2023-11-27T18:00:00+00:00/PT6H",
+                                        "value" => 37.12351,
+                                    ],
+                                    (object) [
+                                        "validTime" =>
+                                            "2023-11-28T00:00:00+00:00/PT3H",
+                                        "value" => 932,
+                                    ],
+                                    (object) [
+                                        "validTime" =>
+                                            "2023-11-28T03:00:00+00:00/PT4H",
+                                        "value" => 0,
+                                    ],
+                                    (object) [
+                                        "validTime" =>
+                                            "2023-11-28T07:00:00+00:00/PT6H",
+                                        "value" => 19.3,
+                                    ],
+                                    (object) [
+                                        "validTime" =>
+                                            "2023-11-28T13:00:00+00:00/PT6H",
+                                        "value" => 0.325,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        );
+
+        $expected = [
+            (object) ["start" => "11 AM", "end" => "5 PM", "value" => 1.5],
+            (object) ["start" => "5 PM", "end" => "8 PM", "value" => 36.7],
+            (object) ["start" => "8 PM", "end" => "12 AM", "value" => 0],
+            (object) ["start" => "12 AM", "end" => "6 AM", "value" => 0.8],
+            (object) ["start" => "6 AM", "end" => "12 PM", "value" => 0],
+        ];
+
+        $actual = $this->weatherDataService->getHourlyPrecipitation(
+            "The Wfo",
+            17,
+            94,
+            $this->now,
+            $this->selfMock,
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/web/modules/weather_data/src/Service/UnitConversionTrait.php
+++ b/web/modules/weather_data/src/Service/UnitConversionTrait.php
@@ -7,6 +7,11 @@ namespace Drupal\weather_data\Service;
  */
 trait UnitConversionTrait
 {
+    public function getLengthScalar($length, bool $inInches = true)
+    {
+        return 17;
+    }
+
     /**
      * Get a temperature scalar from a wmoUnit temperature object.
      */

--- a/web/modules/weather_data/src/Service/UnitConversionTrait.php
+++ b/web/modules/weather_data/src/Service/UnitConversionTrait.php
@@ -7,11 +7,6 @@ namespace Drupal\weather_data\Service;
  */
 trait UnitConversionTrait
 {
-    public function getLengthScalar($length, bool $inInches = true)
-    {
-        return 17;
-    }
-
     /**
      * Get a temperature scalar from a wmoUnit temperature object.
      */

--- a/web/modules/weather_data/src/Service/UnitConversionTrait.php
+++ b/web/modules/weather_data/src/Service/UnitConversionTrait.php
@@ -7,6 +7,12 @@ namespace Drupal\weather_data\Service;
  */
 trait UnitConversionTrait
 {
+    public function millimetersToInches($mm)
+    {
+        // 1 mm = 0.03937008 inches
+        return $mm * 0.03937008;
+    }
+
     /**
      * Get a temperature scalar from a wmoUnit temperature object.
      */

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -686,6 +686,7 @@ class WeatherDataService
         foreach ($forecast->quantitativePrecipitation->values as $quantPrecip) {
             $valid = $quantPrecip->validTime;
             $value = $quantPrecip->value;
+            $value = $this->millimetersToInches($value);
 
             $valid = explode("/", $valid);
             $start = \DateTimeImmutable::createFromFormat(
@@ -700,7 +701,7 @@ class WeatherDataService
                 $periods[] = (object) [
                     "start" => $start->format("g A"),
                     "end" => $end->format("g A"),
-                    "value" => round($value * 0.03937008, 1),
+                    "value" => round($value, 1),
                 ];
             }
         }

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -678,7 +678,7 @@ class WeatherDataService
         $place = $self->getPlaceFromGrid($wfo, $gridX, $gridY);
         $timezone = $place->timezone;
 
-        $forecast = $this->getFromWeatherAPI("/gridpoints/$wfo/$gridX,$gridY")
+        $forecast = $self->getFromWeatherAPI("/gridpoints/$wfo/$gridX,$gridY")
             ->properties;
 
         $periods = [];

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -657,6 +657,57 @@ class WeatherDataService
         ];
     }
 
+    public function getHourlyPrecipitation(
+        $wfo,
+        $gridX,
+        $gridY,
+        $now = false,
+        $self = false,
+    ) {
+        date_default_timezone_set("America/New_York");
+
+        if (!$self) {
+            $self = $this;
+        }
+
+        $wfo = strtoupper($wfo);
+        if (!($now instanceof \DateTimeImmutable)) {
+            $now = new \DateTimeImmutable();
+        }
+
+        $place = $self->getPlaceFromGrid($wfo, $gridX, $gridY);
+        $timezone = $place->timezone;
+
+        $forecast = $this->getFromWeatherAPI("/gridpoints/$wfo/$gridX,$gridY")
+            ->properties;
+
+        $periods = [];
+
+        foreach ($forecast->quantitativePrecipitation->values as $quantPrecip) {
+            $valid = $quantPrecip->validTime;
+            $value = $quantPrecip->value;
+
+            $valid = explode("/", $valid);
+            $start = \DateTimeImmutable::createFromFormat(
+                \DateTimeInterface::ISO8601_EXPANDED,
+                $valid[0],
+            )->setTimeZone(new \DateTimeZone($timezone));
+
+            $duration = new \DateInterval($valid[1]);
+            $end = $start->add($duration);
+
+            if ($end >= $now) {
+                $periods[] = (object) [
+                    "start" => $start->format("g A"),
+                    "end" => $end->format("g A"),
+                    "value" => round($value * 0.03937008, 1),
+                ];
+            }
+        }
+
+        return $periods;
+    }
+
     /**
      * Get the hourly forecast for a location.
      *

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
@@ -1,5 +1,4 @@
 <div class="hourly-forecast-block tablet:grid-col-6 mobile-lg:grid-col-8">
-  <h2>{{ "Hourly forecast" | t }}</h2>
   {% if content.error %}
   {% set message = "There was an error loading the hourly forecast." | t %}
   {% include '@new_weather_theme/partials/uswds-alert.html.twig' with { 'level': "error", body: message } %}

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-precipitation.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-precipitation.html.twig
@@ -2,12 +2,21 @@
 <div class="margin-bottom-4">
 <h3>{{ "Precipitation amounts" |t }}</h3>
 <table class="margin-bottom-1">
+  <caption class="usa-sr-only">{{ "precipitation amounts for the coming hours" | t }}
+  <thead class="usa-sr-only">
+    <tr>
+      <th scope="col">{{ "time period" | t }}</th>
+      <th scope="col">{{ "forecast precipitation" | t }}</th>
+    </tr>
+  </thead>
+  <tbody>
   {% for hour in content.periods %}
   <tr>
     <td class="text-gray-50 padding-right-1">{{ hour.start }} - {{ hour.end }}:</td>
     <td>{{ hour.value }} {{ "inches" | t }}</td>
   </tr>
   {% endfor %}
+  </tbody>
 </table>
 <a href="#">{{ "What do these amounts mean" | t }} ></a>
 </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-precipitation.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-precipitation.html.twig
@@ -1,0 +1,14 @@
+{% if content.periods %}
+<div class="margin-bottom-4">
+<h3>{{ "Precipitation amounts" |t }}</h3>
+<table class="margin-bottom-1">
+  {% for hour in content.periods %}
+  <tr>
+    <td class="text-gray-50 padding-right-1">{{ hour.start }} - {{ hour.end }}:</td>
+    <td>{{ hour.value }} {{ "inches" | t }}</td>
+  </tr>
+  {% endfor %}
+</table>
+<a href="#">{{ "What do these amounts mean" | t }} ></a>
+</div>
+{% endif %}

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-weather-story.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-weather-story.html.twig
@@ -1,6 +1,6 @@
 {% if content.title %}
 {{ attach_library("new_weather_theme/localize-timestamps") }}
-<div data-wx-weather-story>
+<div data-wx-weather-story class="margin-bottom-4">
   <h2>{{ "Weather story" | t }}</h2>
   <p class="text-gray-50">{{ "Last updated" | t }}:
     <time datetime="{{ content.updated.utc }}" data-wx-local-time data-date-format="M d Y T">

--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -50,7 +50,11 @@
         </div>
         <div class="tab-container" id="today"  role="tabpanel" aria-labelledby="today-tab-button" tabindex="0">
           {{ drupal_block("weathergov_weather_story") }}
+
+          <h2 class="margin-0">{{ "Hourly forecast" | t }}</h2>
+          {{ drupal_block("weathergov_hourly_precipitation") }}
           {{ drupal_block("weathergov_hourly_forecast") }}
+
           {{ drupal_block("weathergov_wfo_promo") }}
         </div>
         <div class="tab-container" id="daily" role="tabpanel" aria-labelledby="daily-tab-button" tabindex="0">


### PR DESCRIPTION
## What does this PR do? 🛠️

- adds a `getHourlyPrecipitation` method to the data service, using the `/gridpoints/{wfo}/{x},{y}` endpoint
- adds an hourly precipitation block that puts the next 3 6-hour chunks of precipitation into a table
  - the first of these chunks may actually start in the past; I filter out the ones that ***end*** in the past
- removes the "hourly forecast" heading from the hourly forecast block and puts it in the page template, since where it sits may be independent of the hourly forecast block
- adds the hourly precipitation block to the today tab

> [!NOTE]  
> It might be worth holding this one until there's meaningful rain in someone's forecast so we can double-check that it's working? I feel good about it with the tests, but it'd be nice to see it working in the real world.

closes #796

## Screenshots (if appropriate): 📸

<img width="539" alt="image" src="https://github.com/weather-gov/weather.gov/assets/142943695/5a2142ca-ba33-47bc-8f89-96a91c070f06">
