### PR TITLE
Support HTTP status codes in the API proxy

### DIFF
--- a/tests/api/data/testing/points/47.212,-123.107.json
+++ b/tests/api/data/testing/points/47.212,-123.107.json
@@ -1,0 +1,12 @@
+{
+  "@bundle": {
+    "name": "serves an HTTP 503 on the /points endpoint",
+    "status": 503
+  },
+  "geometry": { "type": "Point", "coordinates": [-123.106, 47.212] },
+  "properties": {
+    "cwa": "SEW",
+    "gridX": 96,
+    "gridY": 55
+  }
+}

--- a/tests/api/serve.js
+++ b/tests/api/serve.js
@@ -113,9 +113,20 @@ export default async (request, response) => {
     console.log(`LOCAL:    local file does not exist; proxying [${filePath}]`);
     await proxy(request, response);
   } else {
-    const isHourlyForecast = filePath.toString().includes("hourly");
     console.log(`LOCAL:    serving local file: ${filePath}`);
     const output = JSON.parse(await fs.readFile(filePath));
+
+    if (output["@bundle"]?.status) {
+      console.log(
+        `LOCAL:    local file has response status ${output["@bundle"].status}`,
+      );
+      response.writeHead(output["@bundle"].status);
+      response.end();
+      return;
+    }
+
+    const isHourlyForecast = filePath.toString().includes("hourly");
+
     processDates(output, isHourlyForecast);
 
     response.writeHead(200, {


### PR DESCRIPTION
## What does this PR do? 🛠️

This PR extends the bundle metadata to include a `status` property. If that property is set, the proxy will return with that HTTP status code.

```json
{
  "@bundle": {
    "status": 404
  }
  ...
}
```

This approach allows us to test any HTTP status rather than just 503. This PR also adds a new `/points/lat,lon.json` proxy file that results in a 503 status.

closes #917 