### PR TITLE
Move Tips to Stay Safe inside accordion

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-dynamic-safety-information.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-dynamic-safety-information.html.twig
@@ -1,5 +1,5 @@
 {% if content.body %}
-<h3 class="text-primary-darker text-normal"> Tips to stay safe </h3>
+<h3 class="text-primary-darker text-normal"> {{ "Tips to stay safe" | t } </h3>
 <div class="usa-prose saftey-tips">
 {{- content.body | raw -}}
 </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-dynamic-safety-information.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-dynamic-safety-information.html.twig
@@ -1,6 +1,6 @@
 {% if content.body %}
-<h3 class="text-primary-darkest text-normal"> {{ content.title | split('\(') | first | t }} </h3>
+<h3 class="text-primary-darker text-normal"> Tips to stay safe </h3>
 <div class="usa-prose saftey-tips">
-{{ content.body | raw }}
+{{- content.body | raw -}}
 </div>
 {% endif %}

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
@@ -48,22 +48,11 @@
                 <li class="">{{ areaName }}</li>
               {% endfor %}
             </ul>
+          {{ drupal_block("weathergov_dynamic_safety_information", { weather_event: alert.event }) }}
         </div>
       </div>
       {% endfor %}
       </weathergov-alerts>
     </div>
   </div>
-  <div class="grid-row">
-    <div class="grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
-      <h2 class="text-primary-darkest text-normal margin-bottom-1">{{ "Tips to stay safe" | t }}</h2>
-    </div>
-  </div>
-  {% for alert in content.alerts %}
-  <div class="grid-row">
-    <div class="grid-col tablet-lg:grid-offset-2 talbet-lg:grid-col-8">
-      {{ drupal_block("weathergov_dynamic_safety_information", { weather_event: alert.event , other: "other"})}}
-    </div>
-  </div>
-  {% endfor %}
 </div>

--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -49,14 +49,14 @@
 
       <div class="bg-base-lightest padding-top-3 padding-bottom-8">
         {% if weather.alerts %}
-        <div class="tab-container focus-offset-205" id="alerts"  role="tabpanel" aria-labelledby="alerts-tab-button" tabindex="0">
+        <div class="tab-container focus-offset-205" id="alerts" role="tabpanel" aria-labelledby="alerts-tab-button" tabindex="0">
           {{ drupal_block("weathergov_local_alerts") }}
         </div>
         {% endif %}
         <div class="tab-container focus-offset-205" id="current" role="tabpanel" aria-labelledby="current-conditions-tab-button" tabindex="0">
           {{ drupal_block("weathergov_current_conditions") }}
         </div>
-        <div class="tab-container focus-offset-205" id="today"  role="tabpanel" aria-labelledby="today-tab-button" tabindex="0">
+        <div class="tab-container focus-offset-205" id="today" role="tabpanel" aria-labelledby="today-tab-button" tabindex="0">
           {{ drupal_block("weathergov_weather_story") }}
           <div class="grid-container padding-x-2">
             <div class="grid-row">


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR moves the "Tips to Stay Safe" section for each hazard into it's corresponding accordion. It removes the title from hazards that don't have any dynamic safety content written yet. 

Closes #931 and #970 

## Screenshots (if appropriate): 📸

Hazard with dynamic safety content
<img width="342" alt="Screenshot of tips to stay safe section inside accordion" src="https://github.com/weather-gov/weather.gov/assets/150970973/3c0a4497-f913-4de9-83b6-2c51f536ec69">

Hazard without dynamic safety content
<img width="319" alt="image" src="https://github.com/weather-gov/weather.gov/assets/150970973/54c35637-224c-4af8-99dc-7045589fb3df">
