### PR TITLE
Login & logout flows

### DIFF
--- a/web/config/cloudgov/samlauth.authentication.yml
+++ b/web/config/cloudgov/samlauth.authentication.yml
@@ -2,8 +2,8 @@ _core:
   default_config_hash: oDGEkhP0h5rXXqlDplxeBDre0goLigOJupHKMDMwcqM
 login_menu_item_title: ''
 logout_menu_item_title: ''
-login_redirect_url: ''
-logout_redirect_url: ''
+login_redirect_url: '/admin/workbench'
+logout_redirect_url: '/user/login'
 error_redirect_url: ''
 error_throw: false
 local_login_saml_error: false

--- a/web/config/sync/block.block.new_weather_theme_locationsearchblock.yml
+++ b/web/config/sync/block.block.new_weather_theme_locationsearchblock.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - system
     - weather_blocks
   theme:
     - new_weather_theme
@@ -18,4 +19,8 @@ settings:
   label_display: '0'
   provider: weather_blocks
   grid: ',,'
-visibility: {  }
+visibility:
+  request_path:
+    id: request_path
+    negate: true
+    pages: '/user/*'

--- a/web/themes/new_weather_theme/new_weather_theme.theme
+++ b/web/themes/new_weather_theme/new_weather_theme.theme
@@ -5,6 +5,30 @@
  * Functions to support theming.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_form_FORM_ID_alter() for the login form.
+ */
+function new_weather_theme_form_user_login_form_alter(
+    &$form, FormStateInterface $form_state
+) {
+    $moduleHandler = \Drupal::service('module_handler');
+    if ($moduleHandler->moduleExists('samlauth')) {
+        $form['samlauth_login_link'] = array(
+            '#title' => 'SAML login',
+            '#type' => 'link',
+            '#url' => Url::fromRoute('samlauth.saml_controller_login'),
+            '#attributes' => [
+                'title' => 'SAML login',
+                'class' => ['usa-button'],
+            ],
+            '#weight' => -1000,
+        );
+    }
+}
+
 /**
  * Implements hook_preprocess_image_widget().
  */

--- a/web/themes/new_weather_theme/new_weather_theme.theme
+++ b/web/themes/new_weather_theme/new_weather_theme.theme
@@ -12,18 +12,23 @@ use Drupal\Core\Url;
  * Implements hook_form_FORM_ID_alter() for the login form.
  */
 function new_weather_theme_form_user_login_form_alter(
-    &$form, FormStateInterface $form_state
+    &$form,
+    FormStateInterface $form_state
 ) {
     $moduleHandler = \Drupal::service('module_handler');
     if ($moduleHandler->moduleExists('samlauth')) {
         $form['samlauth_login_link'] = array(
-            '#title' => 'Login with your NOAA account',
+            '#title' => 'Login with your NOAA Account',
             '#type' => 'link',
             '#url' => Url::fromRoute('samlauth.saml_controller_login'),
             '#attributes' => [
-                'title' => 'NOAA account login',
+                'title' => 'NOAA Account',
                 'class' => ['usa-button'],
             ],
+            '#weight' => -2000,
+        );
+        $form['mymarkup'] = array(
+            '#markup' => '<strong>OR your username and password: </strong>',
             '#weight' => -1000,
         );
     }

--- a/web/themes/new_weather_theme/new_weather_theme.theme
+++ b/web/themes/new_weather_theme/new_weather_theme.theme
@@ -17,11 +17,11 @@ function new_weather_theme_form_user_login_form_alter(
     $moduleHandler = \Drupal::service('module_handler');
     if ($moduleHandler->moduleExists('samlauth')) {
         $form['samlauth_login_link'] = array(
-            '#title' => 'SAML login',
+            '#title' => 'Login with your NOAA account',
             '#type' => 'link',
             '#url' => Url::fromRoute('samlauth.saml_controller_login'),
             '#attributes' => [
-                'title' => 'SAML login',
+                'title' => 'NOAA account login',
                 'class' => ['usa-button'],
             ],
             '#weight' => -1000,


### PR DESCRIPTION
## What does this PR do? 🛠️
Currently deployed to https://weathergov-greg.app.cloud.gov/, see https://weathergov-greg.app.cloud.gov/user/login to start. 

Following #952 this PR: 

* Upon logging into the CMS, lands the user immediately on the workbench OOTB dashboard (most recent content that you engaged with)
* Once logged in, user is still be able to access the front-facing site in a separate tab or window
* Upon logging out of the CMS, have the option on that logout page (/user/login) to log back in

## Screenshots (if appropriate): 📸

Login/logout page (at /user or /user/login when logged out): 
<img width="740" alt="Screenshot 2024-04-03 at 10 06 52 AM" src="https://github.com/weather-gov/weather.gov/assets/142825699/4120a54b-67c3-473e-8869-726f7cbe1186">

Logout button (unchanged): 
<img width="604" alt="Screenshot 2024-04-02 at 10 08 35 AM" src="https://github.com/weather-gov/weather.gov/assets/142825699/3694325e-d907-4447-8a58-ccb71c89299f">



