### PR TITLE
Simplify how we put together polygons for alerts

### DIFF
--- a/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/00_EndToEndBase.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/EndToEnd/00_EndToEndBase.php.test
@@ -116,6 +116,7 @@ abstract class EndToEndBase extends TestCase
 
         $this->weatherData = new WeatherDataService(
             $translation,
+            $cache,
             $newRelic,
             $dataLayer,
         );

--- a/web/modules/weather_data/src/Service/AlertTrait.php
+++ b/web/modules/weather_data/src/Service/AlertTrait.php
@@ -163,10 +163,20 @@ trait AlertTrait
                 $output->alertId = $index;
             }
 
-            $output->geometry = AlertUtility::getGeometryAsJSON(
-                $alert,
-                $this->dataLayer,
-            );
+            $hit = $this->cache->get("alert-polygon-" . $alert->id);
+            if ($hit) {
+                $output->geometry = $hit->data;
+            } else {
+                $output->geometry = AlertUtility::getGeometryAsJSON(
+                    $alert,
+                    $this->dataLayer,
+                );
+                $this->cache->set(
+                    "alert-polygon-" . $alert->id,
+                    $output->geometry,
+                    time() + 3600, // keep it for an hour
+                );
+            }
 
             // See if there is place information from the alert description.
             // This will be false if there is no special location information,

--- a/web/modules/weather_data/src/Service/Test/AlertUtilityGeometry.php.test
+++ b/web/modules/weather_data/src/Service/Test/AlertUtilityGeometry.php.test
@@ -46,70 +46,31 @@ final class AlertUtilityGeometryTest extends TestCase
             ],
         ];
 
-        $zoneShapes = [
-            (object) ["shape" => "shape 1"],
-            (object) ["shape" => "shape 2"],
-            (object) ["shape" => "shape 3"],
-        ];
+        $zoneShapes = (object) ["shape" => '{"combined":"zones"}'];
 
-        $this->dataLayer->method("databaseFetchAll")->will(
+        $this->dataLayer->method("databaseFetch")->will(
             $this->returnValueMap([
                 // Return the shapes for the selected zones
                 [
-                    "SELECT ST_AsWKT(shape) as shape
-                    FROM weathergov_geo_zones
-                    WHERE id IN ('zone 1','zone 2','zone 3')",
+                    "SELECT ST_ASGEOJSON(
+                ST_SIMPLIFY(
+                    ST_SRID(
+                        ST_COLLECT(shape),
+                        0
+                    ),
+                    0.003
+                )
+            )
+            as shape
+                FROM weathergov_geo_zones
+                WHERE id IN ('zone 1','zone 2','zone 3')",
                     $zoneShapes,
                 ],
             ]),
         );
 
-        $this->dataLayer->method("databaseFetch")->will(
-            $this->returnValueMap([
-                // Return the unioned shape of 3 and 1
-                [
-                    "SELECT ST_AsWKT(
-                        ST_UNION(
-                            ST_GEOMFROMTEXT('shape 3'),
-                            ST_GEOMFROMTEXT('shape 1')
-                        )
-                    ) as shape",
-                    (object) ["shape" => "union 3,1"],
-                ],
-
-                // Return the unioned shape of 3,1 and 2
-                [
-                    "SELECT ST_AsWKT(
-                        ST_UNION(
-                            ST_GEOMFROMTEXT('union 3,1'),
-                            ST_GEOMFROMTEXT('shape 2')
-                        )
-                    ) as shape",
-                    (object) ["shape" => "union 1,2,3"],
-                ],
-
-                // Return the simplified shape as a geometry collection, so we
-                // can also test that those points are flipped properly.
-                [
-                    "SELECT ST_ASGEOJSON(
-                    ST_SIMPLIFY(
-                        ST_GEOMFROMTEXT('union 1,2,3'),
-                        0.003
-                    )
-                ) as shape",
-                    (object) [
-                        "shape" =>
-                            '{"type":"GeometryCollection","geometries":[{"coordinates":[[0,1],[2,3],[4,5]]}]}',
-                    ],
-                ],
-            ]),
-        );
-
         $expected = (object) [
-            "type" => "GeometryCollection",
-            "geometries" => [
-                (object) ["coordinates" => [[1, 0], [3, 2], [5, 4]]],
-            ],
+            "combined" => "zones",
         ];
 
         $actual = AlertUtility::getGeometryAsJSON($alert, $this->dataLayer);
@@ -134,68 +95,32 @@ final class AlertUtilityGeometryTest extends TestCase
             ],
         ];
 
-        $countyShapes = [
-            (object) ["shape" => "shape 1"],
-            (object) ["shape" => "shape 2"],
-            (object) ["shape" => "shape 3"],
-        ];
+        $countyShapes = (object) ["shape" => '{"combined":"county"}'];
 
