### PR TITLE
Have the API proxy default to serving the R3 bundle when it starts up

### DIFF
--- a/tests/api/config.js
+++ b/tests/api/config.js
@@ -1,5 +1,5 @@
 let bundling = false;
-let play = "testing";
+let play = "R3";
 
 export default {
   get bundling() {


### PR DESCRIPTION
## What does this PR do? 🛠️

This way when we redeploy, or the proxy restarts for some reason, it will restart by serving the R3 bundle.