### PR TITLE
Retry downloading corrupted zip files

### DIFF
--- a/spatial-data/lib/prep.js
+++ b/spatial-data/lib/prep.js
@@ -1,6 +1,17 @@
-const { exec } = require("node:child_process");
+const { exec: nodeExec } = require("node:child_process");
 const fs = require("node:fs/promises");
 const { fileExists } = require("./util.js");
+
+const exec = async (...args) =>
+  new Promise((resolve, reject) => {
+    nodeExec(...args, (err, stdout) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
 
 module.exports.downloadAndUnzip = async (url) => {
   const filename = url.split("/").pop();
@@ -15,15 +26,20 @@ module.exports.downloadAndUnzip = async (url) => {
     console.log(`${filename} is already present`);
   }
 
-  await module.exports.unzip(filename);
+  await exec(`unzip -t ${filename}`)
+    .then(async () => {
+      await module.exports.unzip(filename);
 
-  console.log(`   [${filename}] done`);
+      console.log(`   [${filename}] done`);
+    })
+    .catch(async () => {
+      console.log("zip file is corrupt. Trying again...");
+      await fs.unlink(filename);
+      await module.exports.downloadAndUnzip(url);
+    });
 };
 
-module.exports.unzip = (path) =>
-  new Promise((resolve) => {
-    console.log(`   [${path}] decompressing...`);
-    exec(`unzip -u ${path}`, () => {
-      resolve();
-    });
-  });
+module.exports.unzip = async (path) => {
+  console.log(`   [${path}] decompressing...`);
+  await exec(`unzip -u ${path}`);
+};


### PR DESCRIPTION
## What does this PR do? 🛠️

Use the `unzip -t` command to check if a zip file is valid before attempting to unzip it. If it's not, try downloading it again.

- fixes #810

## What does the reviewer need to know? 🤔

To test it locally, I added a `return` statement after line 46 of `load-shapefile.js` so the script wouldn't attempt to actually load anything into the database, updated the metadata version to `2` in `sources/counties.js`, and then invalidated my counties zip file by running `truncate -s -50k spatial-data/c_05mr24.zip`.

Then I ran the script, saw it identify the corrupted zip, and watched as it downloaded it afresh.
