### PR TITLE
Change alert ordering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,6 +113,7 @@
     "require-dev": {
         "drupal/coder": "^8.3",
         "drupal/devel": "^5.1.2",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^9.6",
+        "swaggest/json-schema": "^0.12.42"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f94d87839eb752b7a0657e6cc1ade2cb",
+    "content-hash": "c645b6aaff2750ac82aafbb41682beca",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8160,6 +8160,54 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "phplang/scope-exit",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phplang/scope-exit.git",
+                "reference": "239b73abe89f9414aa85a7ca075ec9445629192b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phplang/scope-exit/zipball/239b73abe89f9414aa85a7ca075ec9445629192b",
+                "reference": "239b73abe89f9414aa85a7ca075ec9445629192b",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpLang\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "authors": [
+                {
+                    "name": "Sara Golemon",
+                    "email": "pollita@php.net",
+                    "homepage": "https://twitter.com/SaraMG",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Emulation of SCOPE_EXIT construct from C++",
+            "homepage": "https://github.com/phplang/scope-exit",
+            "keywords": [
+                "cleanup",
+                "exit",
+                "scope"
+            ],
+            "support": {
+                "issues": "https://github.com/phplang/scope-exit/issues",
+                "source": "https://github.com/phplang/scope-exit/tree/master"
+            },
+            "time": "2016-09-17T00:15:18+00:00"
+        },
+        {
             "name": "phpstan/phpdoc-parser",
             "version": "1.26.0",
             "source": {
@@ -8208,16 +8256,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.30",
+            "version": "9.2.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
                 "shasum": ""
             },
             "require": {
@@ -8274,7 +8322,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
             },
             "funding": [
                 {
@@ -8282,7 +8330,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:47:57+00:00"
+            "time": "2024-03-02T06:37:42+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -8527,16 +8575,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.17",
+            "version": "9.6.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd"
+                "reference": "32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1a156980d78a6666721b7e8e8502fe210b587fcd",
-                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04",
+                "reference": "32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04",
                 "shasum": ""
             },
             "require": {
@@ -8610,7 +8658,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.17"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.18"
             },
             "funding": [
                 {
@@ -8626,7 +8674,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-23T13:14:51+00:00"
+            "time": "2024-03-21T12:07:32+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -9728,6 +9776,100 @@
                 }
             ],
             "time": "2024-02-16T15:06:51+00:00"
+        },
+        {
+            "name": "swaggest/json-diff",
+            "version": "v3.10.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swaggest/json-diff.git",
+                "reference": "17bfc66b330f46e12a7e574133497a290cd79ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swaggest/json-diff/zipball/17bfc66b330f46e12a7e574133497a290cd79ba5",
+                "reference": "17bfc66b330f46e12a7e574133497a290cd79ba5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*"
+            },
+            "require-dev": {
+                "phperf/phpunit": "4.8.37"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swaggest\\JsonDiff\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Viacheslav Poturaev",
+                    "email": "vearutop@gmail.com"
+                }
+            ],
+            "description": "JSON diff/rearrange/patch/pointer library for PHP",
+            "support": {
+                "issues": "https://github.com/swaggest/json-diff/issues",
+                "source": "https://github.com/swaggest/json-diff/tree/v3.10.5"
+            },
+            "time": "2023-11-17T11:12:46+00:00"
+        },
+        {
+            "name": "swaggest/json-schema",
+            "version": "v0.12.42",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swaggest/php-json-schema.git",
+                "reference": "d23adb53808b8e2da36f75bc0188546e4cbe3b45"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swaggest/php-json-schema/zipball/d23adb53808b8e2da36f75bc0188546e4cbe3b45",
+                "reference": "d23adb53808b8e2da36f75bc0188546e4cbe3b45",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.4",
+                "phplang/scope-exit": "^1.0",
+                "swaggest/json-diff": "^3.8.2",
+                "symfony/polyfill-mbstring": "^1.19"
+            },
+            "require-dev": {
+                "phperf/phpunit": "4.8.37"
+            },
+            "suggest": {
+                "ext-mbstring": "For better performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swaggest\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Viacheslav Poturaev",
+                    "email": "vearutop@gmail.com"
+                }
+            ],
+            "description": "High definition PHP structures with JSON-schema based validation",
+            "support": {
+                "email": "vearutop@gmail.com",
+                "issues": "https://github.com/swaggest/php-json-schema/issues",
+                "source": "https://github.com/swaggest/php-json-schema/tree/v0.12.42"
+            },
+            "time": "2023-09-12T14:43:42+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/e2e/cypress/e2e/hourly-forecast-table.cy.js
+++ b/tests/e2e/cypress/e2e/hourly-forecast-table.cy.js
@@ -7,7 +7,10 @@ describe("Hourly forecast table tests", () => {
     });
 
     it("Should have 2 alert rows on the hourly forecast", () => {
-      cy.get(`#today hourly-table tr[data-row-name="alert"]`).should("have.length", 2);
+      cy.get(`#today hourly-table tr[data-row-name="alert"]`).should(
+        "have.length",
+        2,
+      );
     });
 
     it("There is a Red Flag alert of the correct displayed duration", () => {
@@ -15,17 +18,17 @@ describe("Hourly forecast table tests", () => {
       // and that contains the correct event label
       cy.contains(
         `#today hourly-table tr[data-row-name="alert"]:nth-child(2) td[colspan]:nth-child(2)`,
-        "Red Flag Warning"
+        "Red Flag Warning",
       )
         .invoke("attr", "colspan")
         .should("equal", "2");
     });
 
     it("Has a Special Weather Statement that begins in the third hour and spans 5 hours", () => {
-      cy
-        .contains(
-          `#today hourly-table tr[data-row-name="alert"]:nth-child(3) td[colspan]`,
-          "Special Weather Statement")
+      cy.contains(
+        `#today hourly-table tr[data-row-name="alert"]:nth-child(3) td[colspan]`,
+        "Special Weather Statement",
+      )
         .invoke("attr", "colspan")
         .should("equal", "5");
     });
@@ -38,21 +41,31 @@ describe("Hourly forecast table tests", () => {
 
     it("works when clicking an alert in the today tab's hourly table", () => {
       cy.visit("/point/34.749/-92.275#today");
-      cy.get(`#today hourly-table tr[data-row-name="alert"]:nth-child(2) .hourly-table__alert`).click();
+      cy.get(
+        `#today hourly-table tr[data-row-name="alert"]:nth-child(2) .hourly-table__alert`,
+      ).click();
 
       cy.get("#alerts").should("be.visible");
-      cy.get("#alerts button").contains("Red Flag Warning").invoke("attr", "aria-expanded").should("equal", "true");
-      cy.get("#a4").should("be.visible");
+      cy.get("#alerts button")
+        .contains("Red Flag Warning")
+        .invoke("attr", "aria-expanded")
+        .should("equal", "true");
+      cy.get("#a3").should("be.visible");
     });
 
     it("works when clicking an alert in one of the daily tab's hourly tables", () => {
       cy.visit("/point/34.749/-92.275#daily");
       cy.get("#daily ol li:first-child wx-hourly-toggle").click();
-      cy.get(`#daily ol li:first-child hourly-table tr[data-row-name="alert"]:nth-child(2) .hourly-table__alert`).click();
+      cy.get(
+        `#daily ol li:first-child hourly-table tr[data-row-name="alert"]:nth-child(2) .hourly-table__alert`,
+      ).click();
 
       cy.get("#alerts").should("be.visible");
-      cy.get("#alerts button").contains("Red Flag Warning").invoke("attr", "aria-expanded").should("equal", "true");
-      cy.get("#a4").should("be.visible");
+      cy.get("#alerts button")
+        .contains("Red Flag Warning")
+        .invoke("attr", "aria-expanded")
+        .should("equal", "true");
+      cy.get("#a3").should("be.visible");
     });
   });
 });

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/Alerts/Alerts.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/Alerts/Alerts.php.test
@@ -3,6 +3,7 @@
 namespace Drupal\weather_blocks\Plugin\Block\Test\EndToEnd;
 
 use Drupal\weather_blocks\Plugin\Block\LocalAlertsBlock;
