### PR TITLE
Fixing bug in FF where click evens on list items were not working

### DIFF
--- a/web/themes/new_weather_theme/assets/js/components/combo-box.js
+++ b/web/themes/new_weather_theme/assets/js/components/combo-box.js
@@ -124,7 +124,7 @@ class ComboBox extends HTMLElement {
 
         this.template = document.createElement("template");
         this.template.innerHTML = comboTemplate;
-        this.attachShadow({mode: "open", delegatesFocus: true});
+        this.attachShadow({mode: "open", delegatesFocus: false});
         this.shadowRoot.append(
             this.template.content.cloneNode(true)
         );
@@ -162,7 +162,7 @@ class ComboBox extends HTMLElement {
         this.addEventListener("input", this.handleInput);
         this.addEventListener("keydown", this.handleKeyDown);
         this.addEventListener("change", this.handleTextInput);
-        this.addEventListener("focusout", this.hideList);
+        this.addEventListener("blur", this.hideList);
 
         // Initial attributes
         this.classList.add("wx-combo-box");
@@ -186,7 +186,7 @@ class ComboBox extends HTMLElement {
         this.removeEventListener("input", this.handleInput);
         this.removeEventListener("keydown", this.handleKeyDown);
         this.removeEventListener("change", this.handleTextInput);
-        this.removeEventListener("focusout", this.hideList);
+        this.removeEventListener("blur", this.hideList);
     }
 
     /**

--- a/web/themes/new_weather_theme/assets/js/components/combo-box.js
+++ b/web/themes/new_weather_theme/assets/js/components/combo-box.js
@@ -124,7 +124,7 @@ class ComboBox extends HTMLElement {
 
         this.template = document.createElement("template");
         this.template.innerHTML = comboTemplate;
-        this.attachShadow({mode: "open", delegatesFocus: false});
+        this.attachShadow({mode: "open", delegatesFocus: true});
         this.shadowRoot.append(
             this.template.content.cloneNode(true)
         );
@@ -159,11 +159,6 @@ class ComboBox extends HTMLElement {
     }
 
     connectedCallback(){
-        this.addEventListener("input", this.handleInput);
-        this.addEventListener("keydown", this.handleKeyDown);
-        this.addEventListener("change", this.handleTextInput);
-        this.addEventListener("blur", this.hideList);
-
         // Initial attributes
         this.classList.add("wx-combo-box");
         this.setAttribute("expanded", "false");
@@ -179,6 +174,13 @@ class ComboBox extends HTMLElement {
         this.initListbox();
         this.initClearButton();
         this.initToggleButton();
+
+        // Bind event listeners
+        this.addEventListener("input", this.handleInput);
+        this.addEventListener("keydown", this.handleKeyDown);
+        this.addEventListener("change", this.handleTextInput);
+        this.addEventListener("blur", this.hideList);
+        this.input.addEventListener("blur", this.hideList);
         
     }
 
@@ -187,6 +189,7 @@ class ComboBox extends HTMLElement {
         this.removeEventListener("keydown", this.handleKeyDown);
         this.removeEventListener("change", this.handleTextInput);
         this.removeEventListener("blur", this.hideList);
+        this.input.removeEventListener("blur", this.hideList)
     }
 
     /**

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -36,7 +36,7 @@ location-search:
     assets/js/components/LocationSearch.js: { preprocess: false }
 
 location-combo-box:
-  version: 2024-03-25
+  version: 2024-04-15
   js:
     assets/js/components/combo-box.js: { preprocess: false }
         

--- a/web/themes/new_weather_theme/tests/components/combo-box-tests.js
+++ b/web/themes/new_weather_theme/tests/components/combo-box-tests.js
@@ -392,7 +392,7 @@ describe("Combo box unit tests", () => {
       const component = document.querySelector("wx-combo-box");
       expect(component.isShowingList).to.be.true;
 
-      const event = new window.FocusEvent("focusout", { bubbles: true});
+      const event = new window.FocusEvent("blur", { bubbles: true});
       component.input.dispatchEvent(event);
 
       expect(component.isShowingList).to.be.false;


### PR DESCRIPTION
## What does this PR do? 🛠️
Previously, in an effort to deal with Safari's non-standard behavior when dealing with focus in shadow doms, I made an attempt to switch from `blur` to `focusout` in order to better capture the click event on a list item before the list hides. The solution that actually worked, however, was to use the [`delegatesFocus`](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus) property on the shadow dom. I forgot to switch back to `blur`. Only this weekend when trying to use beta from my phone, on which I use FF mobile, did I see that I couldn't select a location.

## What does the reviewer need to know? 🤔
Not sure how we want to handle this kind of stuff in the future. I suppose we are only using chromium for e2e testing? Should we consider multiple backends if possible?

