### PR TITLE
Disable PHP opcode caching in dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -40,7 +40,6 @@ RUN set -eux; \
   \
   docker-php-ext-install -j "$(nproc)" \
   gd \
-  opcache \
   pdo_mysql \
   pdo_pgsql \
   zip \
@@ -82,9 +81,6 @@ RUN set -eux; \
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
-  echo 'opcache.memory_consumption=128'; \
-  echo 'opcache.interned_strings_buffer=8'; \
-  echo 'opcache.max_accelerated_files=4000'; \
   echo 'opcache.revalidate_freq=60'; \
   echo 'xdebug.mode=coverage,develop,debug'; \
   #  echo 'xdebug.mode=coverage,develop,debug,profile'; \


### PR DESCRIPTION
## What does this PR do? 🛠️

Just what it says on the tin. I dunno why we didn't do this sooner. Now in your dev environment, if you make changes to PHP code, you don't need to rebuild the container or clear the Drupal cache in order for the changes to become effective.