### PR TITLE
Sync config from beta

### DIFF
--- a/web/config/sync/file.settings.yml
+++ b/web/config/sync/file.settings.yml
@@ -6,3 +6,10 @@ description:
 icon:
   directory: core/modules/file/icons
 make_unused_managed_files_temporary: false
+filename_sanitization:
+  transliterate: false
+  replace_whitespace: false
+  replace_non_alphanumeric: false
+  deduplicate_separators: false
+  lowercase: false
+  replacement_character: '-'


### PR DESCRIPTION
## What does this PR do? 🛠️

Three config files changed in beta:

- `file.settings` - saved here
- `field.storage.node.field_image` - already covered by config split patch
- `system.file` - already covered by config split patch
