### PR TITLE
adds a new module weather_cms and adds a hook for changing alt text on images

### DIFF
--- a/.github/workflows/modules-updated-pr-comment.yaml
+++ b/.github/workflows/modules-updated-pr-comment.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           # Use GitHub API to create a comment on the PR
           PR_NUMBER=${{ github.event.pull_request.number }}
-          COMMENT="It looks like our enabled modules has changed in this PR. Please ensure any documentation in https://github.com/weather-gov/weather.gov/tree/main/docs/contributed-modules.md has been updated!"
+          COMMENT="It looks like our enabled modules has changed in this PR. Please ensure any documentation in https://github.com/weather-gov/weather.gov/tree/main/docs/dev/contributed-modules.md has been updated!"
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           COMMENT_URL="https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
       

--- a/web/config/sync/core.extension.yml
+++ b/web/config/sync/core.extension.yml
@@ -48,6 +48,7 @@ module:
   user: 0
   views_ui: 0
   weather_blocks: 0
+  weather_cms: 0
   weather_data: 0
   weather_login: 0
   weather_routes: 0

--- a/web/modules/weather_cms/weather_cms.info.yml
+++ b/web/modules/weather_cms/weather_cms.info.yml
@@ -1,0 +1,6 @@
+name: Weather cms
+type: module
+description: Various customizations used for the weather.gov CMS
+package: weather.gov
+
+core_version_requirement: ^10

--- a/web/modules/weather_cms/weather_cms.module
+++ b/web/modules/weather_cms/weather_cms.module
@@ -1,0 +1,19 @@
+<?php
+
+use Drupal\Core\Form\FormStateInterface;
+
+// This hook allows us to alter single elements of a widget, which we want to do for alt text on uploaded images
+function weather_cms_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context) // phpcs:ignore
+{
+    if ($context["widget"] instanceof \Drupal\image\Plugin\Field\FieldWidget\ImageWidget) {
+        $element["#process"][] = "weather_cms_image_field_widget_process";
+    }
+}
+
+function weather_cms_image_field_widget_process($element, &$form_state, $form)
+{
+    if (isset($element["alt"])) {
+        $element["alt"]["#description"] = "Alt text should provide the same information as the image, not serve as a description of the image itself. If you have included text on your image, it should be in the alt text along with whatever additional context is needed to provide the same information to users who cannot view the image."; // phpcs:ignore
+    }
+    return $element;
+}


### PR DESCRIPTION
## What does this PR do? 🛠️
Leverages the [hook_field_widget_single_element_form_alter](https://api.drupal.org/api/drupal/core%21modules%21field%21field.api.php/function/hook_field_widget_single_element_form_alter/10) to change our help text on alt text for images, thus fixing #1200 cc/ @kmranjo. 

## What does the reviewer need to know? 🤔
I have added another module that is super small and only does this thing for our CMS hooks and functionality. 

Note that this will change alt text help text on _any_ image, not just in the weather story. Right now we only have an image in the weather story so it shouldn't be too much of a concern. 

## Screenshots (if appropriate): 📸
<img width="1350" alt="Screenshot 2024-05-22 at 2 26 15 PM" src="https://github.com/weather-gov/weather.gov/assets/142825699/c585b82d-c818-4de9-bc41-dcbe7e927a48">
