### PR TITLE
Fix wind speed display when the value is zero.

### DIFF
--- a/web/modules/weather_data/src/Service/ObservationsTrait.php
+++ b/web/modules/weather_data/src/Service/ObservationsTrait.php
@@ -205,7 +205,7 @@ trait ObservationsTrait
             "wind" => [
                 // Kph to mph.
                 "speed" =>
-                    $obs->windSpeed->value == null
+                    $obs->windSpeed->value === null
                         ? null
                         : (int) round($obs->windSpeed->value * 0.6213712),
                 "direction" => UnitConversion::getDirectionOrdinal(

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -45,14 +45,21 @@
 
         <div class="margin-right-05">
           <p class="margin-y-0">
-            {%- if content.wind.speed != null -%}
+            {%- if content.wind.speed is same as(null) -%}
+              {%- set windString = "N/A" | t() -%}
+            {%- else -%}
+              {% if content.wind.speed > 0 %}
               {% set windString = "@windSpeed mph @windDirection" | t({
                   "@windSpeed": content.wind.speed,
                   "@windDirection": content.wind.direction.short
                 }) 
               %}
-            {%- else -%}
-              {%- set windString = "N/A" | t() -%}
+              {% else %}
+                {% set windString = "@windSpeed mph" | t({
+                    "@windSpeed": content.wind.speed,
+                  })
+                %}
+              {% endif %}
             {%- endif -%}
             <span class="font-mono-xs font-family-mono text-uppercase text-base">Wind </span>{{- windString -}}
           </p>


### PR DESCRIPTION
## What does this PR do? 🛠️

When the wind speed is 0, we display `N/A`. That is incorrect. PHP thinks `null` and `zero` are equal. This PR adds strict equality checking to fix that bug.

[reference](https://gsa-tts.slack.com/archives/C05DU11D4J2/p1710347151677179)