+use Swaggest\JsonSchema\Schema;
 
 /**
  * Tests for alerts data structure.
@@ -25,115 +26,157 @@ final class AlertsStructureTest extends EndToEndBase
     {
         $this->onLocationRoute(34.749, -92.275);
 
-        $start = new \DateTimeImmutable();
-        $start = $start
-            ->setTimeZone(new \DateTimeZone("America/Chicago"))
-            ->setTime(16, 0, 0);
+        $isoRegex =
+            "^2[0-9]{3}-[0-9]{2}-[0-9]{2}T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]\\\\+[0-9]{2}:[0-9]{2}$";
+        $formattedDateRegex =
+            "^.+day, [0-1][0-9]\\\\/[0-3][0-9], [1-2]?[0-9]:[0-5][0-9] (A|P)M [A-Z]{3}";
 
-        $sent = $start->modify("-24 hours");
-        $effective = $start->modify("+24 hours");
-        $onset = $effective;
-        $expires = $start->modify("+40 hours");
-        $ends = $start->modify("+48 hours");
-
-        $expectedStructure = (object) [
-            "@id" =>
-                // phpcs:ignore Generic.Files.LineLength.TooLong
-                "https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.0.8760a86c78e313ccfc42aa4eb5166572a0e26e9d.003.1",
-            "@type" => "wx:Alert",
-            "id" =>
-                "urn:oid:2.49.0.1.840.0.8760a86c78e313ccfc42aa4eb5166572a0e26e9d.003.1",
-            "areaDesc" => ["Eastern Beaufort Sea Coast"],
-            "geocode" => (object) ["SAME" => ["005119", "005141"], "UGC" => []],
-            "affectedZones" => [],
-            "references" => [
-                (object) [
-                    "@id" =>
-                        // phpcs:ignore Generic.Files.LineLength.TooLong
-                        "https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.0.50186263db80dd3a37b9a35b4106434dbb236843.003.1",
-                    "identifier" =>
-                        // phpcs:ignore Generic.Files.LineLength.TooLong
-                        "urn:oid:2.49.0.1.840.0.50186263db80dd3a37b9a35b4106434dbb236843.003.1",
-                    "sender" => "w-nws.webmaster@noaa.gov",
-                    "sent" => "2024-01-03T02:50:00-09:00",
-                ],
-            ],
-            "sent" => $sent->format("c"),
-            "effective" => $effective->format("c"),
-            "onset" => $onset->format("l, m/d, g:i A T"),
-            "expires" => $expires->format("l, m/d, g:i A T"),
-            "ends" => $ends->format("l, m/d, g:i A T"),
-            "status" => "Actual",
-            "messageType" => "Update",
-            "category" => "Met",
-            "severity" => "Extreme",
-            "certainty" => "Likely",
-            "urgency" => "Expected",
-            "event" => "Blizzard Warning",
-            "sender" => "w-nws.webmaster@noaa.gov",
-            "senderName" => "NWS Fairbanks AK",
-            "headline" =>
-                // phpcs:ignore Generic.Files.LineLength.TooLong
-                "Blizzard Warning issued January 3 at 9:16AM AKST until January 5 at 3:00PM AKST by NWS Fairbanks AK",
-            "description" => [
-                ["type" => "heading", "text" => "what"],
-                [
-                    "type" => "paragraph",
-                    "text" =>
-                        "Blizzard conditions occuring. Winds gusting as high as 60 mph.",
-                ],
-                ["type" => "heading", "text" => "where"],
-                [
-                    "type" => "paragraph",
-                    "text" => "Eastern Beaufort Sea Coast.",
-                ],
-                ["type" => "heading", "text" => "when"],
-                ["type" => "paragraph", "text" => "Until 3 PM AKST Friday."],
-                ["type" => "heading", "text" => "impacts"],
-                [
-                    "type" => "paragraph",
-                    "text" =>
-                        // phpcs:ignore Generic.Files.LineLength.TooLong
-                        "Travel will be difficult. Blowing snow will cause whiteout conditions. Large snow drifts will form. Wind chills to 50 below zero could cause frostbite on exposed skin in as little as 10 minutes.",
-                ],
-                ["type" => "heading", "text" => "additional details"],
-                [
-                    "type" => "paragraph",
-                    "text" =>
-                        // phpcs:ignore Generic.Files.LineLength.TooLong
-                        "East winds will increase today. The strongest winds and lowest visibility are expected today into Thursday.",
-                ],
-            ],
-            "instruction" =>
-                // phpcs:ignore Generic.Files.LineLength.TooLong
-                "A Blizzard Warning means severe winter weather conditions are expected or occurring. Falling and blowing snow with strong winds and poor visibilities are likely. This will lead to whiteout conditions, making travel extremely difficult.",
-            "response" => "Prepare",
-            "parameters" => (object) [
-                "AWIPSidentifier" => ["WSWNSB"],
-                "WMOidentifier" => ["WWAK41 PAFG 031816"],
-                "NWSheadline" => [
-                    "BLIZZARD WARNING REMAINS IN EFFECT UNTIL 3 PM AKST FRIDAY",
-                ],
-                "BLOCKCHANNEL" => ["EAS", "NWEM", "CMAS"],
-                "EAS-ORG" => ["WXR"],
-                "VTEC" => ["/O.CON.PAFG.BZ.W.0027.000000T0000Z-240106T0000Z/"],
-                "eventEndingTime" => ["2024-01-06T00:00:00+00:00"],
-                "expiredReferences" => [
-                    // phpcs:ignore Generic.Files.LineLength.TooLong
-                    "w-nws.webmaster@noaa.gov,urn:oid:2.49.0.1.840.0.68a432c4b84fb77d2ef4265291d4890fa93f87de.004.1,2024-01-02T15:08:00-09:00 w-nws.webmaster@noaa.gov,urn:oid:2.49.0.1.840.0.4f266b4453e74c6e026c6094e432e45c271e43a5.003.1,2024-01-02T04:55:00-09:00 w-nws.webmaster@noaa.gov,urn:oid:2.49.0.1.840.0.40c0cd80cc652428b57c4b88a9491784caafc662.001.1,2024-01-01T15:21:00-09:00 w-nws.webmaster@noaa.gov,urn:oid:2.49.0.1.840.0.68519a444b9c4fe151b7a4212ef0683fcaf40695.001.1,2024-01-01T05:38:00-09:00 w-nws.webmaster@noaa.gov,urn:oid:2.49.0.1.840.0.bc83b741ef6bcec961b826c0dc76241a32664ede.001.2,2024-01-01T05:33:00-09:00",
-                ],
-            ],
-            "geometry" => [],
-            "onsetRaw" => $onset->format("c"),
-            "endsRaw" => $ends->format("c"),
-            "expiresRaw" => $expires->format("c"),
-            "timezone" => "America/Chicago",
-            "durationText" => "tomorrow afternoon",
-            "alertId" => 1,
-        ];
+        $schema = Schema::import(
+            json_decode(
+                <<<JSON
+                {
+                    "type": "object",
+                    "properties": {
+                        "@id": {
+                            "type": "string",
+                            "pattern": "^https://api\\\\.weather\\\\.gov/alerts/urn:oid:.*$"
+                        },
+                        "@type": {
+                            "const": "wx:Alert"
+                        },
+                        "id": {
+                            "type": "string",
+                            "pattern": "^urn:oid:.*$"
+                        },
+                        "areaDesc": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "geocode": {
+                            "type": "object",
+                            "properties": {
+                                "SAME": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "UGC": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "affectedZones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "pattern": "^https://api\\\\.weather\\\\.gov/zones/(forecast|county|fire)/.*$"
+                            }
+                        },
+                        "sent": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "effective": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "onsetRaw": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "endsRaw": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "expiresRaw": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "onset": {
+                            "type": "string",
+                            "pattern": "$formattedDateRegex"
+                        },
+                        "ends": {
+                            "type": "string",
+                            "pattern": "$formattedDateRegex"
+                        },
+                        "expires": {
+                            "type": "string",
+                            "pattern": "$formattedDateRegex"
+                        },
+                        "event": {
+                            "type": "string"
+                        },
+                        "headline": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "heading",
+                                            "paragraph"
+                                        ]
+                                    },
+                                    "text": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "instruction": {
+                        "type": "string"
+                    },
+                    "response": {
+                        "type": "string"
+                    },
+                    "geometry": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "const": "Polygon"
+                            },
+                            "coordinates": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "number"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "timezone": {
+                        "type": "string",
+                        "pattern": "^.+\\\\/.+$"
+                    },
+                    "duration": {
+                        "type": "string"
+                    },
+                    "alertId": {
+                        "type": "integer"
+                    }
+                }
+                JSON
+                ,
+            ),
+        );
 
         $data = $this->block->build();
 
-        $this->assertEquals($expectedStructure, $data["alerts"][0]);
+        $schema->in(json_decode(json_encode($data["alerts"][0])));
+        $this->assertTrue(true);
     }
 }

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/HourlyForecast/Alerts.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/HourlyForecast/Alerts.php.test
@@ -3,6 +3,7 @@
 namespace Drupal\weather_blocks\Plugin\Block\Test\EndToEnd;
 
 use Drupal\weather_blocks\Plugin\Block\HourlyForecastBlock;
+use Swaggest\JsonSchema\Schema;
 
 /**
  * Tests that hourly forecast data is filtered to the future.
@@ -19,196 +20,163 @@ final class HourlyForecastAlertTest extends EndToEndBase
     /**
      * Simply validate the data structure.
      * @group e2e
-     * @group e2e2
      */
     public function testHourlyAlertDataStructure(): void
     {
         $this->onLocationRoute(34.749, -92.275);
 
+        $isoRegex =
+            "^2[0-9]{3}-[0-9]{2}-[0-9]{2}T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]\\\\+[0-9]{2}:[0-9]{2}$";
+        $formattedDateRegex =
+            "^.+day, [0-1][0-9]\\\\/[0-3][0-9], [1-2]?[0-9]:[0-5][0-9] (A|P)M [A-Z]{3}";
+
+        $schema = Schema::import(
+            json_decode(
+                <<<JSON
+                {
+                    "type": "object",
+                    "properties": {
+                        "@id": {
+                            "type": "string",
+                            "pattern": "^https://api\\\\.weather\\\\.gov/alerts/urn:oid:.*$"
+                        },
+                        "@type": {
+                            "const": "wx:Alert"
+                        },
+                        "id": {
+                            "type": "string",
+                            "pattern": "^urn:oid:.*$"
+                        },
+                        "areaDesc": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "geocode": {
+                            "type": "object",
+                            "properties": {
+                                "SAME": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "UGC": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "affectedZones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "pattern": "^https://api\\\\.weather\\\\.gov/zones/(forecast|county|fire)/.*$"
+                            }
+                        },
+                        "sent": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "effective": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "onsetRaw": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "endsRaw": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "expiresRaw": {
+                            "type": "string",
+                            "pattern": "$isoRegex"
+                        },
+                        "onset": {
+                            "type": "string",
+                            "pattern": "$formattedDateRegex"
+                        },
+                        "ends": {
+                            "type": "string",
+                            "pattern": "$formattedDateRegex"
+                        },
+                        "expires": {
+                            "type": "string",
+                            "pattern": "$formattedDateRegex"
+                        },
+                        "event": {
+                            "type": "string"
+                        },
+                        "headline": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "heading",
+                                            "paragraph"
+                                        ]
+                                    },
+                                    "text": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "instruction": {
+                        "type": "string"
+                    },
+                    "response": {
+                        "type": "string"
+                    },
+                    "geometry": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "const": "Polygon"
+                            },
+                            "coordinates": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "number"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "timezone": {
+                        "type": "string",
+                        "pattern": "^.+\\\\/.+$"
+                    },
+                    "duration": {
+                        "type": "string"
+                    },
+                    "alertId": {
+                        "type": "integer"
+                    }
+                }
+                JSON
+                ,
+            ),
+        );
+
         $data = $this->block->build();
 
