### PR TITLE
When navigating directly to a location page, save that location into recent results

### DIFF
--- a/web/themes/new_weather_theme/assets/js/components/combo-box.js
+++ b/web/themes/new_weather_theme/assets/js/components/combo-box.js
@@ -186,6 +186,13 @@ class ComboBox extends HTMLElement {
     this.input.addEventListener("focus", () => {
       this.updateSearch("");
     });
+
+    if (this.dataset.place) {
+      this.saveSearchResult({
+        text: this.dataset.place,
+        url: window.location.href,
+      });
+    }
   }
 
   disconnectedCallback() {

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-location-search.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-location-search.html.twig
@@ -1,6 +1,7 @@
 {{ attach_library("new_weather_theme/location-search") }}
 {{ attach_library("new_weather_theme/location-combo-box") }}
 {{ attach_library("new_weather_theme/browser-location-button") }}
+
 {% if content.place %}<div class="grid-container">{% endif %}
 <div class="grid-row">
   <form class="usa-form grid-col-12 maxw-tablet-lg margin-bottom-3" data-location-search method="post">
@@ -13,7 +14,7 @@
         <button id="weathergov-use-browser-location" type="button" class="usa-button usa-button--unstyled">{{ 'Use my location' | t }}</button>
       </div>
     </div>
-    <wx-combo-box class="z-top margin-top-1" id="search-combo-box">
+    <wx-combo-box class="z-top margin-top-1" id="search-combo-box" {% if content.place %}data-place="{{ content.place.city }}{% if content.place.state %}, {{ content.place.state }}{% endif %}"{% endif %}}>
     </wx-combo-box>
     <input type="hidden" name="suggestedPlaceName" value="">
   </form>

--- a/web/themes/new_weather_theme/tests/components/combo-box-tests.js
+++ b/web/themes/new_weather_theme/tests/components/combo-box-tests.js
@@ -554,6 +554,23 @@ describe("Combo box unit tests", () => {
         ).to.be.true;
       });
 
+      it("when a user loads a location page", () => {
+        window.document.body.innerHTML = "";
+        const component = document.createElement("wx-combo-box");
+        component.setAttribute("data-place", "Placeville, ST");
+        document.body.append(form);
+        form.append(component);
+
+        expect(
+          global.localStorage.setItem.calledWith(
+            "wxgov_recent_locations",
+            JSON.stringify([
+              { text: "Placeville, ST", url: "http://localhost/" },
+            ]),
+          ),
+        ).to.be.true;
+      });
+
       it("adds new result at the front of the list if prior results exist", () => {
         const previous = ["previous entry 1", "previosu entry 2"];
         global.localStorage.getItem


### PR DESCRIPTION
## What does this PR do? 🛠️

- adds a `data-place` attribute to the search combo box
- when the combo box loads, if its `data-place` attribute is set, saves the current page to recent results
- closes #1107
