### PR TITLE
Fix the timestamp in the screen reader narrative for current conditions

### DIFF
--- a/tests/a11y/cypress/e2e/dates-are-localized.cy.js
+++ b/tests/a11y/cypress/e2e/dates-are-localized.cy.js
@@ -1,0 +1,40 @@
+const dayjs = require("dayjs");
+
+describe("main script", () => {
+  before(() => {
+    cy.request("http://localhost:8081/play/testing");
+  });
+
+  const obsTime = dayjs("2024-02-20T15:53:00+00:00").toDate();
+
+  describe("formats the narrative timestamp according to the browser's locale settings", () => {
+    // US English, Mexican Spanish, Puerto Rican Spanish, and US Spanish. Just
+    // some representative test cases. If these pass, others should too.
+    ["en-US", "es-MX", "es-PR", "es-US"].forEach((locale) => {
+      it(`for the ${locale} locale`, () => {
+        const formatter = new Intl.DateTimeFormat(locale, {
+          weekday: "long",
+          hour: "numeric",
+          minute: "2-digit",
+          timeZoneName: "short",
+        });
+
+        cy.visit("/point/33.521/-86.812/#current", {
+          onBeforeLoad: (win) => {
+            Object.defineProperty(win.navigator, "languages", {
+              value: [locale],
+            });
+          },
+        });
+
+        cy.get(".usa-sr-only").then((sr) => {
+          expect(sr.length).to.be.greaterThan(0);
+
+          const expected = formatter.format(obsTime);
+          console.log(expected);
+          expect(sr).to.contain(expected);
+        });
+      });
+    });
+  });
+});

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -14,15 +14,13 @@
       {# First row is temperature #}
       <div class="display-flex">
         <div class="current-conditions-temp display-flex flex-row flex-align-start margin-right-2 text-primary-darker">
-          {{ content.temperature }}<span aria-hidden="true" class="font-body-xs display-inline-block left-full margin-top-05 margin-left-neg-2px">&deg;F</span>
-          <span class="usa-sr-only">℉</span>
+          {{ content.temperature }}<span class="font-body-xs display-inline-block left-full margin-top-05 margin-left-neg-2px">&deg;F</span>
         </div>
         <div class="margin-top-05 position-relative">
           <div class="font-mono-2xs font-family-mono text-base text-uppercase">{{ "Feels like" | t }}</div>
           <div class="text-primary-darker">
-            <p class="margin-top-2px font-body-md">{{ content.feels_like }}
-              <span aria-hidden="true" class="font-body-3xs position-absolute margin-top">&deg;F</span>
-              <span class="usa-sr-only">℉</span>
+            <p class="margin-top-2px font-body-md">
+              {{ content.feels_like }}<span class="font-body-3xs position-absolute margin-top">&deg;F</span>
             </p>
           </div>
         </div>
@@ -91,12 +89,12 @@
     </div>
 
     {# Weather narrative is for screen readers only #}
-    <div data-wx-current-conditions-narrative class="tablet:grid-col-12 usa-sr-only height-1px">
+    <div role="text" data-wx-current-conditions-narrative class="tablet:grid-col-12 usa-sr-only height-1px">
         {{ 'Weather as of' | t }}
         {# Datetimes are localized in client-side Javascript. #}
-        <weather-timestamp data-utc="{{ content.timestamp.utc }}">
+        <time datetime="{{ content.timestamp.utc }}" data-wx-local-time>
           {{ content.timestamp.formatted }}
-        </weather-timestamp>
+        </time>.
         {{ "The weather in @place, is @conditions.
           Temperature is @temperature ℉." |
         t({


### PR DESCRIPTION
## What does this PR do? 🛠️

The timestamp in the screen reader narrative section of the current conditions component did not get updated when we switched how we do time localization. This PR fixes that.

> [!NOTE]  
> VoiceOver treats inline elements (like `span` or `time`) as independent blocks when reading them, so users must navigate to them individually. We cannot get around this. In Safari, adding `role="text"` to the container element will force VoiceOver to treat it as a single block of text, but that's a nonstandard role and is ignored by all other browsers.
>
> I only have access to VoiceOver, so I cannot test this behavior with other screen readers, unfortunately, but the internet seems to think it should work as expected with them. VoiceOver is the oddball.

- closes #1016
