### PR TITLE
Strict comparisons on null

### DIFF
--- a/web/modules/weather_data/src/Service/ObservationsTrait.php
+++ b/web/modules/weather_data/src/Service/ObservationsTrait.php
@@ -9,7 +9,7 @@ trait ObservationsTrait
      */
     protected function isValidObservation($obs)
     {
-        if ($obs->temperature->value == null) {
+        if ($obs->temperature->value === null) {
             return false;
         }
         return true;
@@ -155,7 +155,7 @@ trait ObservationsTrait
             $obsStationIndex < count($obsStations) - 1 &&
             $obsStationIndex < self::NUMBER_OF_OBS_STATIONS_TO_TRY
         );
-        if ($obs->temperature->value == null) {
+        if ($obs->temperature->value === null) {
             return null;
         }
 
@@ -173,10 +173,10 @@ trait ObservationsTrait
         $timestamp = DateTimeUtility::stringToDate($obs->timestamp);
 
         $feelsLike = UnitConversion::getTemperatureScalar($obs->heatIndex);
-        if ($feelsLike == null) {
+        if ($feelsLike === null) {
             $feelsLike = UnitConversion::getTemperatureScalar($obs->windChill);
         }
-        if ($feelsLike == null) {
+        if ($feelsLike === null) {
             $feelsLike = UnitConversion::getTemperatureScalar(
                 $obs->temperature,
             );

--- a/web/modules/weather_data/src/Service/UnitConversion.php
+++ b/web/modules/weather_data/src/Service/UnitConversion.php
@@ -49,7 +49,7 @@ class UnitConversion
     ) {
         $rawValue = $length->value;
 
-        if ($rawValue == null) {
+        if ($rawValue === null) {
             return null;
         }
 
@@ -77,7 +77,7 @@ class UnitConversion
     {
         $rawValue = $speed->value;
 
-        if ($rawValue == null) {
+        if ($rawValue === null) {
             return null;
         }
 
@@ -110,7 +110,7 @@ class UnitConversion
     ) {
         $rawValue = $temperature->value;
 
-        if ($rawValue == null) {
+        if ($rawValue === null) {
             return null;
         }
 


### PR DESCRIPTION
## What does this PR do? 🛠️

Null is equal to zero and false, but that's pretty much never what we actually want. Change our null equality checks to strict equality.

Incidentally fixes #912
