### PR TITLE
Remove AFD from point page for now

### DIFF
--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -57,7 +57,7 @@
           {{ drupal_block("weathergov_current_conditions") }}
           {% include '@new_weather_theme/partials/radar.html.twig' with { 'point': weather.point  } %}
 
-          {{ drupal_block("weathergov_area_forecast_discussion") }}
+          {#{ drupal_block("weathergov_area_forecast_discussion") }#}
         </div>
 
          <div class="wx-tab-container wx-focus-offset-205" id="daily" role="tabpanel" aria-labelledby="daily-tab-button" tabindex="0">


### PR DESCRIPTION
## What does this PR do? 🛠️

#1495 pulls AFD data from the backend and added it to the point location page in its raw, unformatted state. However, it should not be shown until we've done at least a first pass of formatting.