### PR TITLE
Use alert UUID for in-page hash links

### DIFF
--- a/tests/e2e/cypress/e2e/hourly-forecast-table.cy.js
+++ b/tests/e2e/cypress/e2e/hourly-forecast-table.cy.js
@@ -57,7 +57,9 @@ describe("Hourly forecast table tests", () => {
         .contains("Red Flag Warning")
         .invoke("attr", "aria-expanded")
         .should("equal", "true");
-      cy.get("#a3").should("be.visible");
+      cy.get("#alert_82d03a893a84390fbc5217471cd259eaa41a4135").should(
+        "be.visible",
+      );
     });
   });
 
@@ -69,7 +71,7 @@ describe("Hourly forecast table tests", () => {
         // Our expectation is that up to five days should
         // have precip data. Anything beyond that is not guaranteed
         // at this point
-        if($idx >= 4){
+        if ($idx >= 4) {
           cy.wrap($tbody).children("tr").should("exist");
         }
       });

--- a/tests/e2e/cypress/e2e/tabbed-nav.cy.js
+++ b/tests/e2e/cypress/e2e/tabbed-nav.cy.js
@@ -126,7 +126,7 @@ describe("<wx-tabbed-nav> component tests", () => {
 
   describe("Initial page load with hash", () => {
     it("Navigates to the correct alert accordion and opens it if hash present", () => {
-      const alertId = "alert_2";
+      const alertId = "alert_aa84ba418dfe6f3e1eb046cf9e4086aaaaddeb65";
       cy.visit(`/point/34.749/-92.275#${alertId}`);
       cy.get(`#${alertId}`)
         .as("alertEl")
@@ -142,7 +142,7 @@ describe("<wx-tabbed-nav> component tests", () => {
     });
 
     ["alerts", "daily"].forEach((tabName) => {
-      it(`Acticates the ${tabName} tab if the hash for it is present`, () => {
+      it(`Activates the ${tabName} tab if the hash for it is present`, () => {
         cy.visit(`/point/34.749/-92.275#${tabName}`);
         cy.get(`.tab-button[data-tab-name="${tabName}"]`)
           .as("tabButton")


### PR DESCRIPTION
## What does this PR do? 🛠️

The API provides us with a whole OID URN for each alert, which is a bit too long to be useful, but embedded within the URN is a UUID for the alert itself. The rest of the URN is information about what kind of object is being identified (an alert as defined by the World Meteorological Organization and issued by the United States), but we can take those for granted and don't need to include them.

Closes #862
