### PR TITLE
Update how spatial schemas are managed; update zone schema to add spatial index

### DIFF
--- a/docs/dev/spatial-data.md
+++ b/docs/dev/spatial-data.md
@@ -35,3 +35,37 @@ data into.
 ```sh
 ./scripts/load-spatial-data.sh <environment>
 ```
+
+## Updating geospatial tables
+
+Our geospatial data is managed by a set of utility scripts in the `spatial-data`
+directory at the root of the project. Each spatial data source is represented by
+a Javascript file in the `spatial-data/sources` directory. This Javascript file
+includes code for creating and updating schema versions as well as code for
+loading the actual data into the database.
+
+A sources script file should export an object that looks roughly like this:
+
+```js
+  table: <string>,
+   schemas: {
+      <version | int>: async function() <bool> {},
+      <version | int>: async function() <bool> {},
+   },
+   loadData: async function() {}
+```
+
+The `table` property is the name of the table used by the source.
+
+The `schemas` property is an object whose keys are integers representing schema
+versions. The keys are used to determine the list of schema upgrades necessary
+for a given table. The values are functions that are called if a given schema
+upgrade is necessary. A schema upgrade function should return `true` if the
+source data needs to be reloaded or `false` if only a schema change is
+necessary. If there is an update that _only_ requires reloading data, there
+should be still be an new version created in the `schemas` property, but its
+function should simply return `true`.
+
+The `loadData` function is called if any necessary schema upgrades also need
+data to be loaded/reloaded. The `loadData` should assume that the schema is the
+most recent version and should not need to do any schema consistency checks.

--- a/spatial-data/lib/schema.js
+++ b/spatial-data/lib/schema.js
@@ -1,0 +1,19 @@
+module.exports = async ({ from, metadata: { table, schemas } }) => {
+  const schemaVersions = Object.keys(schemas).filter(
+    (version) => +version > from,
+  );
+  const upgrades = [...Array(schemaVersions.length)].map(
+    // Plus one because our schema versions are 1-based, not 0-based.
+    (_, i) => i + from + 1,
+  );
+
+  let needsDataUpdate = false;
+  for await (const version of upgrades) {
+    console.log(`  upgrading ${table} schema to version ${version}`);
+    const versionNeedsDataUpdate = await schemas[version]();
+
+    needsDataUpdate = needsDataUpdate || versionNeedsDataUpdate;
+  }
+
+  return needsDataUpdate;
+};

--- a/spatial-data/sources/states.js
+++ b/spatial-data/sources/states.js
@@ -4,26 +4,35 @@ const { dropIndexIfExists, openDatabase } = require("../lib/db.js");
 
 const metadata = {
   table: "weathergov_geo_states",
-  version: 1,
 };
 
-module.exports = async () => {
-  console.log("loading states...");
+const schemas = {
+  1: async () => {
+    const db = await openDatabase();
+
+    await db.query(
+      `CREATE TABLE IF NOT EXISTS
+        ${metadata.table}
+        (
+          id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+          state VARCHAR(2),
+          name TEXT,
+          fips VARCHAR(2),
+          shape MULTIPOLYGON NOT NULL
+        )`,
+    );
+
+    await db.end();
+
+    return true;
+  },
+};
+
+const loadData = async () => {
+  console.log("  loading states data");
   const db = await openDatabase();
 
   const file = await shapefile.open(`./s_05mr24.shp`);
-
-  await db.query(
-    `CREATE TABLE IF NOT EXISTS
-      ${metadata.table}
-      (
-        id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
-        state VARCHAR(2),
-        name TEXT,
-        fips VARCHAR(2),
-        shape MULTIPOLYGON NOT NULL
-      )`,
-  );
 
   await dropIndexIfExists(db, "states_spatial_idx", "weathergov_geo_states");
 
@@ -70,4 +79,4 @@ module.exports = async () => {
   db.end();
 };
 
-module.exports.metadata = metadata;
+module.exports = { ...metadata, schemas, loadData };


### PR DESCRIPTION
## What does this PR do? 🛠️

This PR modifies how we manage our spatial data schemas and data. The various `spatial-data/sources` file are all updated accordingly.

- source modules export a single object that identifies the involved table, a list of schema upgrades, and a function for loading data
  - the keys for the schema upgrades is a schema version
  - the values for schema upgrades is a function that makes any necessary schema mutations and returns `true` if source data should also be reloaded or `false` if the schema modification is sufficient on its own
- the `meta` module is updated accordingly
- a new `schema` module is added to handle migrating schemas
- the main `load-shapefile.js` file is modified to be source-agnostic; it can rely on each source plus the schema migration module to handle themselves

Overall, this PR should make zone-based spatial queries a little faster, but it should also make it easier and faster to make schema-only updates to spatial data.

- closes #1490
