### PR TITLE
Change how we determine when to load the front page layout

### DIFF
--- a/web/themes/new_weather_theme/templates/layout/page.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page.html.twig
@@ -80,7 +80,7 @@
   </header>
 	<main role="main" class="flex-1">
     <a id="main-content" tabindex="-1"></a>
-    {% if is_front %}
+    {% if path('<current>') == "/home" %}
     {% include(directory ~ "/templates/layout/frontpage.html.twig") %}
     {% else %}
     {# link is in html.html.twig #}


### PR DESCRIPTION
## What does this PR do? 🛠️

There's an old, old, old, old, old [Drupal issue](https://www.drupal.org/project/drupal/issues/1503146) where the `is_front` variable doesn't work if your site settings refer to the front page by a URL alias, which is exactly what we do because we don't really want it tied to a particular content ID since that's inconsistent across environments.

This PR changes the check from `is_front` to instead look at the page path. If the page is `/home` (which is our alias to the front page), then it loads the front page layout.