### PR TITLE
Add empty alt text to satellite image

### DIFF
--- a/tests/pages.json
+++ b/tests/pages.json
@@ -4,7 +4,7 @@
   { "name": "location page with alerts", "url": "/point/33.521/-86.812" },
   {
     "name": "location page with alerts (today tab)",
-    "url": "/point/33.521/-86.812#today"
+    "url": "/point/33.521/-86.812#current"
   },
   {
     "name": "location page with alerts (daily tab)",

--- a/web/themes/new_weather_theme/templates/partials/satellite.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/satellite.html.twig
@@ -15,7 +15,7 @@
     </div>
 
     <div aria-hidden="true">
-      <img src="{{ weather.satellite.gif }}" class="wx-minw-full">
+      <img src="{{ weather.satellite.gif }}" class="wx-minw-full" alt="">
     </div>
   </div>
 </div>


### PR DESCRIPTION
## What does this PR do? 🛠️

#1310 added satellite imagery to the "current" tab. The satellite imagery should be hidden from assistive technology because it has the `aria-hidden` attribute; however, we should also set the `alt` attribute for technologies to fall back on if they don't support `aria-hidden`. This PR does that.

This PR also puts the "current" tab back into our accessibility testing flow. It fell out by accident when the tab was renamed from "today" to "current."