### PR TITLE
Handle lat/lon consistently

### DIFF
--- a/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/WeatherBlockBase.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\node\NodeInterface;
+use Drupal\weather_data\Service\SpatialUtility;
 use Drupal\weather_data\Service\WeatherDataService;
 use Drupal\weather_data\Service\WeatherEntityService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -167,7 +168,7 @@ abstract class WeatherBlockBase extends BlockBase implements
             $lat = floatval($this->route->getParameter("lat"));
             $lon = floatval($this->route->getParameter("lon"));
 
-            $location->point = (object) ["lat" => $lat, "lon" => $lon];
+            $location->point = SpatialUtility::pointArrayToObject([$lon, $lat]);
 
             $location->grid = $this->weatherData->getGridFromLatLon($lat, $lon);
         } else {

--- a/web/modules/weather_blocks/weather_blocks.module
+++ b/web/modules/weather_blocks/weather_blocks.module
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\weather_data\Service\SpatialUtility;
+
 // This hook lets us alter the variables at the page level. These variables are
 // available globally to all templates.
 function weather_blocks_template_preprocess_default_variables_alter(
@@ -29,7 +31,7 @@ function weather_blocks_template_preprocess_default_variables_alter(
 
             $alerts = $weatherData->getAlerts(
                 $grid,
-                (object) ["lon" => $lon, "lat" => $lat],
+                SpatialUtility::pointArrayToObject([$lon, $lat]),
             );
             $weatherMetadata["alerts"] = count($alerts) > 0;
         } catch (Throwable $e) {

--- a/web/modules/weather_blocks/weather_blocks.module
+++ b/web/modules/weather_blocks/weather_blocks.module
@@ -29,7 +29,7 @@ function weather_blocks_template_preprocess_default_variables_alter(
 
             $alerts = $weatherData->getAlerts(
                 $grid,
-                [$lon, $lat],
+                (object) ["lon" => $lon, "lat" => $lat],
             );
             $weatherMetadata["alerts"] = count($alerts) > 0;
         } catch (Throwable $e) {

--- a/web/modules/weather_data/src/Service/DailyForecastTrait.php
+++ b/web/modules/weather_data/src/Service/DailyForecastTrait.php
@@ -68,11 +68,11 @@ trait DailyForecastTrait
         // and any relevant alerts so we can use them
         // in the hourly details table for each day
         $hourlyPeriods = $this->getHourlyForecastFromGrid($wfo, $x, $y);
-        $point = $this->stashedPoint;
+        $point = self::$stashedPoint;
         if (!$point) {
             $point = $this->getGeometryFromGrid($wfo, $x, $y)[0];
         }
-        $grid = $this->getGridFromLatLon($point[1], $point[0]);
+        $grid = $this->getGridFromLatLon($point->lat, $point->lon);
         $alerts = $this->getAlerts($grid, $point);
 
         // In order to keep the time zones straight,

--- a/web/modules/weather_data/src/Service/DataLayer.php
+++ b/web/modules/weather_data/src/Service/DataLayer.php
@@ -283,7 +283,7 @@ class DataLayer
         $sql = "SELECT
           name,state,stateName,county,timezone,stateFIPS,countyFIPS
           FROM weathergov_geo_places
-          ORDER BY ST_DISTANCE(point,ST_GEOMFROMTEXT('$wktGeometry'))
+          ORDER BY ST_DISTANCE(point,$wktGeometry)
           LIMIT 1";
 
         $place = $this->database->query($sql)->fetch();
@@ -307,7 +307,7 @@ class DataLayer
         $key = "$lat $lon";
         if (!self::$i_placeNearPoint[$key]) {
             self::$i_placeNearPoint[$key] = $this->getPlaceNear(
-                "POINT($lon $lat)",
+                SpatialUtility::pointArrayToWKT([$lon, $lat]),
             );
         }
         return self::$i_placeNearPoint[$key];
@@ -316,14 +316,9 @@ class DataLayer
     private static $i_placeNearPolygon = [];
     public function getPlaceNearPolygon($points)
     {
-        $wktPoints = array_map(function ($point) {
-            return $point[0] . " " . $point[1];
-        }, $points);
-        $wktPoints = implode(",", $wktPoints);
-
         if (!self::$i_placeNearPolygon[$wktPoints]) {
             $this->iPlaceNearPolygon[$wktPoints] = $this->getPlaceNear(
-                "POLYGON(($wktPoints))",
+                SpatialUtility::geometryObjectToWKT($points),
             );
         }
         return $this->iPlaceNearPolygon[$wktPoints];

--- a/web/modules/weather_data/src/Service/SpatialUtility.php
+++ b/web/modules/weather_data/src/Service/SpatialUtility.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\weather_data\Service;
+
+class SpatialUtility
+{
+    public static function pointArrayToObject($point)
+    {
+        return (object) [
+            "lat" => floatval($point[1]),
+            "lon" => floatval($point[0]),
+        ];
+    }
+
+    public static function pointObjectToWKT($point)
+    {
+        return "ST_GEOMFROMTEXT('POINT($point->lon $point->lat)')";
+    }
+
+    public static function pointArrayToWKT($point)
+    {
+        return "ST_GEOMFROMTEXT('POINT($point[0] $point[1])')";
+    }
+
+    public static function geometryArrayToObject($points)
+    {
+        return array_map(function ($point) {
+            return self::pointArrayToObject($point);
+        }, $points);
+    }
+
+    public static function geometryObjectToWKT($geometry)
+    {
+        $wkt = array_map(function ($point) {
+            return $point->lon . " " . $point->lat;
+        }, $geometry);
+        $wkt = implode(",", $wkt);
+
+        return "ST_GEOMFROMTEXT('POLYGON(($wkt))')";
+    }
+
+    public static function geometryArrayToWKT($geometry)
+    {
+        return self::geometryObjectToWKT(
+            self::geometryArrayToObject($geometry),
+        );
+    }
+}

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -73,7 +73,7 @@ class WeatherDataService
      *
      * @var stashedPoint
      */
-    public $stashedPoint;
+    protected static $stashedPoint = null;
 
     /**
      * Constructor.
@@ -93,11 +93,15 @@ class WeatherDataService
         $this->defaultConditions = "No data";
 
         $this->stashedGridGeometry = null;
-        $this->stashedPoint = null;
 
         $this->legacyMapping = json_decode(
             file_get_contents(__DIR__ . "/legacyMapping.json"),
         );
+    }
+
+    public static function setPoint($point)
+    {
+        self::$stashedPoint = $point;
     }
 
     /**
@@ -179,8 +183,7 @@ class WeatherDataService
             $self = $this;
         }
 
-        $gridpoint = $this->dataLayer->getGridpoint($wfo, $x, $y);
-        $geometry = $gridpoint->geometry->coordinates[0];
+        $geometry = $this->getGeometryFromGrid($wfo, $x, $y);
 
         return $this->dataLayer->getPlaceNearPolygon($geometry);
     }
@@ -195,7 +198,9 @@ class WeatherDataService
     {
         if (!$this->stashedGridGeometry) {
             $gridpoint = $this->dataLayer->getGridpoint($wfo, $x, $y);
-            $this->stashedGridGeometry = $gridpoint->geometry->coordinates[0];
+            $this->stashedGridGeometry = SpatialUtility::geometryArrayToObject(
+                $gridpoint->geometry->coordinates[0],
+            );
         }
 
         return $this->stashedGridGeometry;

--- a/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
+++ b/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
@@ -6,6 +6,8 @@ namespace Drupal\weather_routes\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
+use Drupal\weather_data\Service\SpatialUtility;
+use Drupal\weather_data\Service\WeatherDataService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -54,6 +56,9 @@ final class LocationAndGridRouteController extends ControllerBase
     {
         try {
             $this->dataLayer->getPoint($lat, $lon);
+            WeatherDataService::setPoint(
+                SpatialUtility::pointArrayToObject([$lon, $lat]),
+            );
             return [];
         } catch (\Throwable $e) {
             // If we don't get a corresponding grid location, throw a 404.


### PR DESCRIPTION
## What does this PR do? 🛠️

It seems silly to have code sprinkled across several places for building SQL-ready representations of geometries. It also seems silly to have to remember that in a point array, longitude comes first and latitude second. So this PR switches all of our points to objects with `lat` and `lon` properties so we can be more explicit, and adds utilities for simplifying stuff.

* Adds a SpatialUtility class for putting spatial stuff in one place
  * converts an array of lat/lon to a single point object with lat/lon properties
  * converts an array of point arrays into an array of point objects
  * creates SQL-query-ready WKT representations of geometries and points
* Modifies a bunch of code to use the utility classes
* Switches point arrays to point objects for readability
* Fixes an uncaught exception (that weirdly didn't break anything) in the case that we tried to get alerts for hourly periods where the number of hourly periods is zero. (I assume this is a result of current time and testing data, because I don't think this should happen otherwise. But anyway, a little defensive coding doesn't hurt.)

closes #901