-        $this->dataLayer->method("databaseFetchAll")->will(
+        $this->dataLayer->method("databaseFetch")->will(
             $this->returnValueMap([
                 // Return the shapes for the selected zones. Note that county
                 // FIPS codes are numeric, so they are not quoted in the query.
                 [
-                    "SELECT ST_AsWKT(shape) as shape
-                        FROM weathergov_geo_counties
-                        WHERE countyFips IN (county 1,county 2,county 3)",
+                    "SELECT ST_ASGEOJSON(
+                    ST_SIMPLIFY(
+                        ST_SRID(
+                            ST_COLLECT(shape),
+                            0
+                        ),
+                        0.003
+                    )
+                )
+                as shape
+                    FROM weathergov_geo_counties
+                    WHERE countyFips IN (county 1,county 2,county 3)",
                     $countyShapes,
                 ],
             ]),
         );
 
-        $this->dataLayer->method("databaseFetch")->will(
-            $this->returnValueMap([
-                // Return the unioned shape of 3 and 1
-                [
-                    "SELECT ST_AsWKT(
-                        ST_UNION(
-                            ST_GEOMFROMTEXT('shape 3'),
-                            ST_GEOMFROMTEXT('shape 1')
-                        )
-                    ) as shape",
-                    (object) ["shape" => "union 3,1"],
-                ],
-
-                // Return the unioned shape of 3,1 and 2
-                [
-                    "SELECT ST_AsWKT(
-                        ST_UNION(
-                            ST_GEOMFROMTEXT('union 3,1'),
-                            ST_GEOMFROMTEXT('shape 2')
-                        )
-                    ) as shape",
-                    (object) ["shape" => "union 1,2,3"],
-                ],
-
-                // Return the simplified shape
-                [
-                    "SELECT ST_ASGEOJSON(
-                    ST_SIMPLIFY(
-                        ST_GEOMFROMTEXT('union 1,2,3'),
-                        0.003
-                    )
-                ) as shape",
-                    (object) [
-                        "shape" =>
-                            '{"type":"Polygon","coordinates":[[0,1],[2,3],[4,5]]}',
-                    ],
-                ],
-            ]),
-        );
-
         $expected = (object) [
-            "type" => "Polygon",
-            "coordinates" => [[1, 0], [3, 2], [5, 4]],
+            "combined" => "county",
         ];
 
         $actual = AlertUtility::getGeometryAsJSON($alert, $this->dataLayer);

--- a/web/modules/weather_data/src/Service/WeatherDataService.php
+++ b/web/modules/weather_data/src/Service/WeatherDataService.php
@@ -3,6 +3,7 @@
 namespace Drupal\weather_data\Service;
 
 use Drupal\weather_data\Service\HourlyTableTrait;
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -25,6 +26,13 @@ class WeatherDataService
      * @var dataLayer
      */
     private $dataLayer;
+
+    /**
+     * Cache of API calls for this request.
+     *
+     * @var cache
+     */
+    private $cache;
 
     /**
      * Mapping of legacy API icon paths to new icons and conditions text.
@@ -78,9 +86,11 @@ class WeatherDataService
      */
     public function __construct(
         TranslationInterface $t,
+        CacheBackendInterface $cache,
         NewRelicMetrics $newRelic,
         DataLayer $dataLayer,
     ) {
+        $this->cache = $cache;
         $this->dataLayer = $dataLayer;
         $this->t = $t;
         $this->newRelic = $newRelic;

--- a/web/modules/weather_data/weather_data.services.yml
+++ b/web/modules/weather_data/weather_data.services.yml
@@ -7,7 +7,7 @@ services:
     arguments: ['@http_client','@cache.default','@database', '@current_route_match']
   weather_data:
     class: Drupal\weather_data\Service\WeatherDataService
-    arguments: ['@string_translation', '@newrelic_metrics', '@weather_data_layer']
+    arguments: ['@string_translation', '@cache.default', '@newrelic_metrics', '@weather_data_layer']
   newrelic_metrics:
     class: Drupal\weather_data\Service\NewRelicMetrics
     arguments: ['@http_client']


### PR DESCRIPTION
## What does this PR do? 🛠️

Instead of unioning all zone or county polygons into a single polygon, we now "collect" them into a single geometry collection and then geographically simplify it. Creating a union of the polygons was taking entirely too much time in the case where an alert covers several zones with complex geometries (for example, coastal boundaries).

This PR also caches the collected and simplified polygon based on alert ID. If we already have the computed polygon in cache, we return that immediately rather than rebuild it for every single request.

- closes #1521 