### PR TITLE
Update hourly table library date

### DIFF
--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -41,7 +41,7 @@ tabbed-nav:
     assets/js/components/TabbedNavigator.js: { preprocess: false }
 
 hourly-table:
-  version: 2024-05-07
+  version: 2024-06-18
   js:
     assets/js/components/HourlyTable.js: { preprocess: false }
 


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR updates the library date for `HourlyTable.js` to reflect the changes that were added as part of #1334. I believe the old date is causing a browser cache issue that results in the bug in #1411  
