### PR TITLE
Cache a database dump in CI/CD to speed up runs

### DIFF
--- a/.github/actions/setup-site/action.yml
+++ b/.github/actions/setup-site/action.yml
@@ -1,0 +1,51 @@
+runs:
+  using: composite
+  steps:
+    - name: setup image cacheing
+      if: needs.should-test.outputs.yes == 'true'
+      uses: actions/cache@v4
+      with:
+        key: drupal-image-${{ hashFiles('composer.lock','web/sites/example.settings.dev.php','Dockerfile.dev') }}
+        path: /tmp/image.tar
+
+    - name: database dump cache
+      if: needs.should-test.outputs.yes == 'true'
+      uses: actions/cache@v4
+      id: db-cache
+      with:
+        key: drupal-database-${{ hashFiles('web/config/**/*.yml', 'web/scs-export/**/*') }}
+        path: weathergov.sql
+
+    - name: start the site
+      if: needs.should-test.outputs.yes == 'true'
+      shell: bash
+      run: |
+        mkdir .coverage
+        chmod a+rwx -R .coverage
+        docker load --input /tmp/image.tar
+        docker compose up -d
+
+    # Give the containers a moment to settle.
+    - name: wait a tick
+      if: needs.should-test.outputs.yes == 'true'
+      shell: bash
+      run: sleep 10
+
+    - name: populate the site
+      if: needs.should-test.outputs.yes == 'true'
+      shell: bash
+      run: |
+        cp web/sites/example.settings.dev.php web/sites/settings.dev.php
+        mysql \
+          --host=127.0.0.1 \
+          --port=3306 \
+          --password=drupal \
+          --user=root \
+          weathergov < weathergov.sql
+
+        echo "UPDATE users SET uid=0 WHERE uid=2;" | mysql \
+          --host=127.0.0.1 \
+          --port=3306 \
+          --password=drupal \
+          --user=root \
+          weathergov

--- a/.github/workflows/code-standards.yaml
+++ b/.github/workflows/code-standards.yaml
@@ -189,8 +189,8 @@ jobs:
           tags: 18f-zscaler-drupal:10-apache
           outputs: type=docker,dest=/tmp/image.tar
 
-  php-tests:
-    name: PHP tests
+  populate-database:
+    name: populate database
     runs-on: ubuntu-latest
     needs: [build-drupal-image, should-test]
 
@@ -199,15 +199,23 @@ jobs:
         if: needs.should-test.outputs.yes == 'true'
         uses: actions/checkout@v4
 
-      - name: setup image cacheing
+      - name: database dump cache
         if: needs.should-test.outputs.yes == 'true'
+        uses: actions/cache@v4
+        id: db-cache
+        with:
+          key: drupal-database-${{ hashFiles('web/config/**/*.yml', 'web/scs-export/**/*') }}
+          path: weathergov.sql
+
+      - name: setup image cacheing
+        if: needs.should-test.outputs.yes == 'true' && steps.db-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v4
         with:
           key: drupal-image-${{ hashFiles('composer.lock','web/sites/example.settings.dev.php','Dockerfile.dev') }}
           path: /tmp/image.tar
 
       - name: cache spatial data
-        if: needs.should-test.outputs.yes == 'true'
+        if: needs.should-test.outputs.yes == 'true' && steps.db-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v4
         with:
           key: spatial-data-05mr24
@@ -216,24 +224,48 @@ jobs:
             spatial-data/s_05mr24.zip
 
       - name: start the site
-        if: needs.should-test.outputs.yes == 'true'
+        if: needs.should-test.outputs.yes == 'true' && steps.db-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir .coverage
-          chmod a+rwx -R .coverage
           docker load --input /tmp/image.tar
           docker compose up -d
 
       # Give the containers a moment to settle.
       - name: wait a tick
-        if: needs.should-test.outputs.yes == 'true'
+        if: needs.should-test.outputs.yes == 'true' && steps.db-cache.outputs.cache-hit != 'true'
         run: sleep 10
 
       - name: populate the site
-        if: needs.should-test.outputs.yes == 'true'
+        if: needs.should-test.outputs.yes == 'true' && steps.db-cache.outputs.cache-hit != 'true'
         run: |
           cp web/sites/example.settings.dev.php web/sites/settings.dev.php
           make install-site
           make load-spatial
+
+      - name: dump database
+        if: needs.should-test.outputs.yes == 'true' && steps.db-cache.outputs.cache-hit != 'true'
+        run: |
+          mysqldump \
+            --host=127.0.0.1 \
+            --port=3306 \
+            --password=drupal \
+            --user=root \
+            --compact \
+            --add-drop-table \
+            --add-drop-trigger \
+            weathergov > weathergov.sql
+
+  php-tests:
+    name: PHP tests
+    runs-on: ubuntu-latest
+    needs: [populate-database, should-test]
+
+    steps:
+      - name: checkout
+        if: needs.should-test.outputs.yes == 'true'
+        uses: actions/checkout@v4
+
+      - name: setup site
+        uses: ./.github/actions/setup-site
 
       - name: run unit tests
         if: needs.should-test.outputs.yes == 'true'
