### PR TITLE
Remove old LocationSearch from attached libraries

### DIFF
--- a/web/themes/new_weather_theme/templates/block/block--weathergov-location-search.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-location-search.html.twig
@@ -1,4 +1,3 @@
-{{ attach_library("new_weather_theme/location-search") }}
 {{ attach_library("new_weather_theme/location-combo-box") }}
 {{ attach_library("new_weather_theme/browser-location-button") }}
 


### PR DESCRIPTION
Just what it says on the tin.

I think we're fine without this – Drupal appears to ignore it since it doesn't show up in the libraries file – but it's dangly cruft, and we might as well clean it up. This can be rebased to main if #1281 gets merged first.