### PR TITLE
Disable microsoft edge until a working version becomes available

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -2,7 +2,7 @@ runs:
   using: composite
   steps:
     - uses: browser-actions/setup-chrome@v1
-    - uses: browser-actions/setup-edge@v1
+    # - uses: browser-actions/setup-edge@v1
     - uses: actions/setup-node@v4
       with:
         node-version: 18

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -55,10 +55,10 @@ const config = {
     // containerized.
 
     /* Test against branded browsers. */
-    {
-      name: "Microsoft Edge",
-      use: { ...devices["Desktop Edge"], channel: "msedge" },
-    },
+    // {
+    //   name: "Microsoft Edge",
+    //   use: { ...devices["Desktop Edge"], channel: "msedge" },
+    // },
     {
       name: "Google Chrome",
       use: { ...devices["Desktop Chrome"], channel: "chrome" },


### PR DESCRIPTION
## What does this PR do? 🛠️
> It appears that Microsoft’s API for reporting the latest Edge builds is missing build information for Linux systems. Our CI/CD runs in Linux systems, so it’s unable to find a download for Edge, which causes the tool we use for testing to fail. We’re not sure exactly where the issue is, but we’re hopeful it’ll resolve itself in the next couple of days. In the meantime, we’re still poking around to see if we can find any information from Microsoft or the tool we use.

Until a stable version becomes available, disable. We should check in on this in a week. 