### PR TITLE
Radar loading fix

### DIFF
--- a/tests/e2e/cypress/e2e/location-page.cy.js
+++ b/tests/e2e/cypress/e2e/location-page.cy.js
@@ -1,3 +1,4 @@
+/* eslint cypress/no-unnecessary-waiting: 0 */
 describe("the location page", () => {
   before(() => {
     cy.request("http://localhost:8081/play/testing");

--- a/tests/e2e/cypress/e2e/location-page.cy.js
+++ b/tests/e2e/cypress/e2e/location-page.cy.js
@@ -3,7 +3,7 @@ describe("the location page", () => {
     cy.request("http://localhost:8081/play/testing");
   });
 
-  it("does not display marine laerts", () => {
+  it("does not display marine alerts", () => {
     // This point include a wind advisory and a small craft advisory. We
     // should only get the wind advisory.
     cy.visit("/point/33.521/-86.812");
@@ -44,6 +44,20 @@ describe("the location page", () => {
         "include.text",
         "Wind information is unavailable.",
       );
+    });
+  });
+
+  describe("Radar component loading tests", () => {
+    it("does not load if the current tab is not displaying", () => {
+      cy.visit("/point/33.521/-86.812");
+      cy.get("#wx_radar_container:empty").should("exist");
+    });
+
+    it("loads correctly after switching to the current tab", () => {
+      cy.visit("/point/33.521/-86.812");
+      cy.get('[data-tab-name="current"]').trigger("click");
+      cy.wait(1500);
+      cy.get("#wx_radar_container:empty").should("not.exist");
     });
   });
 

--- a/web/themes/new_weather_theme/assets/js/components/TabbedNavigator.js
+++ b/web/themes/new_weather_theme/assets/js/components/TabbedNavigator.js
@@ -106,6 +106,16 @@ class TabbedNavigator extends HTMLElement {
     // Activate the corresponding container
     const tabContainer = this.querySelector(`#${tabId}`);
     tabContainer.setAttribute("data-selected", "");
+
+    // Trigger a custom event for use externally
+    // when tabs switch
+    const event = new CustomEvent("wx:tab-switched", {
+      detail: {
+        tabId
+      },
+      bubbles: true
+    });
+    this.dispatchEvent(event);
   }
 
   handleTabButtonClick(event) {

--- a/web/themes/new_weather_theme/assets/js/radar.js
+++ b/web/themes/new_weather_theme/assets/js/radar.js
@@ -105,12 +105,12 @@ const setupRadar = () => {
   }
 };
 
-document.addEventListener("DOMContentLoaded", () => {
-  if (window.cmiRadar) {
+document.addEventListener("wx:tab-switched", (event) => {
+  if (window.cmiRadar && event.detail.tabId === "current") {
     setupRadar();
+  } else if(event.detail.tabId === "current"){
+    document.querySelector("[data-wx-radar-cmi]").addEventListener("load", () => {
+      setupRadar();
+    });
   }
-
-  document.querySelector("[data-wx-radar-cmi]").addEventListener("load", () => {
-    setupRadar();
-  });
 });

--- a/web/themes/new_weather_theme/assets/js/radar.js
+++ b/web/themes/new_weather_theme/assets/js/radar.js
@@ -19,6 +19,14 @@ artcc/cwa/county/state/rfc: true/false // if overlay should display, default fal
 */
 
 const setupRadar = () => {
+
+  // If radar has already been initialized on the container
+  // element, return and do nothing else.
+  const existingRadar = document.querySelector(".cmi-radar-container");
+  if(existingRadar){
+    return;
+  }
+  
   const container = document.querySelector("wx-radar");
 
   const lat = Number.parseFloat(container.getAttribute("lat"));
@@ -75,34 +83,17 @@ const setupRadar = () => {
     },
   };
 
-  const go = () => {
-    window.app = window.cmiRadar.createApp("#wx_radar_container", options);
-    window.app.$store.dispatch("markLocation", point);
+  window.app = window.cmiRadar.createApp("#wx_radar_container", options);
+  window.app.$store.dispatch("markLocation", point);
 
-    [".cmi-radar-menu-container", ".cmi-radar-menu-agendas"].forEach(
-      (selector) => {
-        const element = document.querySelector(selector);
-        if (element) {
-          element.remove();
-        }
-      },
-    );
-  };
-
-  if (container.offsetParent) {
-    go();
-  } else {
-    const observer = new IntersectionObserver(
-      (entries, self) => {
-        if (entries[0].isIntersecting) {
-          go();
-          self.disconnect();
-        }
-      },
-      { root: document.body, rootMargin: "0px", threshold: 1 },
-    );
-    observer.observe(container);
-  }
+  [".cmi-radar-menu-container", ".cmi-radar-menu-agendas"].forEach(
+    (selector) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        element.remove();
+      }
+    },
+  );
 };
 
 document.addEventListener("wx:tab-switched", (event) => {

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -56,7 +56,7 @@ hourly-toggle:
     assets/js/components/HourlyToggle.js: { preprocess: false }
 
 radar:
-  version: 2024-03-28
+  version: 2024-04-22
   css:
     theme:
       assets/css/radar/cmi-radar.1185c3ee.css:


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR addresses #1038. There are situations where the radar will not load, specifically if the parent container it inserts itself into is not visible on the page at the time it's loaded. 

## What does the reviewer need to know? 🤔
### New custom event ###
The solution we've opted for here is to have the `wx-tabbed-nav` dispatch a custom event that has details about which tabId was selected whenever a tab is selected. The event is called `wx:tab-switched` and the event object's `detail` object has a `tabId` key which corresponds to the id of the selected tab.
  
We use this in the radar library to see if the `current` tab has been switched to -- even on loading. If it has, then we know we can safely try to init the radar component.

## Tests ##
Added two e2e cypress tests to make sure the behavior is working
  
## Closes ##
#1038 