### PR TITLE
Rely on Playwright's built-in tools for downloading browsers

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,8 +1,6 @@
 runs:
   using: composite
   steps:
-    - uses: browser-actions/setup-chrome@v1
-    # - uses: browser-actions/setup-edge@v1
     - uses: actions/setup-node@v4
       with:
         node-version: 18

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -19,7 +19,7 @@ const config = {
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? 'blob' : 'html',
+  reporter: process.env.CI ? "blob" : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -55,10 +55,11 @@ const config = {
     // containerized.
 
     /* Test against branded browsers. */
-    // {
-    //   name: "Microsoft Edge",
-    //   use: { ...devices["Desktop Edge"], channel: "msedge" },
-    // },
+    {
+      name: "Microsoft Edge",
+      use: { ...devices["Desktop Edge"], channel: "msedge" },
+    },
+
     {
       name: "Google Chrome",
       use: { ...devices["Desktop Chrome"], channel: "chrome" },


### PR DESCRIPTION
## What does this PR do? 🛠️

Playwright's built-in tooling fetches browsers for us. I don't know why we added the `setup-browser` step, but getting rid of it and re-enabling MS Edge, tests go back to working.

Spiritual reversion of #1461 

## What does the reviewer need to know? 🤔

The only way I know to verify what browsers were tested is to download the test report and visually verify that MS Edge is in the report.