### PR TITLE
Use ISO8601 timestamps instead of Unix epoch

### DIFF
--- a/tests/e2e/cypress/e2e/dates-are-localized.cy.js
+++ b/tests/e2e/cypress/e2e/dates-are-localized.cy.js
@@ -53,9 +53,7 @@ describe("main script", () => {
             const format =
               timestamp.getAttribute("data-date-format") || "basic";
 
-            const expected = formatters
-              .get(format)
-              .format(dayjs.unix(utc).toDate());
+            const expected = formatters.get(format).format(dayjs(utc).toDate());
             expect(actual).to.equal(expected);
           }
         });

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/Observations/Observations.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/Observations/Observations.php.test
@@ -36,7 +36,7 @@ final class ObservationsStructureTest extends EndToEndBase
             "temperature" => 57,
             "timestamp" => [
                 "formatted" => "Tuesday 3:53 PM GMT+0000",
-                "utc" => 1708444380,
+                "utc" => "2024-02-20T15:53:00+00:00",
             ],
             "wind" => [
                 "speed" => 0,

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/WeatherStoryBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/WeatherStoryBlock.php.test
@@ -85,7 +85,7 @@ final class WeatherStoryBlockTest extends Base
             ],
             "updated" => [
                 "formatted" => "Jun 24, 1977, 7:16 AM",
-                "utc" => "235984600",
+                "utc" => "1977-06-24T07:16:40+00:00",
             ],
         ];
 
@@ -112,7 +112,7 @@ final class WeatherStoryBlockTest extends Base
             "image" => null,
             "updated" => [
                 "formatted" => "Jun 24, 1977, 7:16 AM",
-                "utc" => "235984600",
+                "utc" => "1977-06-24T07:16:40+00:00",
             ],
         ];
 

--- a/web/modules/weather_blocks/src/Plugin/Block/WeatherStoryBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/WeatherStoryBlock.php
@@ -66,7 +66,7 @@ class WeatherStoryBlock extends WeatherBlockBase
                     "image" => $image,
                     "updated" => [
                         "formatted" => $changed->format("M j, Y, g:i A"),
-                        "utc" => $changed->format("U"),
+                        "utc" => $changed->format("c"),
                     ],
                 ];
             }

--- a/web/modules/weather_data/src/Service/ObservationsTrait.php
+++ b/web/modules/weather_data/src/Service/ObservationsTrait.php
@@ -184,7 +184,7 @@ trait ObservationsTrait
             ),
             "timestamp" => [
                 "formatted" => $timestamp->format("l g:i A T"),
-                "utc" => (int) $timestamp->format("U"),
+                "utc" => $timestamp->format("c"),
             ],
             "wind" => [
                 // Kph to mph.

--- a/web/themes/new_weather_theme/assets/js/localizeTimestamps.js
+++ b/web/themes/new_weather_theme/assets/js/localizeTimestamps.js
@@ -37,15 +37,7 @@
 
     const input = timestamp.getAttribute("datetime");
 
-    const date = (() => {
-      // The datetime value we set could be either an ISO8601 string, which
-      // will have non-digit characters, or a Unix epoch timestamp, which only
-      // includes digits. How we parse it depends on which it is.
-      if (input.match(/[^\d]/)) {
-        return new Date(Date.parse(input));
-      }
-      return new Date(Number.parseInt(input, 10) * 1_000);
-    })();
+    const date = new Date(Date.parse(input));
 
     const formatter = timestamp.getAttribute("data-date-format") || "basic";
 


### PR DESCRIPTION
## What does this PR do? 🛠️

When I originally created the current conditions block, I opted to put the Unix epoch timestamp in the Twig template because Javascript Dates natively understand that (plus or minus 3 orders of magnitude...). Then we switched to using the `<time>` element, whose `datetime` property has a limited set of valid formats, none of which are Unix epoch.

This PR updates the current conditions and weather story blocks to use ISO8601 timestamps instead of Unix epoch, making our `<time>` elements spec-compliant. It also fixes the relevant tests.

There should be no user-visible changes.

- closes #1014