### PR TITLE
R3 fix date 

### DIFF
--- a/tests/api/data/R3/alerts/active__status=actual&area=MT.json
+++ b/tests/api/data/R3/alerts/active__status=actual&area=MT.json
@@ -41,7 +41,7 @@
       "geometry": null,
       "properties": {
         "onset": "2025-02-25T15:00:00-07:00",
-        "ends": "2025-02-25T05:00:00-07:00",
+        "ends": "2025-02-26T05:00:00-07:00",
         "areaDesc": "Red Lodge Foothills;Beartooth Foothills;Including the locations of Roberts, Fishtail, Red Lodge, McLeod, Nye and Roscoe",
         "description": "* WHAT...Heavy snow expected. Total snow accumulations between 5 and 10 inches. Winds gusting as high as 40 mph creating significant blowing and drifting snow.\n\n* WHERE...Beartooth Foothills and Red Lodge Foothills.\n\n* WHEN...From 3 PM Tuesday afternoon to 5 AM MST Wednesday.\n\n* IMPACTS...Roads will become slick and hazardous. Travel could be very difficult. Widespread blowing snow could significantly reduce visibility. The hazardous conditions could impact the evening and morning commutes. The cold and wet conditions will be dangerous for young livestock.\n\n* ADDITIONAL DETAILS...The heaviest snowfall is expected Tuesday night.",
         "sent": "2025-02-24T17:00:00-07:00",


### PR DESCRIPTION
## What does this PR do? 🛠️
One of the R3 alerts has a small bug where the end date is before the start date. The correct end date should be 5 AM MT Wed, 2/26. 

![image](https://github.com/weather-gov/weather.gov/assets/150970973/a301f33b-1d1b-4685-98b6-9490a929c8b2)

## What does the reviewer need to know? 🤔
Question – Do we need to redeploy the proxy only? Everything?

## Screenshots (if appropriate): 📸
![image](https://github.com/weather-gov/weather.gov/assets/150970973/85f12926-6638-48d7-b586-68a566d2ae91)

