### PR TITLE
When saving bundles, save API times as relative to the time the bundle is captured

### DIFF
--- a/tests/api/save.js
+++ b/tests/api/save.js
@@ -6,14 +6,20 @@ import { format } from "prettier";
 const getRelativeTimestamp = (str) => {
   const now = dayjs();
 
+  // Timestamps can be in ISO8601 duration format which Dayjs can't parse, so
+  // preemptively split them up.
   const [timestamp, duration] = str.split("/");
+
   const time = dayjs(timestamp);
   if (time.isValid()) {
     const relativeStr = ["date:now"];
 
+    // Get the number of seconds difference between the timestamp and now, and
+    // tack that on to the magic timestamp we end up saving
     const secondsDiff = time.diff(now, "seconds");
     relativeStr.push(`${secondsDiff >= 0 ? "+" : ""}${secondsDiff} seconds`);
 
+    // If we had a duration, put it back now.
     if (duration) {
       relativeStr.push(`/ ${duration}`);
     }
@@ -30,6 +36,7 @@ const replaceTimestamps = (obj) => {
     return obj;
   }
 
+  // These are the time properties that we want to update.
   const timeProperties = new Set([
     "effective",
     "ends",

--- a/tests/api/save.js
+++ b/tests/api/save.js
@@ -1,6 +1,63 @@
+import dayjs from "dayjs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { format } from "prettier";
+
+const getRelativeTimestamp = (str) => {
+  const now = dayjs();
+
+  const [timestamp, duration] = str.split("/");
+  const time = dayjs(timestamp);
+  if (time.isValid()) {
+    const relativeStr = ["date:now"];
+
+    const secondsDiff = time.diff(now, "seconds");
+    relativeStr.push(`${secondsDiff >= 0 ? "+" : ""}${secondsDiff} seconds`);
+
+    if (duration) {
+      relativeStr.push(`/ ${duration}`);
+    }
+
+    return relativeStr.join(" ");
+  }
+
+  return str;
+};
+
+const replaceTimestamps = (obj) => {
+  const replaced = JSON.parse(JSON.stringify(obj ?? {}));
+  if (typeof replaced !== "object") {
+    return obj;
+  }
+
+  const timeProperties = new Set([
+    "effective",
+    "ends",
+    "endTime",
+    "expires",
+    "onset",
+    "sent",
+    "startTime",
+    "timestamp",
+    "generatedAt",
+    "updated",
+    "updateTime",
+    "validTime",
+    "validTimes",
+  ]);
+
+  Object.entries(replaced).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      replaced[key] = value.map((v) => replaceTimestamps(v));
+    } else if (typeof value === "object" && value !== null) {
+      replaced[key] = replaceTimestamps(value);
+    } else if (timeProperties.has(key)) {
+      replaced[key] = getRelativeTimestamp(value);
+    }
+  });
+
+  return replaced;
+};
 
 export default async (request, response, output) => {
   const requestID = request.headers["wx-gov-response-id"];
@@ -31,7 +88,10 @@ export default async (request, response, output) => {
     // Make the directory structure if necessary, then write out the
     // formatted JSON.
     await fs.mkdir(path.dirname(filePath), { recursive: true });
-    const json = await format(output, { parser: "json" });
+
+    const fixedUp = replaceTimestamps(JSON.parse(output));
+
+    const json = await format(JSON.stringify(fixedUp), { parser: "json" });
     await fs.writeFile(filePath, json, {
       encoding: "utf-8",
     });

--- a/tests/api/serve.js
+++ b/tests/api/serve.js
@@ -20,6 +20,12 @@ const exists = async (file) => {
 };
 
 const processDates = (obj) => {
+  // If the input is null, just bail out. Otherwise we'll accidentally turn it
+  // into an object.
+  if (obj === null) {
+    return;
+  }
+
   const now = dayjs();
 
   // Recursively search through the object to find all values that have the
@@ -28,12 +34,12 @@ const processDates = (obj) => {
     // For arrays and objects, recurse into them
     if (Array.isArray(value)) {
       value.forEach(processDates);
-    } else if (typeof value === "object") {
+    } else if (typeof value === "object" && value !== null) {
       processDates(value);
     }
     // But if the value has a startsWith function and it starts with the token,
     // we've got a thing that needs parsing.
-    else if (value.startsWith?.("date:now")) {
+    else if (value?.startsWith?.("date:now")) {
       // Splitting on date:now results in ['', <modifiers>]. Trim it and split
       // on spaces to get the offset and unit.
       const [amount, unit] = value.split("date:now")[1].trim().split(" ");
@@ -51,8 +57,6 @@ const processDates = (obj) => {
       const [, duration] = value.split(" / ");
       if (duration) {
         obj[key] = `${obj[key]}/${duration}`;
-
-        console.log(`modified time for ${key}: ${obj[key]}`);
       }
     }
   });

--- a/tests/api/serve.js
+++ b/tests/api/serve.js
@@ -54,6 +54,8 @@ const processDates = (obj) => {
         obj[key] = now.format();
       }
 
+      // If there's a duration component, smoosh it on to the end of our
+      // generated timestamp so it'll match the ISO8601 time+duration format.
       const [, duration] = value.split(" / ");
       if (duration) {
         obj[key] = `${obj[key]}/${duration}`;


### PR DESCRIPTION
## What does this PR do? 🛠️

When we record bundles, we currently capture the data exactly as provided by the API. As a result, data in bundles can slowly become outdated and no longer displayed by the site. This PR updates timestamps as it records them so that we preserve the relative time from "now" instead of an absolute time. This way, when we replay a bundle, the data presented should be identical to when it was captured, regardless of when it's played back (except for the timestamps, of course, which will be computed as a time relative to when the page is loaded).
