### PR TITLE
Fixes a bug with how we load forecast and fire zones from shapefile

### DIFF
--- a/.github/actions/populate-database/action.yml
+++ b/.github/actions/populate-database/action.yml
@@ -5,7 +5,7 @@ runs:
       uses: actions/cache@v4
       id: db-cache
       with:
-        key: drupal-database-${{ hashFiles('web/config/**/*.yml', 'web/scs-export/**/*', 'web/modules/weather_i18n/translations/*.po') }}
+        key: drupal-database-${{ hashFiles('web/config/**/*.yml', 'web/scs-export/**/*', 'web/modules/weather_i18n/translations/*.po', 'spatial/**/*.js') }}
         path: weathergov.sql
 
     - name: setup image cacheing

--- a/.github/actions/setup-site/action.yml
+++ b/.github/actions/setup-site/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: actions/cache@v4
       id: db-cache
       with:
-        key: drupal-database-${{ hashFiles('web/config/**/*.yml', 'web/scs-export/**/*', 'web/modules/weather_i18n/translations/*.po') }}
+        key: drupal-database-${{ hashFiles('web/config/**/*.yml', 'web/scs-export/**/*', 'web/modules/weather_i18n/translations/*.po', 'spatial/**/*.js') }}
         path: weathergov.sql
 
     - name: start the site

--- a/spatial-data/lib/prep.js
+++ b/spatial-data/lib/prep.js
@@ -41,5 +41,7 @@ module.exports.downloadAndUnzip = async (url) => {
 
 module.exports.unzip = async (path) => {
   console.log(`   [${path}] decompressing...`);
-  await exec(`unzip -u ${path}`);
+
+  // Use -o to overwrite existing files.
+  await exec(`unzip -o -u ${path}`);
 };

--- a/spatial-data/sources/zones.js
+++ b/spatial-data/sources/zones.js
@@ -1,10 +1,11 @@
+const fs = require("node:fs/promises");
 const shapefile = require("shapefile");
 
 const { dropIndexIfExists, openDatabase } = require("../lib/db.js");
 
 const metadata = {
   table: "weathergov_geo_zones",
-  version: 1,
+  version: 2,
 };
 
 module.exports = async () => {
@@ -24,6 +25,13 @@ module.exports = async () => {
   await dropIndexIfExists(db, "zones_spatial_idx", metadata.table);
   await db.query(`TRUNCATE TABLE ${metadata.table}`);
 
+  // Version 2: Change the shape column into a collection rather than a single
+  // multipolygon. This allows us to capture all of the polygons for a zone as
+  // a collection rather than trying to collect or union them into one entity.
+  await db.query(
+    `ALTER TABLE ${metadata.table} MODIFY shape GEOMETRYCOLLECTION`,
+  );
+
   const found = new Map();
 
   const processFile = async (filename, zoneType) => {
@@ -39,30 +47,23 @@ module.exports = async () => {
         geometry,
       } = value;
 
-      if (geometry.type === "Polygon") {
-        geometry.type = "MultiPolygon";
-        geometry.coordinates = [geometry.coordinates];
-      }
-      // These shapefiles are in NAD83, whose SRID is 4269.
-      geometry.crs = { type: "name", properties: { name: "EPSG:4269" } };
-
       const id = `https://api.weather.gov/zones/${zoneType}/${state}Z${zone}`;
 
-      // Some of the zones are duplicated. Dunno why. Don't put them in twice,
-      // the database will scream.
+      // Some of the zones are represented by multiple polygons. To handle that,
+      // we'll gather a list of all polygons and insert them into the database
+      // as a geometry collection.
       if (!found.has(id)) {
-        found.set(id, { state, zone, zoneType, filename, geometry });
-
-        await db.query(
-          `INSERT INTO weathergov_geo_zones
-            (id, state, shape)
-            VALUES(
-              '${id}',
-              '${state}',
-              ST_GeomFromGeoJSON('${JSON.stringify(geometry)}')
-            )`,
-        );
+        found.set(id, {
+          state,
+          zone,
+          zoneType,
+          filename,
+          geometry: [geometry],
+        });
+      } else {
+        found.get(id).geometry.push(geometry);
       }
+
       return file.read().then(getSqlForShape);
     };
 
@@ -71,6 +72,28 @@ module.exports = async () => {
 
   await processFile(`./z_05mr24.shp`, "forecast");
   await processFile(`./fz05mr24.shp`, "fire");
+
+  // Our map now contains entries for every zone. Iterate over that to insert
+  // them into the database.
+  for await (const [id, { state, geometry }] of found) {
+    const featureCollection = {
+      type: "FeatureCollection",
+      features: geometry,
+      // Shapefiles are in NAD83, whose SRID is 4269. Set that at the collection
+      // level so that it automatically applies to all contained shapes.
+      crs: { type: "name", properties: { name: "EPSG:4269" } },
+    };
+
+    await db.query(
+      `INSERT INTO ${metadata.table}
+      (id, state, shape)
+      VALUES(
+        '${id}',
+        '${state}',
+        ST_GeomFromGeoJSON('${JSON.stringify(featureCollection)}')
+      )`,
+    );
+  }
 
   db.end();
 };

--- a/web/modules/weather_data/src/Service/AlertUtility.php
+++ b/web/modules/weather_data/src/Service/AlertUtility.php
@@ -464,9 +464,17 @@ class AlertUtility
 
             $polygon = json_decode($polygon->shape);
 
-            $polygon->coordinates = SpatialUtility::swapLatLon(
-                $polygon->coordinates,
-            );
+            if ($polygon->type == "GeometryCollection") {
+                foreach ($polygon->geometries as $innerPolygon) {
+                    $innerPolygon->coordinates = SpatialUtility::swapLatLon(
+                        $innerPolygon->coordinates,
+                    );
+                }
+            } else {
+                $polygon->coordinates = SpatialUtility::swapLatLon(
+                    $polygon->coordinates,
+                );
+            }
         }
 
         return $polygon;

--- a/web/modules/weather_data/src/Service/Test/AlertUtilityGeometry.php.test
+++ b/web/modules/weather_data/src/Service/Test/AlertUtilityGeometry.php.test
@@ -88,7 +88,8 @@ final class AlertUtilityGeometryTest extends TestCase
                     (object) ["shape" => "union 1,2,3"],
                 ],
 
-                // Return the simplified shape
+                // Return the simplified shape as a geometry collection, so we
+                // can also test that those points are flipped properly.
                 [
                     "SELECT ST_ASGEOJSON(
                     ST_SIMPLIFY(
@@ -96,12 +97,20 @@ final class AlertUtilityGeometryTest extends TestCase
                         0.003
                     )
                 ) as shape",
-                    (object) ["shape" => '{"coordinates":[[0,1],[2,3],[4,5]]}'],
+                    (object) [
+                        "shape" =>
+                            '{"type":"GeometryCollection","geometries":[{"coordinates":[[0,1],[2,3],[4,5]]}]}',
+                    ],
                 ],
             ]),
         );
 