-        // Build up expected times, based on the contents of the test data. Do
-        // this after fetching the data so we don't get a timestamp that's off
-        // by a second due to processing inside the build() method.
-        date_default_timezone_set("UTC");
-        $now = new \DateTimeImmutable();
-
-        $sent = $now->modify("-1 hour");
-        $effective = $now->modify("-1 hour");
-        $onset = $now->modify("-1 hour");
-        $expires = $now->modify("+1 hour");
-        $ends = $now->modify("+3 hours");
-
-        $expectedAlertStructure = [
-            "periodIndex" => 0,
-            "duration" => 2,
-            "alert" => (object) [
-                "@id" =>
-                    // phpcs:ignore Generic.Files.LineLength.TooLong
-                    "https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.0.4805bd40c544dede0e96efd382a00ac5bb5d2edb.001.1",
-                "@type" => "wx:Alert",
-                "id" =>
-                    "urn:oid:2.49.0.1.840.0.4805bd40c544dede0e96efd382a00ac5bb5d2edb.001.1",
-                "areaDesc" => [
-                    "Northeast Plains",
-                    "Middle Rio Grande Valley",
-                    "Northeast Highlands",
-                    "Sandia and Manzano Mountains",
-                    "Central Highlands",
-                    "East Central Plains",
-                ],
-                "geocode" => (object) [
-                    "SAME" => [
-                        "035021",
-                        "035047",
-                        "035059",
-                        "035001",
-                        "035006",
-                        "035043",
-                        "035049",
-                        "035053",
-                        "035057",
-                        "035061",
-                        "035007",
-                        "035033",
-                        "035027",
-                        "035019",
-                        "035037",
-                        "035009",
-                        "035011",
-                        "035041",
-                    ],
-                    "UGC" => [
-                        "NMZ104",
-                        "NMZ106",
-                        "NMZ123",
-                        "NMZ124",
-                        "NMZ125",
-                        "NMZ126",
-                    ],
-                ],
-                "affectedZones" => [
-                    "https://api.weather.gov/zones/fire/ARZ044",
-                    "https://api.weather.gov/zones/fire/NMZ106",
-                    "https://api.weather.gov/zones/fire/NMZ123",
-                    "https://api.weather.gov/zones/fire/NMZ124",
-                    "https://api.weather.gov/zones/fire/NMZ125",
-                    "https://api.weather.gov/zones/fire/NMZ126",
-                ],
-                "references" => [
-                    (object) [
-                        "@id" =>
-                            // phpcs:ignore Generic.Files.LineLength.TooLong
-                            "https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.0.b43c5780909a90056fd85c482ed978a2ac632d50.001.1",
-                        "identifier" =>
-                            "urn:oid:2.49.0.1.840.0.b43c5780909a90056fd85c482ed978a2ac632d50.001.1",
-                        "sender" => "w-nws.webmaster@noaa.gov",
-                        "sent" => "2024-02-21T05:06:00-07:00",
-                    ],
-                ],
-                "sent" => $sent->format("c"),
-                "effective" => $effective->format("c"),
-                "onset" => $onset
-                    ->setTimezone(new \DateTimeZone("America/Chicago"))
-                    ->format("l, m/d, g:i A T"),
-                "expires" => $expires
-                    ->setTimezone(new \DateTimeZone("America/Chicago"))
-                    ->format("l, m/d, g:i A T"),
-                "ends" => $ends
-                    ->setTimezone(new \DateTimeZone("America/Chicago"))
-                    ->format("l, m/d, g:i A T"),
-                "onsetRaw" => $onset->format("c"),
-                "expiresRaw" => $expires->format("c"),
-                "endsRaw" => $ends->format("c"),
-                "status" => "Actual",
-                "messageType" => "Update",
-                "category" => "Met",
-                "severity" => "Severe",
-                "certainty" => "Likely",
-                "urgency" => "Expected",
-                "event" => "Red Flag Warning",
-                "sender" => "w-nws.webmaster@noaa.gov",
-                "senderName" => "NWS Albuquerque NM",
-                "headline" =>
-                    // phpcs:ignore Generic.Files.LineLength.TooLong
-                    "Red Flag Warning issued February 21 at 5:19AM MST until February 21 at 7:00PM MST by NWS Albuquerque NM",
-                "description" => [
-                    [
-                        "type" => "paragraph",
-                        "text" =>
-                            // phpcs:ignore Generic.Files.LineLength.TooLong
-                            "RED FLAG WARNING IN EFFECT TODAY BETWEEN 11 AM MST AND 7 PM MST ACROSS NORTHEASTERN, EAST CENTRAL, AND CENTRAL NEW MEXICO DUE TO LOW HUMIDITY, STRONG WINDS, AND ABOVE NORMAL TEMPERATURES",
-                    ],
-                    [
-                        "type" => "paragraph",
-                        "text" =>
-                            // phpcs:ignore Generic.Files.LineLength.TooLong
-                            ".An upper level disturbance will bring strong southwesterly to westerly winds this afternoon and early evening that will combine with above normal temperatures, an unstable atmosphere, and very low relative humidity in the low double to single digits to produce widespread critical fire weather conditions. Rapid fire spread is possible in receptive fuel beds.",
-                    ],
-                    ["type" => "heading", "text" => "area and timing"],
-                    [
-                        "type" => "paragraph",
-                        "text" =>
-                            // phpcs:ignore Generic.Files.LineLength.TooLong
-                            "Northeast Plains (Zone 104), Northeast Highlands (Zone 123), East Central Plains (Zone 126), Central Highlands (Zone 125), Sandia and Manzano Mountains (Zone 124), and Middle Rio Grande Valley (Zone 106) from 11 AM through 7 PM MST today.",
-                    ],
-                    [
-                        "type" => "paragraph",
-                        "text" =>
-                            "* 20 FOOT WINDS...West to southwest 25 to 35 mph with gusts up to 55 mph.",
-                    ],
-                    [
-                        "type" => "heading",
-                        "text" => "relative humidity",
-                    ],
-                    [
-                        "type" => "paragraph",
-                        "text" => "6 to 15 percent",
-                    ],
-                    ["type" => "heading", "text" => "impacts"],
-                    [
-                        "type" => "paragraph",
-                        "text" =>
-                            "Any fires that develop will likely spread rapidly. Outdoor burning is not recommended.",
-                    ],
-                ],
-                "instruction" =>
-                    "Please advise the appropriate officials or fire crews in the field of this Red Flag Warning.",
-                "response" => "Prepare",
-                "parameters" => (object) [
-                    "AWIPSidentifier" => ["RFWABQ"],
-                    "WMOidentifier" => ["WWUS85 KABQ 211219"],
-                    "NWSheadline" => [
-                        "RED FLAG WARNING REMAINS IN EFFECT FROM 11 AM THIS MORNING TO 7 PM MST THIS EVENING",
-                    ],
-                    "BLOCKCHANNEL" => ["EAS", "NWEM", "CMAS"],
-                    "VTEC" => [
-                        "/O.CON.KABQ.FW.W.0001.240221T1800Z-240222T0200Z/",
-                    ],
-                    "eventEndingTime" => ["2024-02-22T02:00:00+00:00"],
-                    "expiredReferences" => [
-                        // phpcs:ignore Generic.Files.LineLength.TooLong
-                        "w-nws.webmaster@noaa.gov,urn:oid:2.49.0.1.840.0.009cb1d92c051da3ecf8ae561dde07f5fcee9c74.002.2,2024-02-20T13:27:00-07:00",
-                    ],
-                ],
-                "timezone" => "America/Chicago",
-                "geometry" => [],
-                "alertId" => 4,
-            ],
-        ];
-
-        $actual = $data["alertPeriods"][0];
-
-        // The duration text is conditional based on the time of day of the
-        // alert. Because our test alert's times are relative to when the test
-        // is run, the duration text is nondeterministic. So instead of
-        // asserting it directly, we'll assert its type and otherwise remove it
-        // from the structural test.
-        $durationText = $actual["alert"]->durationText;
-        unset($actual["alert"]->durationText);
-
-        $this->assertEquals("string", gettype($durationText));
-        $this->assertEquals($expectedAlertStructure, $actual);
+        $schema->in(json_decode(json_encode($data["alertPeriods"][0])));
+        $this->assertTrue(true);
     }
 
     /**

--- a/web/modules/weather_data/src/Service/Test/AlertUtility.php.test
+++ b/web/modules/weather_data/src/Service/Test/AlertUtility.php.test
@@ -36,62 +36,52 @@ final class AlertUtilityTest extends TestCase
      */
     public function testSortsAlertsCorrectly(): void
     {
+        $now = new \DateTimeImmutable();
+
         $alerts = [
             (object) [
                 "event" => "flood watch",
+                "onset" => $now->modify("-1 hour"),
             ],
             (object) [
                 "event" => "air quality alert",
-                "onset" => \DateTimeImmutable::createFromFormat(
-                    \DateTimeInterface::ISO8601_EXPANDED,
-                    "2000-01-01T00:00:00Z",
-                ),
+                "onset" => $now->modify("+1 hour"),
             ],
             (object) [
                 "event" => "volcano warning",
-                "onset" => \DateTimeImmutable::createFromFormat(
-                    \DateTimeInterface::ISO8601_EXPANDED,
-                    "2012-12-21T00:00:00Z",
-                ),
+                "onset" => $now->modify("-1 hour"),
             ],
             (object) [
                 "event" => "tornado warning",
+                "onset" => $now->modify("-1 hour"),
             ],
             (object) [
                 "event" => "dust storm warning",
+                "onset" => $now->modify("-1 hour"),
             ],
             (object) [
                 "event" => "volcano warning",
-                "onset" => \DateTimeImmutable::createFromFormat(
-                    \DateTimeInterface::ISO8601_EXPANDED,
-                    "2000-01-01T00:00:00Z",
-                ),
+                "onset" => $now->modify("+2 hour"),
             ],
             (object) [
                 "event" => "air quality alert",
-                "onset" => \DateTimeImmutable::createFromFormat(
-                    \DateTimeInterface::ISO8601_EXPANDED,
-                    "2020-01-01T00:00:00Z",
-                ),
+                "onset" => $now->modify("+2 hours"),
             ],
             (object) [
                 "event" => "air quality alert",
-                "onset" => \DateTimeImmutable::createFromFormat(
-                    \DateTimeInterface::ISO8601_EXPANDED,
-                    "2020-01-01T00:00:00Z",
-                ),
+                "onset" => $now->modify("+3 hour"),
             ],
         ];
 
         $expected = [
-            $alerts[3],
-            $alerts[5],
-            $alerts[2],
-            $alerts[4],
-            $alerts[0],
-            $alerts[1],
-            $alerts[6],
-            $alerts[7],
+            $alerts[3], // active tornado warning
+            $alerts[2], // active volcano warning
+            $alerts[4], // active dust storm warning
+            $alerts[0], // active flood watch
+            $alerts[1], // next hour air quality alert
+            $alerts[5], // in two hours volcano warning
+            $alerts[6], // in two hours air quality alert
+            $alerts[7], // in three hours air quality alert
         ];
 
         $actual = AlertUtility::sort($alerts);

--- a/web/modules/weather_data/src/Service/Test/LegacyIconMapping.php.test
+++ b/web/modules/weather_data/src/Service/Test/LegacyIconMapping.php.test
@@ -18,9 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class WeatherDataLegacyIconMapping extends TestCase
 {
-    /**
-     * @group unit
-     */
+    #[Group(unit)]
     public function testIconMapping(): void
     {
         $path = realpath(

--- a/web/modules/weather_data/src/Service/Test/LegacyIconMapping.php.test
+++ b/web/modules/weather_data/src/Service/Test/LegacyIconMapping.php.test
@@ -18,7 +18,9 @@ use PHPUnit\Framework\TestCase;
  */
 final class WeatherDataLegacyIconMapping extends TestCase
 {
-    #[Group(unit)]
+    /**
+     * @group unit
+     */
     public function testIconMapping(): void
     {
         $path = realpath(


### PR DESCRIPTION
## What does this PR do? 🛠️

- Sort currently-active alerts by priority
- Sort future alerts by onset time
- If multiple alerts have the same onset time, sort them by priority within their onset time

closes #940

## What does the reviewer need to know? 🤔

- Incidentally updates the alert structure tests to use JSON schema validation, so we don't have to care as much about *actual* values, only the form of the values. (Both of those e2e tests needed to be updated for this PR anyway because the ordering of alerts was different after the change, and I figured rather than keep fighting these super fragile timing tests, I'd just... try something new.)