### PR TITLE
Adjust headings on current tab

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-current-conditions.html.twig
@@ -4,7 +4,7 @@
 {# Widgets and stuff. This is presented as a row of columns. #}
 <div class="grid-container padding-x-0 tablet:padding-x-2">
   <div class="grid-row grid-col-8 grid-offset-2">
-    <h3 class="visual-h2">Current conditions</h3>
+    <h3 class="usa-sr-only">Current conditions</h3>
   </div>
 
   <div class="grid-container bg-white padding-y-2 shadow-1 grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">

--- a/web/themes/new_weather_theme/templates/partials/radar.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/radar.html.twig
@@ -1,8 +1,8 @@
 {{ attach_library("new_weather_theme/radar") }}
 
 <div class="grid-container margin-top-2 padding-x-0 tablet:padding-x-2" wx-outer-radar-container>
-  <div class="grid-row grid-col-8 grid-offset-2">
-    <h3 class="visual-h2">Radar</h3>
+  <div class="grid-row tablet-lg:grid-col-8 tablet-lg:grid-offset-2">
+    <h3 class="visual-h2 text-normal text-primary-darker padding-x-2 tablet:padding-x-0 margin-top-3 margin-bottom-2">Radar</h3>
   </div>
 
   <div class="grid-container padding-0 bg-white shadow-1 grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR adjusts the headings on the current tab, making the "Current conditions" heading SR only (discussed with @kmranjo) and updating the alignment of "Radar" to left align with the other elements on the page on mobile. 

## Screenshots (if appropriate): 📸

![Screenshot of updated current headings on mobile size](https://github.com/weather-gov/weather.gov/assets/150970973/9b8fba65-6e82-422a-8cf6-46e256442355)

