### PR TITLE
Alternate method for getting times in Drupal

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -29,8 +29,8 @@ RUN set -eux; \
   libzip-dev \
   ; \
   # xdebug is being pinned to 3.2.2 because of an issue with Drupal 10.2, see: https://git.drupalcode.org/project/drupal/-/merge_requests/5774
-  pecl install xdebug-3.2.2; \
-  docker-php-ext-enable xdebug; \
+  pecl install xdebug-3.2.2 uopz; \
+  docker-php-ext-enable xdebug uopz; \
   \
   docker-php-ext-configure gd \
   --with-freetype \
@@ -99,5 +99,10 @@ RUN { \
   } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# Add an Apache config that conditionally sets our pre-run scripts
+COPY ./web/config/dev/.htaccess /tmp/coverage-htaccess
+RUN cat /tmp/coverage-htaccess >> /opt/drupal/web/.htaccess
+RUN rm /tmp/coverage-htaccess
 
 # vim:set ft=dockerfile:

--- a/composer.json
+++ b/composer.json
@@ -130,6 +130,7 @@
         "drupal/coder": "^8.3",
         "drupal/devel": "^5.1.2",
         "phpunit/phpunit": "^9.6",
+        "slope-it/clock-mock": "^0.4.0",
         "swaggest/json-schema": "^0.12.42"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f02820db14c0888b3c310bc18d9ae24",
+    "content-hash": "80ee6481b71197cb497336e461430129",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10086,6 +10086,60 @@
                 }
             ],
             "time": "2024-03-09T15:20:58+00:00"
+        },
+        {
+            "name": "slope-it/clock-mock",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slope-it/clock-mock.git",
+                "reference": "075d6052b1c029b62a0e757b62082697546e08fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slope-it/clock-mock/zipball/075d6052b1c029b62a0e757b62082697546e08fe",
+                "reference": "075d6052b1c029b62a0e757b62082697546e08fe",
+                "shasum": ""
+            },
+            "require": {
+                "ext-uopz": ">=6.1.1",
+                "php": ">=7.4.0"
+            },
+            "require-dev": {
+                "ext-calendar": "*",
+                "mockery/mockery": "^1.4.3",
+                "phpunit/phpunit": "^9.6 || ^10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SlopeIt\\ClockMock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andrea Sprega",
+                    "email": "andrea.sprega@slope.it",
+                    "role": "Software engineer"
+                }
+            ],
+            "description": "A library for mocking current date and time in tests.",
+            "keywords": [
+                "ClockMock",
+                "clock",
+                "mock",
+                "slope",
+                "slope.it"
+            ],
+            "support": {
+                "issues": "https://github.com/slope-it/clock-mock/issues",
+                "source": "https://github.com/slope-it/clock-mock/tree/0.4.0"
+            },
+            "time": "2023-08-21T12:01:30+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/web/config/dev/.htaccess
+++ b/web/config/dev/.htaccess
@@ -1,0 +1,6 @@
+# Look for a query string that includes a time parameter. If that exists,
+# prepend our setTime script to anything else that gets run.
+<If "%{QUERY_STRING} =~ /time=/">
+  php_value auto_prepend_file "/opt/drupal/web/config/dev/setTime.php"
+  php_flag opcache.enable Off
+</If>

--- a/web/config/dev/setTime.php
+++ b/web/config/dev/setTime.php
@@ -1,0 +1,25 @@
+<?php
+
+// Run the autoloader so we get everything wired up
+require_once "../vendor/autoload.php";
+
+use SlopeIt\ClockMock\ClockMock;
+
+$qs = [];
+parse_str($_SERVER["QUERY_STRING"], $qs);
+
+if (strlen($qs["time"]) > 0) {
+    // If we have a time string, try to freeze the clock with it.
+    try {
+        ClockMock::freeze(new \DateTime($qs["time"]));
+    } catch (\Throwable $e) {
+        // If that fails for some reason, print the plaintext exception and
+        // bail out. This should help with debugging this particular behavior.
+        header("Content-type: text/plain");
+        http_response_code(404);
+        print_r($e);
+        throw $e;
+    }
+}
+
+uopz_allow_exit(true);


### PR DESCRIPTION
## What does this PR do? 🛠️

- Installs [uopz](https://github.com/krakjoe/uopz) for PHP core method overwriting and [clock-mock](https://github.com/slope-it/clock-mock) for time faking
- Adds an Apache conditional so that if there is a `time` query parameter, it loads a `setTime.php` script before handing anything off to Drupal
- Adds the `setTime.php` script which attempts to freeze time based on the `time` query parameter

With this, you can set Drupal's clock by providing a query parameter, like so:

[http://localhost:8080/point/34.749/-92.275?time=2024-06-17T20:00:00-600](http://localhost:8080/point/34.749/-92.275?time=2024-06-17T20:00:00-600)

...which gives you Little Rock, AR, at 9 PM tonight, June 17, 2024.

## What does the reviewer need to know?

I think this should work fine alongside what you have. If the setting is empty and the environment variable is unset, then this query parameter will work; otherwise, those two should take precedence.