### PR TITLE
Redirect URLs with uppercase letters to lowercase instead

### DIFF
--- a/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
+++ b/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
@@ -10,6 +10,7 @@ use Drupal\weather_data\Service\SpatialUtility;
 use Drupal\weather_data\Service\WeatherDataService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -24,12 +25,15 @@ final class LocationAndGridRouteController extends ControllerBase
      */
     private $dataLayer;
 
+    private $request;
+
     /**
      * Constructor for dependency injection.
      */
-    public function __construct($dataLayer)
+    public function __construct($dataLayer, $request)
     {
         $this->dataLayer = $dataLayer;
+        $this->request = $request;
     }
 
     /**
@@ -37,7 +41,10 @@ final class LocationAndGridRouteController extends ControllerBase
      */
     public static function create(ContainerInterface $container)
     {
-        return new static($container->get("weather_data_layer"));
+        return new static(
+            $container->get("weather_data_layer"),
+            $container->get("request_stack"),
+        );
     }
 
     /**
@@ -54,6 +61,11 @@ final class LocationAndGridRouteController extends ControllerBase
 
     public function serveLocationPage($lat, $lon)
     {
+        $path = $this->request->getCurrentRequest()->getPathInfo();
+        if ($path !== strtolower($path)) {
+            return new RedirectResponse(strtolower($path));
+        }
+
         try {
             $this->dataLayer->getPoint($lat, $lon);
             WeatherDataService::setPoint(

--- a/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
+++ b/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
@@ -62,6 +62,17 @@ final class LocationAndGridRouteController extends ControllerBase
     public function serveLocationPage($lat, $lon)
     {
         $path = $this->request->getCurrentRequest()->getPathInfo();
+
+        // Drupal routes are not case-sensitive. However, it uses the path to
+        // determine what Twig files to load, and it *DOES* maintain casing for
+        // that. So where we might land here for a URL that looks like
+        // /POINT/{lat}/{lon} correctly, Drupal will then try to load a template
+        // at page--POINT.html.twig instead of page--point.html.twig.
+        //
+        // To guard against his, if we see that we're not on a lowercase path,
+        // redirect to the lowercase one. It's a bit clunky, but it shouldn't
+        // be a particularly common use case. We can consider looking at other
+        // options if analytics shows us people are landing here frequently.
         if ($path !== strtolower($path)) {
             return new RedirectResponse(strtolower($path));
         }


### PR DESCRIPTION
## What does this PR do? 🛠️

This is a not-ideal solution to case-insensitive URLs. Technically URLs are case-sensitive according to specification, but we don't have to treat them that way. Drupal doesn't! What Drupal *does* do, however, is use the case-sensitive version of the URL path to determine which Twig file to use and it expects the Twig filename to exactly match the case-sensitive URL path.

This PR works around that by issues an HTTP redirect if the URL path has any uppercase characters.

The primary drawback here is that if a user comes to a URL that has uppercased characters, we force them to make an additional network request before we show them anything. This may be a minor concern – we will never *generate* uppercase URLs, so someone will likely have had to manually type it that way, which seems like it ought to be an infrequent problem. (Though I can imagine an EM in a chaotic environment needing to get people's attention quickly might make the URL all caps.)

A better solution would be if we can get Drupal to lowercase what Twig file it expects, but this PR is here as a backup.