@@ -274,46 +306,15 @@ jobs:
   end-to-end-tests:
     name: end-to-end tests
     runs-on: ubuntu-latest
-    needs: [build-drupal-image, should-test]
+    needs: [populate-database, should-test]
 
     steps:
       - name: checkout
         if: needs.should-test.outputs.yes == 'true'
         uses: actions/checkout@v4
 
-      - name: setup image cacheing
-        if: needs.should-test.outputs.yes == 'true'
-        uses: actions/cache@v4
-        with:
-          key: drupal-image-${{ hashFiles('composer.lock','web/sites/example.settings.dev.php','Dockerfile.dev') }}
-          path: /tmp/image.tar
-
-      - name: cache spatial data
-        if: needs.should-test.outputs.yes == 'true'
-        uses: actions/cache@v4
-        with:
-          key: spatial-data-05mr24
-          path: |
-            spatial-data/c_05mr24.zip
-            spatial-data/s_05mr24.zip
-
-      - name: start the site
-        if: needs.should-test.outputs.yes == 'true'
-        run: |
-          docker load --input /tmp/image.tar
-          docker compose up -d
-
-      # Give the containers a moment to settle.
-      - name: wait a tick
-        if: needs.should-test.outputs.yes == 'true'
-        run: sleep 10
-
-      - name: populate the site
-        if: needs.should-test.outputs.yes == 'true'
-        run: |
-          cp web/sites/example.settings.dev.php web/sites/settings.dev.php
-          make install-site
-          make load-spatial
+      - name: setup site
+        uses: ./.github/actions/setup-site
 
       - name: Cypress run
         if: needs.should-test.outputs.yes == 'true'
@@ -332,7 +333,7 @@ jobs:
   accessibility-tests:
     name: accessibility tests
     runs-on: ubuntu-latest
-    needs: [build-drupal-image, should-test]
+    needs: [populate-database, should-test]
 
     steps:
       - name: checkout
@@ -341,31 +342,8 @@ jobs:
         with:
           lfs: true
 
-      - name: setup image cacheing
-        if: needs.should-test.outputs.yes == 'true'
-        uses: actions/cache@v4
-        id: cache
-        with:
-          key: drupal-image-${{ hashFiles('composer.lock','web/sites/example.settings.dev.php','Dockerfile.dev') }}
-          path: /tmp/image.tar
-
-      - name: start the site
-        if: needs.should-test.outputs.yes == 'true'
-        run: |
-          docker load --input /tmp/image.tar
-          docker compose up -d
-
-      # Give the containers a moment to settle.
-      - name: wait a tick
-        if: needs.should-test.outputs.yes == 'true'
-        run: sleep 10
-
-      - name: populate the site
-        if: needs.should-test.outputs.yes == 'true'
-        run: |
-          cp web/sites/example.settings.dev.php web/sites/settings.dev.php
-          make install-site
-          make load-spatial
+      - name: setup site
+        uses: ./.github/actions/setup-site
 
       - name: Cypress run
         if: needs.should-test.outputs.yes == 'true'
@@ -377,34 +355,15 @@ jobs:
   page-load-time-tests:
     name: page load time tests
     runs-on: ubuntu-latest
-    needs: [build-drupal-image, should-test]
+    needs: [populate-database, should-test]
     if: needs.should-test.outputs.yes == 'true'
 
     steps:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: setup image cacheing
-        uses: actions/cache@v4
-        id: cache
-        with:
-          key: drupal-image-${{ hashFiles('composer.lock','web/sites/example.settings.dev.php','Dockerfile.dev') }}
-          path: /tmp/image.tar
-
-      - name: start the site
-        run: |
-          docker load --input /tmp/image.tar
-          docker compose up -d
-
-      # Give the containers a moment to settle.
-      - name: wait a tick
-        run: sleep 10
-
-      - name: populate the site
-        run: |
-          cp web/sites/example.settings.dev.php web/sites/settings.dev.php
-          make install-site
-          make load-spatial
+      - name: setup site
+        uses: ./.github/actions/setup-site
 
       - name: Cypress run
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
## What does this PR do? 🛠️

- caches a dump of our fully-populated database (keyed on config and content hashes)
- if no cache, builds the database
- in subsequent testing steps, rather than building the database, restore it from cache

This takes our build times from around 8 minutes to around 4 minutes.