### PR TITLE
Add link to preexisting content on duplicate safety info

### DIFF
--- a/web/config/sync/field.field.node.dynamic_safety_information.field_weather_event_type.yml
+++ b/web/config/sync/field.field.node.dynamic_safety_information.field_weather_event_type.yml
@@ -11,7 +11,7 @@ dependencies:
 third_party_settings:
   unique_content_field_validation:
     unique: true
-    unique_text: 'Safety information for this event type already exists. Please edit the existing event type instead of creating a new one.'
+    unique_text: 'Safety information for this event type already exists. Please <a href="/node/%nodeId/edit">edit the existing event type</a> instead of creating a new one.'
 id: node.dynamic_safety_information.field_weather_event_type
 field_name: field_weather_event_type
 entity_type: node

--- a/web/modules/unique_content_field_validation/src/Plugin/Validation/Constraint/UniqueContentTitleValidator.php
+++ b/web/modules/unique_content_field_validation/src/Plugin/Validation/Constraint/UniqueContentTitleValidator.php
@@ -76,12 +76,23 @@ class UniqueContentTitleValidator extends ConstraintValidator implements Contain
                 $id_field = 'nid';
                 break;
         }
-        if ($unique_validation_enabled && $this->uniqueValidation($unique_field_name, $value, $entity_type, $bundle_field, $entity_bundle, $id_field)) { //phpcs:ignore
-            $message = $custom_message ?: $constraint->message;
-            $this->context->addViolation($message, [
-                '%label' => $unique_entity_title_label,
-                '%value' => $value,
-            ]);
+        if ($unique_validation_enabled) {
+            $existingNodes = $this->uniqueValidation(
+                $unique_field_name,
+                $value,
+                $entity_type,
+                $bundle_field,
+                $entity_bundle,
+                $id_field,
+            );
+            if ($existingNodes !== false) {
+                $message = $custom_message ?: $constraint->message;
+                $this->context->addViolation($message, [
+                    "%label" => $unique_entity_title_label,
+                    "%value" => $value,
+                    "%nodeId" => array_pop($existingNodes),
+                ]);
+            }
         }
     }
 
@@ -117,7 +128,7 @@ class UniqueContentTitleValidator extends ConstraintValidator implements Contain
             }
             $entities = $query->accessCheck(false)->execute();
             if (!empty($entities)) {
-                return true;
+                return $entities;
             }
         }
         return false;

