### PR TITLE
Radar fixes: round 2

### DIFF
--- a/web/themes/new_weather_theme/assets/js/radar.js
+++ b/web/themes/new_weather_theme/assets/js/radar.js
@@ -96,12 +96,14 @@ const setupRadar = () => {
   );
 };
 
-document.addEventListener("wx:tab-switched", (event) => {
-  if (window.cmiRadar && event.detail.tabId === "current") {
-    setupRadar();
-  } else if(event.detail.tabId === "current"){
-    document.querySelector("[data-wx-radar-cmi]").addEventListener("load", () => {
+document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("wx:tab-switched", (event) => {
+    if (window.cmiRadar && event.detail.tabId === "current") {
       setupRadar();
-    });
-  }
+    } else if(event.detail.tabId === "current"){
+      document.querySelector("[data-wx-radar-cmi]").addEventListener("load", () => {
+        setupRadar();
+      });
+    }
+  });
 });

--- a/web/themes/new_weather_theme/assets/js/radar.js
+++ b/web/themes/new_weather_theme/assets/js/radar.js
@@ -97,13 +97,27 @@ const setupRadar = () => {
 };
 
 document.addEventListener("DOMContentLoaded", () => {
-  document.addEventListener("wx:tab-switched", (event) => {
-    if (window.cmiRadar && event.detail.tabId === "current") {
+  const scriptEl = document.querySelector("[data-ex-radar-cmi]");
+  const currentTabSelected = document.querySelector("#current[data-selected]");
+  // If the page loads with the current tab selected
+  // then we try to load the radar.
+  // If the page loads with some other tab selected,
+  // than we bind a listener for the tab-switched event.
+  if(currentTabSelected && window.cmiRadar){
+    setupRadar();
+  } else if(currentTabSelected){
+    scriptEl.addEventListener("load", () => {
       setupRadar();
-    } else if(event.detail.tabId === "current"){
-      document.querySelector("[data-wx-radar-cmi]").addEventListener("load", () => {
+    });
+  } else {
+    document.addEventListener("wx:tab-switched", (event) => {
+      if (window.cmiRadar && event.detail.tabId === "current") {
         setupRadar();
-      });
-    }
-  });
+      } else if(event.detail.tabId === "current"){
+        scriptEl.addEventListener("load", () => {
+          setupRadar();
+        });
+      }
+    });
+  }
 });

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -56,7 +56,7 @@ hourly-toggle:
     assets/js/components/HourlyToggle.js: { preprocess: false }
 
 radar:
-  version: 2024-04-22
+  version: 2024-04-22.2
   css:
     theme:
       assets/css/radar/cmi-radar.1185c3ee.css:

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -63,9 +63,10 @@ radar:
   js:
     assets/js/radar.js:
       attributes:
-        async: true
+        defer: true
     https://radar.weather.gov/cmi-radar/cmi-radar.1185c3ee.js:
       attributes:
+        defer: true
         data-wx-radar-cmi: true
 
 digital-analytics-program:


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR addresses #1099. We have tried several times to fix radar loading, but keep coming across inconsistent behavior in our live environments.

## What does the reviewer need to know? 🤔
There are two key changes in this PR.
  
First, we are swapping the `async` property on the radar wrapper script tag with `defer`. This allows it to take advantage of the `DOMContentLoaded` event, after which we can attempt to load the radar based on whatever the status is of the actual NWS radar library.
  
Second, we wrap initialization of the radar component in _both_ the `DOMContentLoaded` event handler _and_, if needed, the tab switch event. This is because sometimes the page loads with the current tab displayed first.
