### PR TITLE
Hourly table scrolling

### DIFF
--- a/web/themes/new_weather_theme/assets/js/components/HourlyTable.js
+++ b/web/themes/new_weather_theme/assets/js/components/HourlyTable.js
@@ -42,6 +42,9 @@ class HourlyTable extends HTMLElement {
   }
 
   clickScrollRight(wrapper) {
+    const containerWidth = wrapper.getBoundingClientRect().width;
+    const firstColumnWidth = this.querySelector("table tr:last-child th").getBoundingClientRect().width;
+    const visibleWidth = containerWidth - firstColumnWidth;
     const cellsToRight = Array.from(
       this.querySelectorAll("table tr:last-child td"),
     ).filter((cell) => {
@@ -51,13 +54,16 @@ class HourlyTable extends HTMLElement {
 
     if (cellsToRight.length) {
       wrapper.scrollTo({
-        left: cellsToRight[0].offsetLeft - 16,
+        left: (wrapper.scrollLeft + visibleWidth) - 16,
         behavior: "smooth",
       });
     }
   }
 
   clickScrollLeft(wrapper) {
+    const containerWidth = wrapper.getBoundingClientRect().width;
+    const firstColumnWidth = this.querySelector("table tr:last-child th").getBoundingClientRect().width;
+    const visibleWidth = containerWidth - firstColumnWidth;
     const cellsToLeft = Array.from(
       this.querySelectorAll("table tr:last-child td"),
     ).filter((cell) => {
@@ -67,7 +73,7 @@ class HourlyTable extends HTMLElement {
 
     if (cellsToLeft.length) {
       wrapper.scrollTo({
-        left: cellsToLeft.at(-1).offsetLeft - 16,
+        left: wrapper.scrollLeft - visibleWidth - 16,
         behavior: "smooth",
       });
     } else {

--- a/web/themes/new_weather_theme/assets/js/components/HourlyTable.js
+++ b/web/themes/new_weather_theme/assets/js/components/HourlyTable.js
@@ -52,11 +52,16 @@ class HourlyTable extends HTMLElement {
             const left = el.offsetLeft;
             const right = el.offsetLeft + el.offsetWidth;
             return left <= rightSide && right >= rightSide;
-          });
+          });   
 
     if (nextCol) {
+      let nextLeftPos = nextCol.offsetLeft - firstColumnWidth - 16;
+      if(Math.floor(nextLeftPos) <= Math.floor(wrapper.scrollLeft)){
+        nextLeftPos = nextCol.nextElementSibling.offsetLeft - firstColumnWidth - 16;
+      }
+      
       wrapper.scrollTo({
-        left: nextCol.offsetLeft - firstColumnWidth - 16,
+        left: nextLeftPos,
         behavior: "smooth",
       });
     }
@@ -76,8 +81,13 @@ class HourlyTable extends HTMLElement {
           });
 
     if (prevCol) {
+      let nextLeftPos = prevCol.nextElementSibling.offsetLeft - firstColumnWidth - 16;
+      if(Math.floor(nextLeftPos) >= Math.floor(wrapper.scrollLeft)){
+        nextLeftPos = prevCol.offsetLeft - firstColumnWidth - 16;
+      }
+
       wrapper.scrollTo({
-        left: prevCol.nextElementSibling.offsetLeft - firstColumnWidth - 16,
+        left: nextLeftPos,
         behavior: "smooth",
       });
     } else {

--- a/web/themes/new_weather_theme/assets/js/components/HourlyTable.js
+++ b/web/themes/new_weather_theme/assets/js/components/HourlyTable.js
@@ -45,16 +45,18 @@ class HourlyTable extends HTMLElement {
     const containerWidth = wrapper.getBoundingClientRect().width;
     const firstColumnWidth = this.querySelector("table tr:last-child th").getBoundingClientRect().width;
     const visibleWidth = containerWidth - firstColumnWidth;
-    const cellsToRight = Array.from(
-      this.querySelectorAll("table tr:last-child td"),
-    ).filter((cell) => {
-      const diff = cell.offsetLeft - wrapper.scrollLeft;
-      return diff > 16;
-    });
+    const rightSide = wrapper.scrollLeft + visibleWidth;
 
-    if (cellsToRight.length) {
+    const nextCol = Array.from(this.querySelectorAll("table tr:last-child td"))
+          .find(el => {
+            const left = el.offsetLeft;
+            const right = el.offsetLeft + el.offsetWidth;
+            return left <= rightSide && right >= rightSide;
+          });
+
+    if (nextCol) {
       wrapper.scrollTo({
-        left: (wrapper.scrollLeft + visibleWidth) - 16,
+        left: nextCol.offsetLeft - 16,
         behavior: "smooth",
       });
     }
@@ -64,16 +66,18 @@ class HourlyTable extends HTMLElement {
     const containerWidth = wrapper.getBoundingClientRect().width;
     const firstColumnWidth = this.querySelector("table tr:last-child th").getBoundingClientRect().width;
     const visibleWidth = containerWidth - firstColumnWidth;
-    const cellsToLeft = Array.from(
-      this.querySelectorAll("table tr:last-child td"),
-    ).filter((cell) => {
-      const diff = cell.offsetLeft - wrapper.scrollLeft;
-      return diff < 16;
-    });
+    const leftSide = wrapper.scrollLeft - visibleWidth;
 
-    if (cellsToLeft.length) {
+    const prevCol = Array.from(this.querySelectorAll("table tr:last-child td"))
+          .find(el => {
+            const left = el.offsetLeft;
+            const right = el.offsetLeft + el.offsetWidth;
+            return left <= leftSide && right >= leftSide;
+          });
+
+    if (prevCol) {
       wrapper.scrollTo({
-        left: wrapper.scrollLeft - visibleWidth - 16,
+        left: prevCol.nextElementSibling.offsetLeft - 16,
         behavior: "smooth",
       });
     } else {

--- a/web/themes/new_weather_theme/assets/js/components/HourlyTable.js
+++ b/web/themes/new_weather_theme/assets/js/components/HourlyTable.js
@@ -44,7 +44,7 @@ class HourlyTable extends HTMLElement {
   clickScrollRight(wrapper) {
     const containerWidth = wrapper.getBoundingClientRect().width;
     const firstColumnWidth = this.querySelector("table tr:last-child th").getBoundingClientRect().width;
-    const visibleWidth = containerWidth - firstColumnWidth;
+    const visibleWidth = containerWidth;
     const rightSide = wrapper.scrollLeft + visibleWidth;
 
     const nextCol = Array.from(this.querySelectorAll("table tr:last-child td"))
@@ -56,7 +56,7 @@ class HourlyTable extends HTMLElement {
 
     if (nextCol) {
       wrapper.scrollTo({
-        left: nextCol.offsetLeft - 16,
+        left: nextCol.offsetLeft - firstColumnWidth - 16,
         behavior: "smooth",
       });
     }
@@ -66,7 +66,7 @@ class HourlyTable extends HTMLElement {
     const containerWidth = wrapper.getBoundingClientRect().width;
     const firstColumnWidth = this.querySelector("table tr:last-child th").getBoundingClientRect().width;
     const visibleWidth = containerWidth - firstColumnWidth;
-    const leftSide = wrapper.scrollLeft - visibleWidth;
+    const leftSide = wrapper.scrollLeft - visibleWidth + firstColumnWidth;
 
     const prevCol = Array.from(this.querySelectorAll("table tr:last-child td"))
           .find(el => {
@@ -77,7 +77,7 @@ class HourlyTable extends HTMLElement {
 
     if (prevCol) {
       wrapper.scrollTo({
-        left: prevCol.nextElementSibling.offsetLeft - 16,
+        left: prevCol.nextElementSibling.offsetLeft - firstColumnWidth - 16,
         behavior: "smooth",
       });
     } else {

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -46,7 +46,7 @@ tabbed-nav:
     assets/js/components/TabbedNavigator.js: { preprocess: false }
 
 hourly-table:
-  version: 2024-03-21
+  version: 2024-05-07
   js:
     assets/js/components/HourlyTable.js: { preprocess: false }
 


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR implements the changes in #972, which called for the hourly table scroll buttons to scroll more than just one column at a time.

## What does the reviewer need to know? 🤔
Instead of scrolling one column, each direction will attempt to scroll one full "page" (ie width of the table) view in the relevant direction. It will then attempt to align on the nearest intersecting column on the left, so that the whole column is visible.
