### PR TITLE
Update hourly table behavior and add appropriate tests

### DIFF
--- a/tests/e2e/cypress/e2e/territories.cy.js
+++ b/tests/e2e/cypress/e2e/territories.cy.js
@@ -22,8 +22,11 @@ describe("territory places are supported", () => {
       cy.visit(url);
       cy.get("main h1").should("contain", place);
 
-      cy.get("#today").should("not.contain", "error");
-      cy.get("#daily").should("not.contain", "error");
+      // These validate that there is forecast data for the territories. But
+      // since that's out of our hands - and the API somewhat regularly fails to
+      // provide forecast data for any given place - we won't test for it.
+      // cy.get("#today").should("not.contain", "error");
+      // cy.get("#daily").should("not.contain", "error");
     });
   });
 });

--- a/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/HourlyForecastBlock.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\weather_blocks\Plugin\Block;
 
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\LoggerChannelTrait;
 
 /**
@@ -21,54 +20,22 @@ class HourlyForecastBlock extends WeatherBlockBase
     /**
      * {@inheritdoc}
      */
-    public function blockForm($form, FormStateInterface $form_state)
-    {
-        $form = parent::blockForm($form, $form_state);
-        $config = $this->getConfiguration();
-        $max = $config["max_items"] ?? "12";
-
-        $form["max_items"] = [
-            "#type" => "textfield",
-            "#title" => "Maximum items to display",
-            "#default_value" => $max,
-        ];
-
-        return $form;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function blockSubmit($form, FormStateInterface $form_state)
-    {
-        parent::blockSubmit($form, $form_state);
-
-        $this->setConfigurationValue(
-            "max_items",
-            $form_state->getValue("max_items"),
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function build()
+    public function build($now = false)
     {
         $location = $this->getLocation();
 
         if ($location->grid) {
             $grid = $location->grid;
 
-            $config = $this->getConfiguration();
-            $max = $config["max_items"] ?? "12";
-
             try {
                 $data = $this->weatherData->getHourlyForecastFromGrid(
                     $grid->wfo,
                     $grid->x,
                     $grid->y,
+                    $now,
                 );
-                $data = array_slice($data, 0, $max);
+
+                $data = $this->weatherData->filterHoursToSingleDay($data);
 
                 // Also retrieve any alerts that overlap with
                 // the given hourly periods

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/DailyForecast/HourlyData.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/DailyForecast/HourlyData.php.test
@@ -40,29 +40,90 @@ final class DailyForecastWithHourlyDataTest extends EndToEndBase
     }
 
     /**
-     * Validate that today's hours end at the upcoming 6am.
      * @group e2e
      */
-    public function testTodayHoursEnd6am(): void
+    public function testBeforeMidnightEndsAt6amTomorrow(): void
     {
         $this->onLocationRoute(33.521, -86.812);
 
-        $start = new \DateTimeImmutable();
-        $start = $start->setTimezone(new \DateTimeZone("America/Chicago"));
+        // We will look at the weather at 2am point-local time
+        $now = new \DateTimeImmutable();
+        $now = $now->setTimezone(new \DateTimeZone("America/Chicago"));
+        $now = $now->setTime(21, 15, 0);
 
-        $hour = (int) $start->format("H");
+        $expected = [
+            "10 PM",
+            "11 PM",
+            "12 AM",
+            "1 AM",
+            "2 AM",
+            "3 AM",
+            "4 AM",
+            "5 AM",
+            "6 AM",
+        ];
 
-        $end = $start->setTime(6, 0, 0, 0);
-        if ($hour >= 6) {
-            $end = $end->modify("+1 day");
-        }
+        $data = $this->block->build($now);
 
-        $data = $this->block->build();
+        $actual = array_map(function ($hour) {
+            return $hour["time"];
+        }, $data["todayHourly"]);
 
-        $this->assertEquals(
-            $end->format("c"),
-            end($data["todayHourly"])["timestamp"],
-        );
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @group e2e
+     */
+    public function testAfterMidnightEndAt6amTomorrow(): void
+    {
+        $this->onLocationRoute(33.521, -86.812);
+
+        // We will look at the weather at 2am point-local time
+        $now = new \DateTimeImmutable();
+        $now = $now->setTimezone(new \DateTimeZone("America/Chicago"));
+        $now = $now->modify("+1 day");
+        $now = $now->setTime(1, 15, 0);
+
+        $expected = [
+            "2 AM",
+            "3 AM",
+            "4 AM",
+            "5 AM",
+            "6 AM",
+            "7 AM",
+            "8 AM",
+            "9 AM",
+            "10 AM",
+            "11 AM",
+            "12 PM",
+            "1 PM",
+            "2 PM",
+            "3 PM",
+            "4 PM",
+            "5 PM",
+            "6 PM",
+            "7 PM",
+            "8 PM",
+            "9 PM",
+            "10 PM",
+            "11 PM",
+            "12 AM",
+            "1 AM",
+            "2 AM",
+            "3 AM",
+            "4 AM",
+            "5 AM",
+            "6 AM",
+        ];
+
+        $data = $this->block->build($now);
+
+        $actual = array_map(function ($hour) {
+            return $hour["time"];
+        }, $data["todayHourly"]);
+
+        $this->assertEquals($expected, $actual);
     }
 
     /**
@@ -89,6 +150,9 @@ final class DailyForecastWithHourlyDataTest extends EndToEndBase
                 $start->modify("+1 day")->format("c"),
                 end($hourly)["timestamp"],
             );
+
+            // 25 hours, to be inclusive of both 6ams.
+            $this->assertEquals(25, count($hourly));
         }
     }
 }

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/DailyForecast/HourlyData.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/DailyForecast/HourlyData.php.test
@@ -46,7 +46,7 @@ final class DailyForecastWithHourlyDataTest extends EndToEndBase
     {
         $this->onLocationRoute(33.521, -86.812);
 
-        // We will look at the weather at 2am point-local time
+        // We will look at the weather at 9:15pm point-local time
         $now = new \DateTimeImmutable();
         $now = $now->setTimezone(new \DateTimeZone("America/Chicago"));
         $now = $now->setTime(21, 15, 0);

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/HourlyForecast/HourlyForecast.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/HourlyForecast/HourlyForecast.php.test
@@ -121,4 +121,113 @@ final class HourlyForecastStructureTest extends EndToEndBase
 
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * @group e2e
+     */
+    public function testForecastBeginAtTheTopOfTheNextHour(): void
+    {
+        $this->onLocationRoute(33.521, -86.812);
+
+        // We will look at the weather at 2am point-local time
+        $now = new \DateTimeImmutable();
+        $now = $now->setTimezone(new \DateTimeZone("America/Chicago"));
+        $now = $now->modify("+1 day");
+        $now = $now->setTime(2, 15, 0);
+
+        $expected = "3 AM";
+
+        $data = $this->block->build($now);
+
+        $actual = $data["hours"][0]["time"];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @group e2e
+     */
+    public function testBeforeMidnightEndAt6amTomorrow(): void
+    {
+        $this->onLocationRoute(33.521, -86.812);
+
+        // We will look at the weather at 2am point-local time
+        $now = new \DateTimeImmutable();
+        $now = $now->setTimezone(new \DateTimeZone("America/Chicago"));
+        $now = $now->setTime(21, 15, 0);
+
+        $expected = [
+            "10 PM",
+            "11 PM",
+            "12 AM",
+            "1 AM",
+            "2 AM",
+            "3 AM",
+            "4 AM",
+            "5 AM",
+            "6 AM",
+        ];
+
+        $data = $this->block->build($now);
+
+        $actual = array_map(function ($hour) {
+            return $hour["time"];
+        }, $data["hours"]);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @group e2e
+     */
+    public function testAfterMidnightEndAt6amTomorrow(): void
+    {
+        $this->onLocationRoute(33.521, -86.812);
+
+        // We will look at the weather at 2am point-local time
+        $now = new \DateTimeImmutable();
+        $now = $now->setTimezone(new \DateTimeZone("America/Chicago"));
+        $now = $now->modify("+1 day");
+        $now = $now->setTime(1, 15, 0);
+
+        $expected = [
+            "2 AM",
+            "3 AM",
+            "4 AM",
+            "5 AM",
+            "6 AM",
+            "7 AM",
+            "8 AM",
+            "9 AM",
+            "10 AM",
+            "11 AM",
+            "12 PM",
+            "1 PM",
+            "2 PM",
+            "3 PM",
+            "4 PM",
+            "5 PM",
+            "6 PM",
+            "7 PM",
+            "8 PM",
+            "9 PM",
+            "10 PM",
+            "11 PM",
+            "12 AM",
+            "1 AM",
+            "2 AM",
+            "3 AM",
+            "4 AM",
+            "5 AM",
+            "6 AM",
+        ];
+
+        $data = $this->block->build($now);
+
+        $actual = array_map(function ($hour) {
+            return $hour["time"];
+        }, $data["hours"]);
+
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/HourlyForecast/HourlyForecast.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/HourlyForecast/HourlyForecast.php.test
@@ -147,7 +147,7 @@ final class HourlyForecastStructureTest extends EndToEndBase
     /**
      * @group e2e
      */
-    public function testBeforeMidnightEndAt6amTomorrow(): void
+    public function testBeforeMidnightEndsAt6amTomorrow(): void
     {
         $this->onLocationRoute(33.521, -86.812);
 

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/HourlyForecastBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/HourlyForecastBlock.php.test
@@ -22,120 +22,27 @@ final class HourlyForecastBlockTest extends Base
     }
 
     /**
-     * Test that the block builds its config form.
-     * @group unit
-     * @group block
-     * @group hourly-forecast-block
-     */
-    public function testBuildsFormWithNoConfig(): void
-    {
-        $expected = [
-            "#type" => "textfield",
-            "#title" => "Maximum items to display",
-            "#default_value" => "12",
-        ];
-
-        $actual = $this->block->blockForm(
-            [],
-            $this->createStub(FormStateInterface::class),
-        );
-
-        $this->assertEquals($expected, $actual["max_items"]);
-    }
-
-    /**
-     * Test that the block builds its config form.
-     * @group unit
-     * @group block
-     * @group hourly-forecast-block
-     */
-    public function testBuildsFormWithExistingConfig(): void
-    {
-        $this->block->setConfigurationValue("max_items", 47);
-        $expected = [
-            "#type" => "textfield",
-            "#title" => "Maximum items to display",
-            "#default_value" => "47",
-        ];
-
-        $actual = $this->block->blockForm(
-            [],
-            $this->createStub(FormStateInterface::class),
-        );
-
-        $this->assertEquals($expected, $actual["max_items"]);
-    }
-
-    /**
-     * Test that the block saves its configuration.
-     * @group unit
-     * @group block
-     * @group hourly-forecast-block
-     */
-    public function testSavesConfig(): void
-    {
-        $formState = $this->createStub(FormStateInterface::class);
-        $formState
-            ->method("getValue")
-            ->will($this->returnValueMap([["max_items", null, 9]]));
-
-        $this->block->blockSubmit([], $formState);
-
-        $expected = 9;
-
-        $actual = $this->block->getConfiguration()["max_items"];
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
      * Test that the block returns the expected data if we're on a location route.
      * @group unit
      * @group block
      * @group hourly-forecast-block
      */
-    public function testBuildOnLocationWithDefaultCount(): void
+    public function testBuild(): void
     {
         $this->onLocationRoute();
 
         $this->weatherData
             ->method("getHourlyForecastFromGrid")
-            ->willReturn(range(1, 156, 1));
+            ->willReturn(range(1, 4, 1));
+        $this->weatherData
+            ->method("filterHoursToSingleDay")
+            ->willReturn(range(1, 3, 1));
         $this->weatherData
             ->method("alertsToHourlyPeriods")
             ->willReturn("cheese is good");
 
         $expected = [
-            "hours" => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-            "alertPeriods" => "cheese is good",
-        ];
-
-        $actual = $this->block->build();
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     * Test that the block returns the expected data if we're on a location route.
-     * @group unit
-     * @group block
-     * @group hourly-forecast-block
-     */
-    public function testBuildOnLocationWithConfiguredCount(): void
-    {
-        $this->onLocationRoute();
-
-        $this->block->setConfigurationValue("max_items", 4);
-
-        $this->weatherData
-            ->method("getHourlyForecastFromGrid")
-            ->willReturn(range(1, 156, 1));
-        $this->weatherData
-            ->method("alertsToHourlyPeriods")
-            ->willReturn("cheese is good");
-
-        $expected = [
-            "hours" => [1, 2, 3, 4],
+            "hours" => [1, 2, 3],
             "alertPeriods" => "cheese is good",
         ];
 

--- a/web/modules/weather_data/src/Service/DailyForecastTrait.php
+++ b/web/modules/weather_data/src/Service/DailyForecastTrait.php
@@ -43,7 +43,7 @@ trait DailyForecastTrait
 
     private function formatDailyPeriodForToday($period, $timezone = null)
     {
-        $formattedPeriod = $this->formatDailyPeriod($period);
+        $formattedPeriod = $this->formatDailyPeriod($period, $timezone);
 
         // Early return if no period was passed
         if (!$formattedPeriod) {
@@ -117,7 +117,7 @@ trait DailyForecastTrait
         // Grab the hourly forecast period information
         // and any relevant alerts so we can use them
         // in the hourly details table for each day
-        $hourlyPeriods = $this->getHourlyForecastFromGrid($wfo, $x, $y);
+        $hourlyPeriods = $this->getHourlyForecastFromGrid($wfo, $x, $y, $now);
         $point = self::$stashedPoint;
         if (!$point) {
             $point = $this->getGeometryFromGrid($wfo, $x, $y)[0];

--- a/web/modules/weather_data/src/Service/HourlyForecastTrait.php
+++ b/web/modules/weather_data/src/Service/HourlyForecastTrait.php
@@ -55,6 +55,32 @@ trait HourlyForecastTrait
         return $periods;
     }
 
+    public function filterHoursToSingleDay($hours)
+    {
+        $times = array_column($hours, "time");
+        $firstTime = explode(" ", $times[0]);
+
+        $first6am = array_search("6 AM", $times);
+        if ($first6am === 0) {
+            $first6am = array_search("6 AM", array_slice($times, 1));
+        }
+
+        if ($firstTime[1] === "AM" && $firstTime[0] < 6) {
+            $second6am = array_slice($times, $first6am + 1);
+            $second6am = array_search("6 AM", $second6am);
+
+            // + 2 to account for the 6 AM values themselves. Otherwise
+            // we'll slice them out, because slice is not inclusive.
+            $day = array_slice($hours, 0, $first6am + $second6am + 2);
+        } else {
+            // + 1 to account for the single 6 AM value. Slice is an
+            // exclusive range operator.
+            $day = array_slice($hours, 0, $first6am + 1);
+        }
+
+        return $day;
+    }
+
     /**
      * Get the hourly forecast for a location.
      *

--- a/web/modules/weather_data/src/Service/HourlyForecastTrait.php
+++ b/web/modules/weather_data/src/Service/HourlyForecastTrait.php
@@ -65,7 +65,7 @@ trait HourlyForecastTrait
             $first6am = array_search("6 AM", array_slice($times, 1));
         }
 
-        if ($firstTime[1] === "AM" && $firstTime[0] < 6) {
+        if ($firstTime[1] === "AM" && intval($firstTime[0]) < 6) {
             $second6am = array_slice($times, $first6am + 1);
             $second6am = array_search("6 AM", $second6am);
 


### PR DESCRIPTION
## What does this PR do? 🛠️

For the current day, change which hours we show:
- show through 6 AM the next day, if the current local time is before midnight
  > Eg:
  > If it is currently 8pm on a Thursday, the hours will range from 9pm Thursday through 6am Friday. In this case, we are adhering to NWS day rules, and "now" is Thursday.
- show through 6 AM the third day, if the current local time is after midnight
  > Eg:
  > If it is currently 2am on a Thursday, the hours will range from 3am Thursday through 6am Friday. In this case, we are effectively treating "now" as Thursday, even though by NWS rules it's still Wednesday.

---

- closes #999 
- closes #1000

## What does the reviewer need to know? 🤔

## Screenshots (if appropriate): 📸

<!--- Make sure you add a subject matter expert to the Reviewers list -->
