### PR TITLE
Fix the library version checker thing

### DIFF
--- a/.github/workflows/update-theme-libraries.yaml
+++ b/.github/workflows/update-theme-libraries.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           set +e
           git diff --exit-code origin/main web/themes/new_weather_theme/new_weather_theme.libraries.yml > /dev/null
-          if [ "$?" -ne 0 ]
+          if [ "$?" -eq 0 ]
           then
             gh pr comment ${{ github.event.number }} -b "This PR modifies theme Javascript or CSS assets but does not update the theme libraries file. Did you mean to update the appropriate version information in the libraries file?"
           fi


### PR DESCRIPTION
## What does this PR do? 🛠️

Fixes the check added in #788. As @elijah-wright pointed out then, we wanted to check for a zero status, not non-zero ones. To you, Elijah:

![cheers](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExajVnZjM5M3duZndxMW1wZmc5Zzk5a3hxZjNkamF6YmR4Y3BjNmJuNiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/BPJmthQ3YRwD6QqcVD/giphy.gif)

## What does the reviewer need to know? 🤔

The comments in this PR are out of whack because I squashed down to just one commit. But if you want to see it working correctly yourself, change one of our CSS or JS assets on this branch and push it. You'll get the comment from the bot. Then update the libraries file and note that you don't get another comment.

