### PR TITLE
Updating relevant library versions for v1.0.0

### DIFF
--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -6,7 +6,7 @@ uswds-init:
       minified: true
 
 uswds-customized:
-  version: 2024-06-17
+  version: 2024-06-21
   css:
     theme:
       assets/css/styles.css: {}
@@ -65,7 +65,7 @@ radar:
         data-wx-radar-cmi: true
 
 leaflet:
-  version: 1.9.4
+  version: 2024-06-21
   css:
     theme:
       assets/css/leaflet.css:

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -17,7 +17,7 @@ uswds-customized:
       minified: true
 
 browser-location-button:
-  version: 2024-06-04
+  version: 2024-06-21
   js:
     assets/js/locationSearch.js:
       attributes:
@@ -36,7 +36,7 @@ location-combo-box:
     assets/js/components/combo-box.js: { preprocess: false }
         
 tabbed-nav:
-  version: 2024-05-30
+  version: 2024-06-21
   js:
     assets/js/components/TabbedNavigator.js: { preprocess: false }
 


### PR DESCRIPTION
## What does this PR do? 🛠️
We failed to update some javascript library versions before the v.1.0.0 release. This means that browsers that were caching the JS files were loading the page incorrectly, due to new element class names etc.
  
I believe this PR fixes the issue by updating the versions on all relevant / changed js libraries
