### PR TITLE
For visual cases, use separate degree and F characters

### DIFF
--- a/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/HourlyForecast/Alerts.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/HourlyForecast/Alerts.php.test
@@ -19,12 +19,18 @@ final class HourlyForecastAlertTest extends EndToEndBase
     /**
      * Simply validate the data structure.
      * @group e2e
+     * @group e2e2
      */
     public function testHourlyAlertDataStructure(): void
     {
         $this->onLocationRoute(34.749, -92.275);
 
-        // Build up expected times, based on the contents of the test data.
+        $data = $this->block->build();
+
+        // Build up expected times, based on the contents of the test data. Do
+        // this after fetching the data so we don't get a timestamp that's off
+        // by a second due to processing inside the build() method.
+        date_default_timezone_set("UTC");
         $now = new \DateTimeImmutable();
 
         $sent = $now->modify("-1 hour");
@@ -190,8 +196,6 @@ final class HourlyForecastAlertTest extends EndToEndBase
                 "alertId" => 4,
             ],
         ];
-
-        $data = $this->block->build();
 
         $actual = $data["alertPeriods"][0];
 

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -15,13 +15,15 @@
       <div class="display-flex">
         <div class="current-conditions-temp display-flex flex-row flex-align-start margin-right-2 text-primary-darker">
           {{ content.temperature }}
-          <span class="font-body-xs display-inline-block left-full margin-top-05 margin-left-neg-2px">℉</span>
+          <span class="usa-sr-only">℉</span>
+          <span aria-hidden="true" class="font-body-xs display-inline-block left-full margin-top-05 margin-left-neg-2px">&deg;F</span>
         </div>
         <div class="margin-top-05 position-relative">
           <div class="font-mono-2xs font-family-mono text-base text-uppercase">{{ "Feels like" | t }}</div>
           <div class="text-primary-darker">
             <p class="margin-top-2px font-body-md">{{ content.feels_like }}
-              <span class="font-body-3xs position-absolute margin-top">℉</span>
+              <span class="usa-sr-only">℉</span>
+              <span aria-hidden="true" class="font-body-3xs position-absolute margin-top">&deg;F</span>
             </p>
           </div>
         </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -14,16 +14,15 @@
       {# First row is temperature #}
       <div class="display-flex">
         <div class="current-conditions-temp display-flex flex-row flex-align-start margin-right-2 text-primary-darker">
-          {{ content.temperature }}
+          {{ content.temperature }}<span aria-hidden="true" class="font-body-xs display-inline-block left-full margin-top-05 margin-left-neg-2px">&deg;F</span>
           <span class="usa-sr-only">℉</span>
-          <span aria-hidden="true" class="font-body-xs display-inline-block left-full margin-top-05 margin-left-neg-2px">&deg;F</span>
         </div>
         <div class="margin-top-05 position-relative">
           <div class="font-mono-2xs font-family-mono text-base text-uppercase">{{ "Feels like" | t }}</div>
           <div class="text-primary-darker">
             <p class="margin-top-2px font-body-md">{{ content.feels_like }}
-              <span class="usa-sr-only">℉</span>
               <span aria-hidden="true" class="font-body-3xs position-absolute margin-top">&deg;F</span>
+              <span class="usa-sr-only">℉</span>
             </p>
           </div>
         </div>

--- a/web/themes/new_weather_theme/templates/partials/daily-high-low.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/daily-high-low.html.twig
@@ -3,8 +3,7 @@
     {{period.isDaytime ? "High" | t | upper : "Low" | t | upper}}
   </span>
   <span class="font-ui-lg display-flex flex-row flex-align-start">
-    {{ period.temperature  }}
+    {{ period.temperature  }}<span aria-hidden="true" class="font-body-3xs margin-top-2px padding-left-1px">&deg;F</span>
     <span class="usa-sr-only">℉</span>
-    <span aria-hidden="true" class="font-body-3xs margin-top-2px padding-left-1px">&deg;F</span>
   </span>
 </div>

--- a/web/themes/new_weather_theme/templates/partials/daily-high-low.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/daily-high-low.html.twig
@@ -4,6 +4,7 @@
   </span>
   <span class="font-ui-lg display-flex flex-row flex-align-start">
     {{ period.temperature  }}
-    <span class="font-body-3xs margin-top-2px padding-left-1px">℉</span>
+    <span class="usa-sr-only">℉</span>
+    <span aria-hidden="true" class="font-body-3xs margin-top-2px padding-left-1px">&deg;F</span>
   </span>
 </div>

--- a/web/themes/new_weather_theme/templates/partials/hourly-table.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/hourly-table.html.twig
@@ -33,9 +33,8 @@
         {% for period in hours %}
         <td>
           {% if period.temperature is not same as (null) %}
-          {{ period.temperature }}
+          {{ period.temperature }}<span aria-hidden="true" class="font-sans-3xs text-ttop padding-left-1px">&deg;F</span>
           <span class="usa-sr-only">℉</span>
-          <span aria-hidden="true" class="font-sans-3xs text-ttop padding-left-1px">&deg;F</span>
           {% else %}
           <span class="text-base font-mono-xs"> {{ "N/A" | t }} </span>
           {% endif %}
@@ -115,9 +114,8 @@
         {% for period in hours %}
         <td>
           {% if period.dewpoint is not same as (null) %}
-          {{period.dewpoint}}
+          {{period.dewpoint}}<span aria-hidden="true" class="font-sans-3xs text-ttop padding-left-1px">&deg;F</span>
           <span class="usa-sr-only">℉</span>
-          <span aria-hidden="true" class="font-sans-3xs text-ttop padding-left-1px">&deg;F</span>
           {% else %}
           <span class="text-base font-mono-xs"> {{ "N/A" | t }} </span>
           {% endif %}

--- a/web/themes/new_weather_theme/templates/partials/hourly-table.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/hourly-table.html.twig
@@ -33,7 +33,9 @@
         {% for period in hours %}
         <td>
           {% if period.temperature is not same as (null) %}
-          {{ period.temperature }}<span class="font-sans-3xs text-ttop padding-left-1px">℉</span>
+          {{ period.temperature }}
+          <span class="usa-sr-only">℉</span>
+          <span aria-hidden="true" class="font-sans-3xs text-ttop padding-left-1px">&deg;F</span>
           {% else %}
           <span class="text-base font-mono-xs"> {{ "N/A" | t }} </span>
           {% endif %}
@@ -113,7 +115,9 @@
         {% for period in hours %}
         <td>
           {% if period.dewpoint is not same as (null) %}
-          {{period.dewpoint}}<span class="font-sans-3xs text-ttop padding-left-1px">℉</span>
+          {{period.dewpoint}}
+          <span class="usa-sr-only">℉</span>
+          <span aria-hidden="true" class="font-sans-3xs text-ttop padding-left-1px">&deg;F</span>
           {% else %}
           <span class="text-base font-mono-xs"> {{ "N/A" | t }} </span>
           {% endif %}


### PR DESCRIPTION
## What does this PR do? 🛠️

- Where we display degrees, visually use two characters so they will be in our design system fonts, but hide those from screen readers
- For screen readers, preserve the single character and mark it sr-only

closes #930
