### PR TITLE
Remove unnecessary padding in alert tab

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
@@ -1,4 +1,4 @@
-<div class="grid-container padding-x-0 tablet:padding-x-2"> 
+<div class="grid-container"> 
   <div class="grid-row"> 
     <div class="grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
       <weathergov-alerts class="display-block">
@@ -54,13 +54,13 @@
       </weathergov-alerts>
     </div>
   </div>
-  <div class="grid-row padding-x-2 tablet:padding-x-0">
+  <div class="grid-row">
     <div class="grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
       <h2 class="text-primary-darkest text-normal margin-bottom-1">{{ "Tips to stay safe" | t }}</h2>
     </div>
   </div>
   {% for alert in content.alerts %}
-  <div class="grid-row padding-x-2 tablet:padding-x-0">
+  <div class="grid-row">
     <div class="grid-col tablet-lg:grid-offset-2 talbet-lg:grid-col-8">
       {{ drupal_block("weathergov_dynamic_safety_information", { weather_event: alert.event , other: "other"})}}
     </div>


### PR DESCRIPTION
## What does this PR do? 🛠️
When working on #894 I realized there was some unnecessary padding classes that were cancelling each other out in the alert tab. Quick fix to simplify. Visually should look the same as before.

![Screenshot of alerts tab showing alignment](https://github.com/weather-gov/weather.gov/assets/150970973/bac47b44-8b53-4eb5-b37d-20233fca18a7)
