### PR TITLE
Reduce spacing for alert county lists

### DIFF
--- a/.github/actions/setup-site/action.yml
+++ b/.github/actions/setup-site/action.yml
@@ -25,7 +25,7 @@ runs:
     # Give the containers a moment to settle.
     - name: wait a tick
       shell: bash
-      run: sleep 15
+      run: sleep 10
 
     - name: populate the site
       shell: bash

--- a/.github/actions/setup-site/action.yml
+++ b/.github/actions/setup-site/action.yml
@@ -25,7 +25,7 @@ runs:
     # Give the containers a moment to settle.
     - name: wait a tick
       shell: bash
-      run: sleep 10
+      run: sleep 15
 
     - name: populate the site
       shell: bash

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-local-alerts.html.twig
@@ -69,10 +69,10 @@
           {% if alert.alertAreas != false %}
             {% for area in alert.alertAreas.countyAreas %}
               <wx-alert-county-region>
-              <h5 class="wx-visual-h4 text-normal text-primary-dark">
+              <h5 class="wx-visual-h4 text-normal text-primary-dark margin-top-205 margin-bottom-0">
                 {{ "Counties in" | t }} {{ area.area }}
               </h5>
-              <ul class="usa-list {%- if area.counties | length > 7 %} wx-col-2 {%- endif -%}">
+              <ul class="usa-list margin-top-1 {%- if area.counties | length > 7 %} wx-col-2 {%- endif -%}">
                 {%  for county in area.counties %}
                   <li class="">{{ county }}</li>
                 {% endfor %}
@@ -81,10 +81,10 @@
             {% endfor %}
             {% if alert.alertAreas.cities %}
               <wx-alert-cities>
-              <h5 class="wx-visual-h4 text-normal text-primary-dark">
+              <h5 class="wx-visual-h4 text-normal text-primary-dark margin-top-105 margin-bottom-0">
                 {{ "Including these cities" | t }} {{ area.area }}
               </h5>
-              <ul class="usa-list {%- if alert.alertAreas.cities | length > 7 %} wx-col-2 {%- endif -%}">
+              <ul class="usa-list margin-top-1 {%- if alert.alertAreas.cities | length > 7 %} wx-col-2 {%- endif -%}">
 
               {% for city in alert.alertAreas.cities %}
                 <li class="">{{ city }}</li>


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR reduces the spacing for the county region lists in the alert details. Currently the spacing for these headings and lists is a little wide, and can be tightened up to create groupings of content and preserve a bit of vertical space.


## Screenshots (if appropriate): 📸
![Screenshot comparing the spacing of the county region lists ](https://github.com/user-attachments/assets/1741b5ee-c673-47d9-a61f-d2b1e654fc4f)



