### PR TITLE
Fix alert link styling

### DIFF
--- a/web/themes/new_weather_theme/templates/partials/alert-link.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/alert-link.html.twig
@@ -11,7 +11,12 @@
     </svg>
   </div>
   <a
-    class="margin-top-05"
+    {#
+      Table cells have a set line height. Set our own line height so that we
+      know what we're working with. The margin nudges the text down a bit so it
+      vertically aligns with the icon.
+    #}
+    class="line-height-sans-1 margin-top-05"
     href="#{{ alertID is same as(null) ? "alerts" : "alert_" ~ alertID }}">
       {{ alertType }}
   </a>

--- a/web/themes/new_weather_theme/templates/partials/alert-link.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/alert-link.html.twig
@@ -16,7 +16,7 @@
       know what we're working with. The margin nudges the text down a bit so it
       vertically aligns with the icon.
     #}
-    class="line-height-sans-1 margin-top-05"
+    class="line-height-sans-2 margin-top-05"
     href="#{{ alertID is same as(null) ? "alerts" : "alert_" ~ alertID }}">
       {{ alertType }}
   </a>


### PR DESCRIPTION
## What does this PR do? 🛠️

The alert links in the hourly table were having their line heights set higher than default text, resulting in the text rendering slightly lower in the alert box in the hourly table than outside the table. This PR explicitly sets the line height on the alert link so it's consistent everywhere.

- closes #1300

## Screenshots (if appropriate): 📸

<img width="932" alt="image" src="https://github.com/weather-gov/weather.gov/assets/142943695/d127a4b0-af21-4d9e-aa2e-4d5adb47cb04">
