### PR TITLE
Fix a bug with transforming GeoJSON to WKT

### DIFF
--- a/web/modules/weather_data/src/Service/AlertTrait.php
+++ b/web/modules/weather_data/src/Service/AlertTrait.php
@@ -81,13 +81,11 @@ trait AlertTrait
             // If there's a geometry for this alert, use that to determine
             // whether it's relevant for our location.
             if ($alert->geometry) {
-                $alertWKT = SpatialUtility::geometryArrayToWKT(
-                    $alert->geometry->coordinates[0],
-                );
+                $alertSQL = SpatialUtility::geoJSONtoSQL($alert->geometry);
 
                 $sql = "SELECT ST_INTERSECTS(
                     $gridWKT,
-                    $alertWKT
+                    $alertSQL
                 ) as yes";
 
                 $intersects = $this->dataLayer->databaseFetch($sql)->yes;

--- a/web/modules/weather_data/src/Service/Test/SpatialUtility.php.test
+++ b/web/modules/weather_data/src/Service/Test/SpatialUtility.php.test
@@ -64,11 +64,63 @@ final class SpatialUtilityTest extends TestCase
      * @group unit
      * @group spatial-utility
      */
-    public function testGeometryArrayToWKT(): void
+    public function testGeoJSONtoSQLWithPoint(): void
     {
-        $expected = "ST_GEOMFROMTEXT('POLYGON((1 2,3 4,5 6))')";
-        $actual = SpatialUtility::geometryArrayToWKT([[1, 2], [3, 4], [5, 6]]);
+        $expected = "ST_GEOMFROMTEXT('POINT(1 2)')";
+        $actual = SpatialUtility::geoJSONtoSQL(
+            (object) [
+                "type" => "point",
+                "coordinates" => [1, 2],
+            ],
+        );
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @group unit
+     * @group spatial-utility
+     */
+    public function testGeoJSONtoSQLWithPolygon(): void
+    {
+        $expected = "ST_GEOMFROMTEXT('POLYGON((1 2))')";
+        $actual = SpatialUtility::geoJSONtoSQL(
+            (object) [
+                "type" => "PolyGON",
+                "coordinates" => [[[1, 2]]],
+            ],
+        );
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @group unit
+     * @group spatial-utility
+     */
+    public function testGeoJSONtoSQLWithMultipolygon(): void
+    {
+        $expected = "ST_GEOMFROMTEXT('MULTIPOLYGON(((1 2)),((3 4)))')";
+        $actual = SpatialUtility::geoJSONtoSQL(
+            (object) [
+                "type" => "MuLtIpOlYgOn",
+                "coordinates" => [[[[1, 2]]], [[[3, 4]]]],
+            ],
+        );
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @group unit
+     * @group spatial-utility
+     */
+    public function testGeoJSONtoSQLWithUnsupportedType(): void
+    {
+        $this->expectException(\Exception::class);
+        $actual = SpatialUtility::geoJSONtoSQL(
+            (object) [
+                "type" => "Line",
+                "coordinates" => [[1, 2], [3, 4]],
+            ],
+        );
     }
 
     /**


### PR DESCRIPTION
## What does this PR do? 🛠️

Due to a bad assumption about what the API returns (I assumed it was always polygons or nothing), the process by which we converted an alert geometry into a SQL query would break on multipolygons. This PR implements a new helper method called `geoJSONtoSQL`, which takes the entire GeoJSON object (instead of just the list of points) and uses the GeoJSON geometry type as a switch for what kind of WKT text to create.

- fixes #1331
