### PR TITLE
Anchor the regex for identifying alert overviews

### DIFF
--- a/.github/actions/build-drupal-image/action.yml
+++ b/.github/actions/build-drupal-image/action.yml
@@ -3,17 +3,17 @@ runs:
   steps:
     - name: setup image cacheing
       uses: actions/cache@v4
-      id: cache
+      id: docker-cache
       with:
         key: drupal-image-${{ hashFiles('composer.lock','web/sites/example.settings.dev.php','Dockerfile.dev') }}
         path: /tmp/image.tar
 
     - name: Set up Docker Buildx
-      if: steps.db-cache.outputs.cache-hit != 'true'
+      if: steps.docker-cache.outputs.cache-hit != 'true'
       uses: docker/setup-buildx-action@v3
 
     - name: build and export
-      if: steps.db-cache.outputs.cache-hit != 'true'
+      if: steps.docker-cache.outputs.cache-hit != 'true'
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/.github/actions/build-drupal-image/action.yml
+++ b/.github/actions/build-drupal-image/action.yml
@@ -9,9 +9,11 @@ runs:
         path: /tmp/image.tar
 
     - name: Set up Docker Buildx
+      if: steps.db-cache.outputs.cache-hit != 'true'
       uses: docker/setup-buildx-action@v3
 
     - name: build and export
+      if: steps.db-cache.outputs.cache-hit != 'true'
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/.github/actions/populate-database/action.yml
+++ b/.github/actions/populate-database/action.yml
@@ -9,12 +9,14 @@ runs:
         path: weathergov.sql
 
     - name: setup image cacheing
+      if: steps.db-cache.outputs.cache-hit != 'true'
       uses: actions/cache@v4
       with:
         key: drupal-image-${{ hashFiles('composer.lock','web/sites/example.settings.dev.php','Dockerfile.dev') }}
         path: /tmp/image.tar
 
     - name: cache spatial data
+      if: steps.db-cache.outputs.cache-hit != 'true'
       uses: actions/cache@v4
       with:
         key: spatial-data-05mr24
@@ -23,6 +25,7 @@ runs:
           spatial-data/s_05mr24.zip
 
     - name: start the site
+      if: steps.db-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         docker load --input /tmp/image.tar
@@ -30,10 +33,12 @@ runs:
 
     # Give the containers a moment to settle.
     - name: wait a tick
+      if: steps.db-cache.outputs.cache-hit != 'true'
       shell: bash
       run: sleep 10
 
     - name: populate the site
+      if: steps.db-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cp web/sites/example.settings.dev.php web/sites/settings.dev.php
@@ -41,6 +46,7 @@ runs:
         make load-spatial
 
     - name: dump database
+      if: steps.db-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         mysqldump \

--- a/web/modules/weather_data/src/Service/Test/WeatherAlertParser.php.test
+++ b/web/modules/weather_data/src/Service/Test/WeatherAlertParser.php.test
@@ -102,6 +102,8 @@ final class WeatherAlertParserTest extends TestCase
         $rawDescription = "...WINTER CONDITIONS RETURN TO THE SIERRA AND NORTHEAST CALIFORNIA
 FOR MID-LATE WEEK...
 
+This bit...has ellipses in the middle...but is not an overview.
+
 .After a few days of warm weather, a potent winter storm will bring
 windy and colder conditions with periods of heavy snow to the Sierra
 and higher elevations of northeast California later this week. While
@@ -136,6 +138,11 @@ Wednesday, then drop to near 5500 feet Wednesday night and near
                 "type" => "paragraph",
                 "text" =>
                     "WINTER CONDITIONS RETURN TO THE SIERRA AND NORTHEAST CALIFORNIA FOR MID-LATE WEEK",
+            ],
+            [
+                "type" => "paragraph",
+                "text" =>
+                    "This bit...has ellipses in the middle...but is not an overview.",
             ],
             [
                 "type" => "paragraph",

--- a/web/modules/weather_data/src/Service/WeatherAlertParser.php
+++ b/web/modules/weather_data/src/Service/WeatherAlertParser.php
@@ -80,7 +80,7 @@ class WeatherAlertParser
      */
     public function parseOverview($str)
     {
-        $regex = "/\.\.\.([^\.]+)\.\.\./";
+        $regex = "/^\.\.\.([^\.]+)\.\.\.$/";
         if (preg_match($regex, $str, $matches)) {
             array_push($this->parsedNodes, [
                 "type" => "paragraph",


### PR DESCRIPTION
## What does this PR do? 🛠️

We look for alert overviews as lines that begin and end with ellipses (`...`). Previously, the regular expression we used would match any line that had two sets of ellipses in it. This PR modifies the regex so the ellipses must be at the very beginning and very end of the line.

Fixes #1154 
Fixes #1146