### PR TITLE
Quick width issue fixes

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-daily-forecast.html.twig
@@ -1,4 +1,4 @@
-<div class="daily-forecast-block tablet:grid-col-6 mobile-lg:grid-col-8">
+<div class="daily-forecast-block">
   <h2>{{ "Daily forecast" | t}}</h2>
   {% if content.error %}
   {% set message = "There was an error loading the daily forecast." | t %}

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-hourly-forecast.html.twig
@@ -1,4 +1,4 @@
-<div class="hourly-forecast-block tablet:grid-col-6 mobile-lg:grid-col-8">
+<div class="hourly-forecast-block">
   {{ attach_library('new_weather_theme/hourly_table') }}
   <h2>{{ "Hourly forecast" | t }}</h2>
   {% if content.error %}


### PR DESCRIPTION
## What does this PR do? 🛠️
With the merging of the new styling changes, we need to also update some of the width classes on subcomponents, like hourly and daily forecast.

## Screenshots (if appropriate): 📸
<details>
<summary>Before:</summary>
  
<img width="965" alt="Screen Shot 2024-03-01 at 9 18 07 AM" src="https://github.com/weather-gov/weather.gov/assets/105373963/8dc733b8-f8da-45c2-877e-55d18c617584">
<img width="998" alt="Screen Shot 2024-03-01 at 9 18 02 AM" src="https://github.com/weather-gov/weather.gov/assets/105373963/6880c522-68c1-48b7-ac69-85d1897872a5">


</details>
  
<details>
<summary>After:</summary>
  
<img width="1037" alt="Screen Shot 2024-03-01 at 9 17 26 AM" src="https://github.com/weather-gov/weather.gov/assets/105373963/d704c74c-8e37-47e0-a58e-c9c06b8b30b6">
<img width="1023" alt="Screen Shot 2024-03-01 at 9 17 18 AM" src="https://github.com/weather-gov/weather.gov/assets/105373963/b708ebb0-de06-477d-ba86-b8894c03b00a">
  

</details>