--- a/web/modules/unique_content_field_validation/unique_content_field_validation.module
+++ b/web/modules/unique_content_field_validation/unique_content_field_validation.module
@@ -220,18 +220,27 @@ function unique_content_field_validation_validate_unique($element, FormStateInte
     $entity_type = $entity->getEntityTypeId();
 
     if ($items) {
-      // If field is not unique set error.
-        $valid = unique_content_field_validation_field_is_unique($entity_type, $langcode, $field_name, $items, $entity->bundle(), $entity); //phpcs:ignore
-        if (!$valid) {
-            $items_msg = implode(',', $items);
-            if (!empty($element['#unique_field_settings']['message'])) {
-                $message = str_replace(["%label", "%value"], [$field_label, $items_msg], $element['#unique_field_settings']['message']); //phpcs:ignore
+        // If field is not unique set error.
+        $valid = unique_content_field_validation_field_is_unique( $entity_type, $langcode, $field_name, $items, $entity->bundle(), $entity); //phpcs:ignore
+        if ($valid !== true) {
+            $existingNodeID = array_pop($valid);
+            $items_msg = implode(",", $items);
+            if (!empty($element["#unique_field_settings"]["message"])) {
+                $message = str_replace(
+                    ["%label", "%value", "%nodeId"],
+                    [$field_label, $items_msg, $existingNodeID],
+                    $element["#unique_field_settings"]["message"],
+                ); //phpcs:ignore
                 $form_state->setErrorByName($field_name, t($message));
             } else {
-                $form_state->setErrorByName($field_name, t('%label must be unique but "%value" already exists!', [
-                    '%label' => $field_label,
-                    '%value' => $items_msg,
-                ]));
+                $form_state->setErrorByName(
+                    $field_name,
+                    t('%label must be unique but "%value" already exists!', [
+                        "%label" => $field_label,
+                        "%value" => $items_msg,
+                        "%nodeId" => $existingNodeID,
+                    ]),
+                );
             }
 
             $form_state->setRebuild();
@@ -317,7 +326,7 @@ function unique_content_field_validation_field_is_unique($entity_type, $langcode
             $valid = true;
         }
     }
-    return $valid;
+    return $valid ? $valid : $entities;
 }
 
 /**

--- a/web/modules/unique_content_field_validation/unique_content_field_validation.module
+++ b/web/modules/unique_content_field_validation/unique_content_field_validation.module
@@ -74,7 +74,7 @@ function unique_content_field_validation_form_field_config_edit_form_alter(array
           '#type' => 'textarea',
           '#title' => t('Unique message validation'),
           '#default_value' => $field->getThirdPartySetting('unique_content_field_validation', 'unique_text', ''),
-          '#description' => t('Message to show up when the content is duplicated. <br /> To show the field name use %label <br /> To show the field value use %value'), //phpcs:ignore
+          '#description' => t('Message to show up when the content is duplicated. <br /> To show the field name use %label <br /> To show the field value use %value <br /> To show the ID of the preexisting node use %nodeId'), //phpcs:ignore
           '#states' => [
             'visible' => [
               ':input[name="third_party_settings[unique_content_field_validation][unique]"]' => ['checked' => true],
@@ -95,7 +95,7 @@ function unique_content_field_validation_form_field_config_edit_form_alter(array
                 '#type' => 'textarea',
                 '#title' => t('Multi value field message validation'),
                 '#default_value' => $field->getThirdPartySetting('unique_content_field_validation', 'unique_multivalue_text', ''), //phpcs:ignore
-                '#description' => t('Message to show up when the content entered is set more than one time within the same field. <br /> To show the field name use %label <br /> To show the field value use %value'), //phpcs:ignore
+                '#description' => t('Message to show up when the content entered is set more than one time within the same field. <br /> To show the field name use %label <br /> To show the field value use %value <br /> To show the ID of the preexisting node use %nodeId'), //phpcs:ignore
                 '#states' => [
                     'visible' => [
                         ':input[name="third_party_settings[unique_content_field_validation][unique_multivalue]"]' => ['checked' => true], //phpcs:ignore
@@ -130,7 +130,7 @@ function unique_content_field_validation_form_node_type_form_alter(array &$form,
         '#type' => 'textarea',
         '#title' => t('Unique message validation'),
         '#default_value' => $node_type->getThirdPartySetting('unique_content_field_validation', 'unique_text', ''),
-        '#description' => t('Message to show up when the content is duplicated. <br /> To show the Title field label use %label <br /> To show the value of the field use %value'), //phpcs:ignore
+        '#description' => t('Message to show up when the content is duplicated. <br /> To show the Title field label use %label <br /> To show the value of the field use %value <br /> To show the ID of the preexisting node use %nodeId'), //phpcs:ignore
         '#states' => [
             'visible' => [
                 ':input[name="unique_content_field_validation[unique]"]' => ['checked' => true],


### PR DESCRIPTION
## What does this PR do? 🛠️

Updates the unique content validator to add `%nodeId` as a template variable. In the user-provided validation error message, the `%nodeId` token will be replaced with the ID of the preexisting node for this the uniqueness constraint (in this case, weather event type).

The in config, updates the validation message to encapsulate the node ID into a link to that node's edit form.

- closes #1335

## Screenshots (if appropriate): 📸

### Error message
![image](https://github.com/weather-gov/weather.gov/assets/142943695/6ca2446e-d43e-41bd-b167-45f568cd6184)

### Config
![image](https://github.com/weather-gov/weather.gov/assets/142943695/413876ea-3f5d-49d8-8487-1542ad99c70c)
