### PR TITLE
Only allows predefined HTML elements in weather stories

### DIFF
--- a/web/config/sync/field.field.node.weather_story.body.yml
+++ b/web/config/sync/field.field.node.weather_story.body.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.body
+    - filter.format.basic_html
     - node.type.weather_story
   module:
     - text
@@ -20,5 +21,6 @@ default_value_callback: ''
 settings:
   display_summary: false
   required_summary: false
-  allowed_formats: {  }
+  allowed_formats:
+    - basic_html
 field_type: text_with_summary


### PR DESCRIPTION
## What does this PR do? 🛠️

This PR disables the option to change input formats and restricts content to "basic HTML," allowing only the HTML tags we previously established in #1020.

For reference, those are:
- bold
- italic
- links
- lists (bulleted and numbered)
- block quotes
- heading levels 2 through 6
