### PR TITLE
Hourly table alert header a11y fix

### DIFF
--- a/web/themes/new_weather_theme/templates/partials/alerts-in-hourly-table.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/alerts-in-hourly-table.html.twig
@@ -12,8 +12,8 @@
     {% if loop.first %}
       {% if alertPeriods | length > 1 %} {% set plural="s" %} {% endif %}
       <span class="" aria-hidden="true">{{ "Alert#{plural}" | t }}</span>
-      <span class="usa-sr-only">{{ "Alert" | t }}</span>
     {% endif %}
+      <span class="usa-sr-only">{{ "Alert" | t }}</span>
     </th>
     {% if alertInfo.periodIndex > 0 %}
       <td colspan="{{ alertInfo.periodIndex }}"></td>


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR updates the alert table heading in the hourly table to always display for screen readers. Currently it was only displaying for the first alert row, resulting in empty table headers which is flagged as an a11y error. 

## What does the reviewer need to know? 🤔
There is no visual change to the table



