### PR TITLE
Weather Story WFO Publish Confirmation

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,9 +14,11 @@
   >
     <include>
       <directory suffix=".theme">web/themes/new_weather_theme</directory>
-      <directory suffix=".theme">web/themes/weathergov_admin</directory>
       <directory>web/modules/weather_blocks</directory>
       <directory>web/modules/weather_data</directory>
     </include>
+    <exclude>
+      <directory suffix=".theme">web/themes/weathergov_admin</directory>
+    </exclude>
   </coverage>
 </phpunit>

--- a/web/themes/weathergov_admin/assets/js/weather-story-modal.js
+++ b/web/themes/weathergov_admin/assets/js/weather-story-modal.js
@@ -1,3 +1,4 @@
+/* eslint no-use-before-define: 0 */
 /**
  * Weather Story Create Confirm Modal
  * --------------------------------
@@ -32,9 +33,7 @@ const getMarkupForEntries = (entries) => {
  * Find the dialog element on the page
  * and return it
  */
-const getModal = () => {
-  return document.querySelector("dialog#weather-story-confirm-modal");
-};
+const getModal = () => document.querySelector("dialog#weather-story-confirm-modal");
 
 /**
  * Attempt to retrieve an array of objects

--- a/web/themes/weathergov_admin/assets/js/weather-story-modal.js
+++ b/web/themes/weathergov_admin/assets/js/weather-story-modal.js
@@ -18,12 +18,12 @@ const getMarkupForEntries = (entries) => {
   // different node of existing published content.
   const wfoName = entries[0].name;
   let infoPrefix = `There is already a published Weather Story for the ${wfoName} WFO:`;
-  if(entries.length > 1){
+  if (entries.length > 1) {
     infoPrefix = `There are already published Weather Stories for the ${wfoName} WFO:`;
   }
-  const linkListLinks = entries.map(entry => {
-    return `<li><a href=${entry.nodeUrl} target="_blank">${entry.nodeTitle}</a></li>`;
-  }).join("\n");
+  const linkListLinks = entries
+    .map((entry) => `<li><a href=${entry.nodeUrl} target="_blank">${entry.nodeTitle}</a></li>`)
+    .join("\n");
   const linkList = `<ul>${linkListLinks}</ul>`;
   return `<p>${infoPrefix}</p>\n${linkList}`;
 };
@@ -48,10 +48,10 @@ const WeatherStoryModalHandler = {
    * WFO Term ids
    */
   hasExistingId: (anId) => {
-    if(WeatherStoryModalHandler.entries){
-      return WeatherStoryModalHandler.entries.map(entry => {
-        return entry.id;
-      }).includes(anId);
+    if (WeatherStoryModalHandler.entries) {
+      return WeatherStoryModalHandler.entries
+        .map((entry) => entry.id)
+        .includes(anId);
     }
 
     return false;
@@ -64,21 +64,20 @@ const WeatherStoryModalHandler = {
   submitHandler: (event) => {
     // We only care about submit events where
     // the publish button was pushed.
-    if(event.target.id !== "edit-publish"){
+    if (event.target.id !== "edit-publish") {
       return;
     }
-    const value = document.querySelector('input[data-drupal-selector^="edit-field-wfo"]').value;
-    if(!value || value == ""){
+    const value = document.querySelector(
+      'input[data-drupal-selector^="edit-field-wfo"]',
+    ).value;
+    if (!value || value === "") {
       return;
     }
     const idMatch = value.match(/^.*\(([0-9]+)\).*$/);
     const id = idMatch[1];
-    const matchingEntries = WeatherStoryModalHandler.entries.filter(entry => {
-      return entry.id == id;
-    });
-    if(matchingEntries.length){
+    const matchingEntries = WeatherStoryModalHandler.entries.filter((entry) => entry.id === id);
+    if (matchingEntries.length) {
       event.preventDefault();
-      console.log(event.target);
       WeatherStoryModalHandler.showModalWith(id, event.target, matchingEntries);
     }
   },
@@ -89,67 +88,69 @@ const WeatherStoryModalHandler = {
    */
   showModalWith: (id, submitterElement, matchingEntries) => {
     // Add the text to the modal
-    const description = document.createElement('div');
+    const description = document.createElement("div");
     description.innerHTML = getMarkupForEntries(matchingEntries);
     WeatherStoryModalHandler.modal.prepend(description);
 
     // Add event handlers to the modal's buttons
-    Array.from(WeatherStoryModalHandler.modal.querySelectorAll('button'))
-      .forEach(button => {
-        button.addEventListener('click', () => {
-          // The data attribute will reference the id
-          // of a target button to programmatically click
-          // on the page's actual form.
-          // If there is no target, the modal will simply close
-          const targetButton = document.getElementById(
-            button.dataset.modalSubmitterTarget
+    Array.from(
+      WeatherStoryModalHandler.modal.querySelectorAll("button"),
+    ).forEach((button) => {
+      button.addEventListener("click", () => {
+        // The data attribute will reference the id
+        // of a target button to programmatically click
+        // on the page's actual form.
+        // If there is no target, the modal will simply close
+        const targetButton = document.getElementById(
+          button.dataset.modalSubmitterTarget,
+        );
+        if (!targetButton) {
+          WeatherStoryModalHandler.modal.close();
+        } else {
+          submitterElement.removeEventListener(
+            "click",
+            WeatherStoryModalHandler.submitHandler,
           );
-          if(!targetButton){
-            console.log(button.dataset.modalSubmitterTarget, 'close');
-            WeatherStoryModalHandler.modal.close();
-          } else {
-            submitterElement.removeEventListener('click', WeatherStoryModalHandler.submitHandler);
-            WeatherStoryModalHandler.modal.close();
-            targetButton.click();
-          }
-        });
+          WeatherStoryModalHandler.modal.close();
+          targetButton.click();
+        }
       });
+    });
 
     // Now show the modal
     WeatherStoryModalHandler.modal.showModal();
   },
 
-  get modal(){
-    return document.querySelector('dialog#weather-story-confirm-modal');
-  }
+  get modal() {
+    return document.querySelector("dialog#weather-story-confirm-modal");
+  },
 };
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   // First, we find the script tag containing the
   // JSON with any published WFO stories
-  const existingEl = document.getElementById('existing-wfo-entries');
+  const existingEl = document.getElementById("existing-wfo-entries");
 
   // Make sure there is a publish button
-  const publishButton = document.getElementById('edit-publish');
-  if(!publishButton){
+  const publishButton = document.getElementById("edit-publish");
+  if (!publishButton) {
     return;
   }
 
   // Next, ensure that the corresponding modal is
   // on the page
-  if(!existingEl || !WeatherStoryModalHandler.modal){
+  if (!existingEl || !WeatherStoryModalHandler.modal) {
     return;
   }
 
   // Parse the JSON and load it into the
   // modal handler
-  const existingItems = JSON.parse(
-    existingEl.textContent
-  );
+  const existingItems = JSON.parse(existingEl.textContent);
   WeatherStoryModalHandler.setExisting(existingItems);
 
   // Listen for click events on the publish button
-  publishButton.addEventListener('click', WeatherStoryModalHandler.submitHandler);
-  
+  publishButton.addEventListener(
+    "click",
+    WeatherStoryModalHandler.submitHandler,
+  );
 });
-console.log('MODULE LOADED');

--- a/web/themes/weathergov_admin/assets/js/weather-story-modal.js
+++ b/web/themes/weathergov_admin/assets/js/weather-story-modal.js
@@ -1,0 +1,155 @@
+/**
+ * Weather Story Create Confirm Modal
+ * --------------------------------
+ * Will trigger a dialog modal popup in the
+ * event that a Weather Story with the given
+ * WFO already exists and is published.
+ */
+
+/**
+ * Generate the inner modal dialog markup
+ * for a given array of WFO term entry objects
+ * as provided by our Drupal hook
+ * (See `weathergov_admin_preprocess_page__node__add__weather_story`)
+ */
+const getMarkupForEntries = (entries) => {
+  // We assume that all incoming entries are the
+  // same WFO term, but might each reference a
+  // different node of existing published content.
+  const wfoName = entries[0].name;
+  let infoPrefix = `There is already a published Weather Story for the ${wfoName} WFO:`;
+  if(entries.length > 1){
+    infoPrefix = `There are already published Weather Stories for the ${wfoName} WFO:`;
+  }
+  const linkListLinks = entries.map(entry => {
+    return `<li><a href=${entry.nodeUrl} target="_blank">${entry.nodeTitle}</a></li>`;
+  }).join("\n");
+  const linkList = `<ul>${linkListLinks}</ul>`;
+  return `<p>${infoPrefix}</p>\n${linkList}`;
+};
+
+const WeatherStoryModalHandler = {
+  /**
+   * Take an array of objects that represents
+   * existing WFO Terms that already
+   * have published Weather Stories.
+   * These objects will have the keys:
+   *     id - The WFO Term ID
+   *     name - The name of the WFO
+   *     code - The WFO three-letter code
+   */
+  setExisting: (aDictArray) => {
+    WeatherStoryModalHandler.entries = aDictArray;
+  },
+
+  /**
+   * Responds true if the given id
+   * matches one of our existing
+   * WFO Term ids
+   */
+  hasExistingId: (anId) => {
+    if(WeatherStoryModalHandler.entries){
+      return WeatherStoryModalHandler.entries.map(entry => {
+        return entry.id;
+      }).includes(anId);
+    }
+
+    return false;
+  },
+
+  /**
+   * A handler for any submit events at the
+   * document level. Will check for matches.
+   */
+  submitHandler: (event) => {
+    // We only care about submit events where
+    // the publish button was pushed.
+    if(event.target.id !== "edit-publish"){
+      return;
+    }
+    const value = document.querySelector('input[data-drupal-selector^="edit-field-wfo"]').value;
+    if(!value || value == ""){
+      return;
+    }
+    const idMatch = value.match(/^.*\(([0-9]+)\).*$/);
+    const id = idMatch[1];
+    const matchingEntries = WeatherStoryModalHandler.entries.filter(entry => {
+      return entry.id == id;
+    });
+    if(matchingEntries.length){
+      event.preventDefault();
+      console.log(event.target);
+      WeatherStoryModalHandler.showModalWith(id, event.target, matchingEntries);
+    }
+  },
+
+  /**
+   * Show the modal, binding appropriate methods
+   * to the buttons inside of it
+   */
+  showModalWith: (id, submitterElement, matchingEntries) => {
+    // Add the text to the modal
+    const description = document.createElement('div');
+    description.innerHTML = getMarkupForEntries(matchingEntries);
+    WeatherStoryModalHandler.modal.prepend(description);
+
+    // Add event handlers to the modal's buttons
+    Array.from(WeatherStoryModalHandler.modal.querySelectorAll('button'))
+      .forEach(button => {
+        button.addEventListener('click', () => {
+          // The data attribute will reference the id
+          // of a target button to programmatically click
+          // on the page's actual form.
+          // If there is no target, the modal will simply close
+          const targetButton = document.getElementById(
+            button.dataset.modalSubmitterTarget
+          );
+          if(!targetButton){
+            console.log(button.dataset.modalSubmitterTarget, 'close');
+            WeatherStoryModalHandler.modal.close();
+          } else {
+            submitterElement.removeEventListener('click', WeatherStoryModalHandler.submitHandler);
+            WeatherStoryModalHandler.modal.close();
+            targetButton.click();
+          }
+        });
+      });
+
+    // Now show the modal
+    WeatherStoryModalHandler.modal.showModal();
+  },
+
+  get modal(){
+    return document.querySelector('dialog#weather-story-confirm-modal');
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  // First, we find the script tag containing the
+  // JSON with any published WFO stories
+  const existingEl = document.getElementById('existing-wfo-entries');
+
+  // Make sure there is a publish button
+  const publishButton = document.getElementById('edit-publish');
+  if(!publishButton){
+    return;
+  }
+
+  // Next, ensure that the corresponding modal is
+  // on the page
+  if(!existingEl || !WeatherStoryModalHandler.modal){
+    return;
+  }
+
+  // Parse the JSON and load it into the
+  // modal handler
+  const existingItems = JSON.parse(
+    existingEl.textContent
+  );
+  WeatherStoryModalHandler.setExisting(existingItems);
+
+  // Listen for click events on the publish button
+  publishButton.addEventListener('click', WeatherStoryModalHandler.submitHandler);
+  
+});
+console.log('MODULE LOADED');

--- a/web/themes/weathergov_admin/templates/page--node--add--weather-story.html.twig
+++ b/web/themes/weathergov_admin/templates/page--node--add--weather-story.html.twig
@@ -1,0 +1,69 @@
+{#
+/**
+ * @file
+ * Claro's theme implementation to display a single Drupal page.
+ *
+ * The doctype, html, head, and body tags are not in this template. Instead
+ * they can be found in the html.html.twig template normally located in the
+ * core/modules/system directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.pre_content: Items for the pre-content region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ * - page.highlighted: Items for the highlighted region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+  <header class="content-header clearfix">
+    <div class="layout-container">
+      {{ page.breadcrumb }}
+      {{ page.header }}
+    </div>
+  </header>
+  <div class="layout-container">
+    {{ page.pre_content }}
+    <main class="page-content clearfix" role="main">
+      <div class="visually-hidden"><a id="main-content" tabindex="-1"></a></div>
+      {{ page.highlighted }}
+      {% if page.help %}
+        <div class="help">
+          {{ page.help }}
+        </div>
+      {% endif %}
+      {{ page.content }}
+    </main>
+  </div>
+  <script type="application/json" id="existing-wfo-entries">
+   {{published_wfos | raw}}
+  </script>
+  <dialog id="weather-story-confirm-modal">
+      <p>What would you like to do?</p>
+      <button data-modal-submitter-target="edit-publish">Replace</button>
+      <button data-modal-submitter-target="edit-submit">Save as draft</button>
+      <button>Close</button>
+  </dialog>

--- a/web/themes/weathergov_admin/weathergov_admin.libraries.yml
+++ b/web/themes/weathergov_admin/weathergov_admin.libraries.yml
@@ -1,0 +1,4 @@
+weather-story-modal-dialog:
+  version: 2024-06-24
+  js:
+    assets/js/weather-story-modal.js: {}

--- a/web/themes/weathergov_admin/weathergov_admin.theme
+++ b/web/themes/weathergov_admin/weathergov_admin.theme
@@ -55,9 +55,9 @@ function weathergov_admin_form_node_form_alter(
         // that one's status. If this one isn't published, then the node isn't
         // published at all.
         $isPublished = \Drupal::entityTypeManager()
-            ->getStorage("node")
-            ->load($node->id())
-            ->isPublished();
+                              ->getStorage("node")
+                              ->load($node->id())
+                              ->isPublished();
 
         if ($isPublished) {
             $form["actions"]["unpublish"] = [
@@ -95,10 +95,23 @@ function weathergov_admin_form_node_form_alter(
                 "Content must be previewed before it can be saved or published.",
         ];
     }
+
+    // If this is a node form for a Weather Story,
+    // we attach the modal confirm library
+    if($form_id == "node_weather_story_form"){
+        $form['#attached']['library'][] = 'weathergov_admin/weather-story-modal-dialog';
+    }
 }
 
 function weathergov_form_node_publish($form, &$formState)
 {
+    // First, archive any Weather Story nodes that are already
+    // published if they have the same WFO as was submitted
+    $wfo_id = $formState->getValue('field_wfo')[0]['target_id'];
+    weathergov_unpublish_published_weather_stories($wfo_id);
+
+    // Now change the moderation state in order to publish
+    // the current node described by the form
     $node = $formState->getFormObject()->getEntity();
     $node->set("moderation_state", "published");
     $node->save();
@@ -164,5 +177,69 @@ function weathergov_admin_form_alter(&$form, $form_state, $form_id)
             $input["field_wfo_target_id"] = $wfo;
             $form_state->setUserInput($input);
         }
+    }
+}
+
+function get_all_published_weather_stories(){
+    // Get a list of published weather story nodes and
+    // their associated WFOs.
+    return \Drupal::entityTypeManager()
+                  ->getStorage('node')
+                  ->loadByProperties(
+                      [
+                          'type' => 'weather_story',
+                          'status' => 1
+                      ]
+                  );
+}
+
+function weathergov_admin_preprocess_page__node__add__weather_story(&$variables)
+{
+    $nodes = get_all_published_weather_stories();
+    // Get an associative array of published wfo term
+    // information, including its id and name.
+    // Set a template variable to be the JSON string
+    // of this array.
+    $wfos = array_map(function($node){
+        $reference = $node->get('field_wfo')->referencedEntities()[0];
+        return (object)[
+            'name' => $reference->get('name')->value,
+            'code' => $reference->get('field_wfo_code')->value,
+            'id' => $reference->id(),
+            'nodeUrl' => $node->toUrl()->toString(),
+            'nodeTitle' => $node->getTitle()
+        ];
+    }, $nodes);
+    $wfos = array_values($wfos);
+    $variables["#attached"]["library"][] = "weathergov_admin/weather-story-modal-dialog";
+    $variables["published_wfos"] = json_encode($wfos);
+}
+
+function weathergov_unpublish_published_weather_stories($wfo_id)
+{
+    // Get all published weather story nodes
+    $nodes = get_all_published_weather_stories();
+
+    // Filter to only those nodes that have the corresponding
+    // WFO Term id
+    $filtered_nodes = array_filter(
+        $nodes,
+        function($node) use (&$wfo_id){
+            $wfo_ref = $node->get('field_wfo')->referencedEntities()[0];
+            return $wfo_ref->id() == $wfo_id;
+        }
+    );
+
+    foreach($filtered_nodes as $node){
+        $node->set('moderation_state', 'archived');
+        $node->save();
+
+        $url = $node->toUrl()->toString();
+        $title = $node->getTitle();
+        
+        // Add the pretty message.
+        \Drupal::service("messenger")->addMessage(
+            Markup::create("Unpublished Weather Story <a href=\"$url\">$title</a> (due to same WFO)"),
+        );
     }
 }

--- a/web/themes/weathergov_admin/weathergov_admin.theme
+++ b/web/themes/weathergov_admin/weathergov_admin.theme
@@ -55,9 +55,9 @@ function weathergov_admin_form_node_form_alter(
         // that one's status. If this one isn't published, then the node isn't
         // published at all.
         $isPublished = \Drupal::entityTypeManager()
-                              ->getStorage("node")
-                              ->load($node->id())
-                              ->isPublished();
+            ->getStorage("node")
+            ->load($node->id())
+            ->isPublished();
 
         if ($isPublished) {
             $form["actions"]["unpublish"] = [
@@ -108,11 +108,11 @@ function weathergov_form_node_publish($form, &$formState)
 {
     // Grab the referenced content node
     $node = $formState->getFormObject()->getEntity();
-    
+
     // If this is a Weather Story, archive any Weather Story nodes
     // that are already published if they have the same WFO
     // as was submitted
-    if($node->getType() == "weather_story"){
+    if ($node->getType() == "weather_story") {
         $wfo_id = $formState->getValue("field_wfo")[0]["target_id"];
         weathergov_unpublish_published_weather_stories($wfo_id);
     }
@@ -191,11 +191,11 @@ function get_all_published_weather_stories()
     // Get a list of published weather story nodes and
     // their associated WFOs.
     return \Drupal::entityTypeManager()
-                  ->getStorage("node")
-                  ->loadByProperties([
-                      "type" => "weather_story",
-                      "status" => 1,
-                  ]);
+        ->getStorage("node")
+        ->loadByProperties([
+            "type" => "weather_story",
+            "status" => 1,
+        ]);
 }
 
 function weathergov_admin_preprocess_page__node__add__weather_story(&$variables)

--- a/web/themes/weathergov_admin/weathergov_admin.theme
+++ b/web/themes/weathergov_admin/weathergov_admin.theme
@@ -55,9 +55,9 @@ function weathergov_admin_form_node_form_alter(
         // that one's status. If this one isn't published, then the node isn't
         // published at all.
         $isPublished = \Drupal::entityTypeManager()
-            ->getStorage("node")
-            ->load($node->id())
-            ->isPublished();
+                              ->getStorage("node")
+                              ->load($node->id())
+                              ->isPublished();
 
         if ($isPublished) {
             $form["actions"]["unpublish"] = [
@@ -106,14 +106,19 @@ function weathergov_admin_form_node_form_alter(
 
 function weathergov_form_node_publish($form, &$formState)
 {
-    // First, archive any Weather Story nodes that are already
-    // published if they have the same WFO as was submitted
-    $wfo_id = $formState->getValue("field_wfo")[0]["target_id"];
-    weathergov_unpublish_published_weather_stories($wfo_id);
+    // Grab the referenced content node
+    $node = $formState->getFormObject()->getEntity();
+    
+    // If this is a Weather Story, archive any Weather Story nodes
+    // that are already published if they have the same WFO
+    // as was submitted
+    if($node->getType() == "weather_story"){
+        $wfo_id = $formState->getValue("field_wfo")[0]["target_id"];
+        weathergov_unpublish_published_weather_stories($wfo_id);
+    }
 
     // Now change the moderation state in order to publish
     // the current node described by the form
-    $node = $formState->getFormObject()->getEntity();
     $node->set("moderation_state", "published");
     $node->save();
 
@@ -186,11 +191,11 @@ function get_all_published_weather_stories()
     // Get a list of published weather story nodes and
     // their associated WFOs.
     return \Drupal::entityTypeManager()
-        ->getStorage("node")
-        ->loadByProperties([
-            "type" => "weather_story",
-            "status" => 1,
-        ]);
+                  ->getStorage("node")
+                  ->loadByProperties([
+                      "type" => "weather_story",
+                      "status" => 1,
+                  ]);
 }
 
 function weathergov_admin_preprocess_page__node__add__weather_story(&$variables)

--- a/web/themes/weathergov_admin/weathergov_admin.theme
+++ b/web/themes/weathergov_admin/weathergov_admin.theme
@@ -55,9 +55,9 @@ function weathergov_admin_form_node_form_alter(
         // that one's status. If this one isn't published, then the node isn't
         // published at all.
         $isPublished = \Drupal::entityTypeManager()
-                              ->getStorage("node")
-                              ->load($node->id())
-                              ->isPublished();
+            ->getStorage("node")
+            ->load($node->id())
+            ->isPublished();
 
         if ($isPublished) {
             $form["actions"]["unpublish"] = [
@@ -98,8 +98,9 @@ function weathergov_admin_form_node_form_alter(
 
     // If this is a node form for a Weather Story,
     // we attach the modal confirm library
-    if($form_id == "node_weather_story_form"){
-        $form['#attached']['library'][] = 'weathergov_admin/weather-story-modal-dialog';
+    if ($form_id == "node_weather_story_form") {
+        $form["#attached"]["library"][] =
+            "weathergov_admin/weather-story-modal-dialog";
     }
 }
 
@@ -107,7 +108,7 @@ function weathergov_form_node_publish($form, &$formState)
 {
     // First, archive any Weather Story nodes that are already
     // published if they have the same WFO as was submitted
-    $wfo_id = $formState->getValue('field_wfo')[0]['target_id'];
+    $wfo_id = $formState->getValue("field_wfo")[0]["target_id"];
     weathergov_unpublish_published_weather_stories($wfo_id);
 
     // Now change the moderation state in order to publish
@@ -180,17 +181,16 @@ function weathergov_admin_form_alter(&$form, $form_state, $form_id)
     }
 }
 
-function get_all_published_weather_stories(){
+function get_all_published_weather_stories()
+{
     // Get a list of published weather story nodes and
     // their associated WFOs.
     return \Drupal::entityTypeManager()
-                  ->getStorage('node')
-                  ->loadByProperties(
-                      [
-                          'type' => 'weather_story',
-                          'status' => 1
-                      ]
-                  );
+        ->getStorage("node")
+        ->loadByProperties([
+            "type" => "weather_story",
+            "status" => 1,
+        ]);
 }
 
 function weathergov_admin_preprocess_page__node__add__weather_story(&$variables)
@@ -200,18 +200,19 @@ function weathergov_admin_preprocess_page__node__add__weather_story(&$variables)
     // information, including its id and name.
     // Set a template variable to be the JSON string
     // of this array.
-    $wfos = array_map(function($node){
-        $reference = $node->get('field_wfo')->referencedEntities()[0];
-        return (object)[
-            'name' => $reference->get('name')->value,
-            'code' => $reference->get('field_wfo_code')->value,
-            'id' => $reference->id(),
-            'nodeUrl' => $node->toUrl()->toString(),
-            'nodeTitle' => $node->getTitle()
+    $wfos = array_map(function ($node) {
+        $reference = $node->get("field_wfo")->referencedEntities()[0];
+        return (object) [
+            "name" => $reference->get("name")->value,
+            "code" => $reference->get("field_wfo_code")->value,
+            "id" => $reference->id(),
+            "nodeUrl" => $node->toUrl()->toString(),
+            "nodeTitle" => $node->getTitle(),
         ];
     }, $nodes);
     $wfos = array_values($wfos);
-    $variables["#attached"]["library"][] = "weathergov_admin/weather-story-modal-dialog";
+    $variables["#attached"]["library"][] =
+        "weathergov_admin/weather-story-modal-dialog";
     $variables["published_wfos"] = json_encode($wfos);
 }
 
@@ -222,24 +223,23 @@ function weathergov_unpublish_published_weather_stories($wfo_id)
 
     // Filter to only those nodes that have the corresponding
     // WFO Term id
-    $filtered_nodes = array_filter(
-        $nodes,
-        function($node) use (&$wfo_id){
-            $wfo_ref = $node->get('field_wfo')->referencedEntities()[0];
-            return $wfo_ref->id() == $wfo_id;
-        }
-    );
+    $filtered_nodes = array_filter($nodes, function ($node) use (&$wfo_id) {
+        $wfo_ref = $node->get("field_wfo")->referencedEntities()[0];
+        return $wfo_ref->id() == $wfo_id;
+    });
 
-    foreach($filtered_nodes as $node){
-        $node->set('moderation_state', 'archived');
+    foreach ($filtered_nodes as $node) {
+        $node->set("moderation_state", "archived");
         $node->save();
 
         $url = $node->toUrl()->toString();
         $title = $node->getTitle();
-        
+
         // Add the pretty message.
         \Drupal::service("messenger")->addMessage(
-            Markup::create("Unpublished Weather Story <a href=\"$url\">$title</a> (due to same WFO)"),
+            Markup::create(
+                "Unpublished Weather Story <a href=\"$url\">$title</a> (due to same WFO)",
+            ),
         );
     }
 }


### PR DESCRIPTION
## What does this PR do? 🛠️
After eons, this PR addresses #1269. The gist is that when creating a new Weather Story and entering a linked WFO, authors should see a dialog of some sort informing them that there is another Weather Story already published with the same WFO. The dialog will have options to save a draft, cancel, or "replace" -- meaning unpublish the other Weather Story first, then publish the new one.

## What does the reviewer need to know? 🤔
### Hey, isn't there a way to already do this? ###
![th](https://github.com/weather-gov/weather.gov/assets/105373963/4cee0e1c-5290-4e50-9d36-700a6dbc7277)
  
**No.**
  
I spent a significant amount of time trying to get this "confirmation, with original form data" concept to work via various Drupal APIs and patterns. None of them worked.
  
After _days_ of poking at it, I threw my hands up and decided to go with Javascript and some basic hook/template alterations.
  
### Ok, sure, but how does it work? ###
We add a custom [JS file](https://github.com/weather-gov/weather.gov/blob/eg-1269-basic-js-ws-confirmation/web/themes/weathergov_admin/assets/js/weather-story-modal.js) as a theme library called `weather-story-modal-dialog` which handles the logic of an otherwise inert `<dialog>` element that is now present in the template for adding weather stories.
  
In the admin theme file, we add a few helper methods and hooks that will load this library.
  
Additionally, if the form is a Weather Story create form, the hook will query the system for all weather stories that are currently published, passing information about all of them -- including and especially i[nformation about their linked WFO Terms](https://github.com/weather-gov/weather.gov/blob/eg-1269-basic-js-ws-confirmation/web/themes/weathergov_admin/weathergov_admin.theme#L196-L217) -- to the template file as [a JSON object tucked away in a script tag](https://github.com/weather-gov/weather.gov/blob/eg-1269-basic-js-ws-confirmation/web/themes/weathergov_admin/templates/page--node--add--weather-story.html.twig#L61-L63).
  
If the user decides to publish anyway, all existing published Weather Stories with the same WFO will be archived. This happens [by default in the publish action now](https://github.com/weather-gov/weather.gov/blob/eg-1269-basic-js-ws-confirmation/web/themes/weathergov_admin/weathergov_admin.theme#L109-L112), and is not unique to the dialog.
  
### Boring! How can I just try it out? ###
Here are some steps to follow to try it out locally:
* `zap` your containers
* Create a Weather Story for a specific WFO
* Publish the story
* Go back to the content page, and try to add a new Weather Story. Select the same WFO
* Click "Preview"
* Click the back link
* Click "Publish"
* A dialog should appear warning you about the original story being already published. Click "replace"
* You should see a message saying the new story was published and the old one was unpublished
* In the content list, there should only be one published weather story

## Screenshots (if appropriate): 📸
<details>
<summary>Visual summary of "replacing" with a new weather story for Nashville</summary>
  
![Screenshot 2024-06-26 at 4 23 21 PM](https://github.com/weather-gov/weather.gov/assets/105373963/fdc077ed-1277-49d7-ad38-f3e377247463)
![Screenshot 2024-06-26 at 4 23 53 PM](https://github.com/weather-gov/weather.gov/assets/105373963/224d763e-2fe7-46e5-9df9-f4e8c9787b15)
![Screenshot 2024-06-26 at 4 24 26 PM](https://github.com/weather-gov/weather.gov/assets/105373963/5dbcae63-db6f-46df-9e43-4eefab8ae32e)
![Screenshot 2024-06-26 at 4 24 36 PM](https://github.com/weather-gov/weather.gov/assets/105373963/61cf121e-d041-4925-8172-c21cf65bf119)
![Screenshot 2024-06-26 at 4 24 43 PM](https://github.com/weather-gov/weather.gov/assets/105373963/50041b03-2c69-43d9-8852-e3a5487a1ecc)

</details>