-        $expected = (object) ["coordinates" => [[1, 0], [3, 2], [5, 4]]];
+        $expected = (object) [
+            "type" => "GeometryCollection",
+            "geometries" => [
+                (object) ["coordinates" => [[1, 0], [3, 2], [5, 4]]],
+            ],
+        ];
 
         $actual = AlertUtility::getGeometryAsJSON($alert, $this->dataLayer);
         $this->assertEquals($expected, $actual);
@@ -176,12 +185,18 @@ final class AlertUtilityGeometryTest extends TestCase
                         0.003
                     )
                 ) as shape",
-                    (object) ["shape" => '{"coordinates":[[0,1],[2,3],[4,5]]}'],
+                    (object) [
+                        "shape" =>
+                            '{"type":"Polygon","coordinates":[[0,1],[2,3],[4,5]]}',
+                    ],
                 ],
             ]),
         );
 
-        $expected = (object) ["coordinates" => [[1, 0], [3, 2], [5, 4]]];
+        $expected = (object) [
+            "type" => "Polygon",
+            "coordinates" => [[1, 0], [3, 2], [5, 4]],
+        ];
 
         $actual = AlertUtility::getGeometryAsJSON($alert, $this->dataLayer);
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
## What does this PR do? 🛠️

Previously, we'd encountered a situation where the zones shapefile could include multiple entries for a single zone. We mistakenly believed this was simply a duplication. However, zones are sometimes described by multiple polygons. We only kept the first polygon we encountered for a given zone, resulting in a couple dozen zones that had wildly incorrect geometries. Worse, it meant we could sometimes tell a user that there were no alerts for them because we had a misrepresentation of zones in our database. And it showed up visually (see #1409) where we drew the zone on the map, but what we drew was not the entire zone.

To fix this, our zones table is modified to expect a geometry collection for its `shape` column. When we import zones from the shapefile, we collect all geometries for a single zone and put them into the geometry collection for that zone's database row.

- closes #1409

## What does the reviewer need to know? 🤔

After merging, we will need to run a spatial load on all of our environments.