### PR TITLE
Fix how we id alerts

### DIFF
--- a/tests/e2e/cypress/e2e/hourly-forecast-table.cy.js
+++ b/tests/e2e/cypress/e2e/hourly-forecast-table.cy.js
@@ -57,7 +57,7 @@ describe("Hourly forecast table tests", () => {
         .contains("Red Flag Warning")
         .invoke("attr", "aria-expanded")
         .should("equal", "true");
-      cy.get("#alert_82d03a893a84390fbc5217471cd259eaa41a4135").should(
+      cy.get("#alert_82d03a893a84390fbc5217471cd259eaa41a4135_001_1").should(
         "be.visible",
       );
     });

--- a/tests/e2e/cypress/e2e/tabbed-nav.cy.js
+++ b/tests/e2e/cypress/e2e/tabbed-nav.cy.js
@@ -126,7 +126,7 @@ describe("<wx-tabbed-nav> component tests", () => {
 
   describe("Initial page load with hash", () => {
     it("Navigates to the correct alert accordion and opens it if hash present", () => {
-      const alertId = "alert_aa84ba418dfe6f3e1eb046cf9e4086aaaaddeb65";
+      const alertId = "alert_aa84ba418dfe6f3e1eb046cf9e4086aaaaddeb65_001_1";
       cy.visit(`/point/34.749/-92.275#${alertId}`);
       cy.get(`#${alertId}`)
         .as("alertEl")

--- a/web/modules/weather_data/src/Service/AlertTrait.php
+++ b/web/modules/weather_data/src/Service/AlertTrait.php
@@ -148,12 +148,16 @@ trait AlertTrait
                 // https://oidref.com/2.49.0, and then
                 // http://www.oid-info.com/doc/introduction%20to%20object%20identifiers%20(OIDs)%20at%20WMO.pdf).
                 //
-                // The UUID uniquely identifies the alert, so we can use that. Not
-                // sure what the 001 and 0 parts of the OID are - updates, maybe?
-                // But not super relevant for us.
+                // The UUID uniquely identifies the alert and the .001.1 part
+                // uniquely identifies the alert.
+                //
+                // There's something funky that happens where a single alert can
+                // show up multiple times, but that's an issue upstream of us
+                // and for now, we can't really do anything about it.
                 $id = explode(".", $alert->properties->id);
+                $id = array_slice($id, -3);
+                $id = implode("_", $id);
 
-                $id = $id[count($id) - 3];
                 $output->alertId = $id;
             } else {
                 // If it's not a NWS OID, just use the array index.


### PR DESCRIPTION
## What does this PR do? 🛠️

Include more of the OID in the alert ID until we sort out what's going on with CAP.

@loganmcdonald-noaa This should unblock your PR.