### PR TITLE
Add snow squall warning to land hazards

### DIFF
--- a/web/modules/weather_data/src/Service/AlertPriority.php
+++ b/web/modules/weather_data/src/Service/AlertPriority.php
@@ -151,6 +151,7 @@ class AlertPriority
         "hurricane warning",
         "typhoon warning",
         "blizzard warning",
+        "snow squall warning",
         "ice storm warning",
         "winter storm warning",
         "high wind warning",


### PR DESCRIPTION
## What does this PR do? 🛠️

Snow Squall Warning is a fairly new alert type. It is present in our prioritized list of hazards but it is not included in the list of land hazards. This PR adds it.
