### PR TITLE
Modify WFO promo block to serve data from the WFO info content type

### DIFF
--- a/web/modules/weather_blocks/src/Plugin/Block/Test/WFOPromoBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/WFOPromoBlock.php.test
@@ -3,6 +3,7 @@
 namespace Drupal\weather_blocks\Plugin\Block\Test;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
 use Drupal\weather_blocks\Plugin\Block\WFOPromoBlock;
 
 /**
@@ -23,7 +24,7 @@ final class WFOPromoBlockTest extends Base
     }
 
     /**
-     * Test that the block returns a node iD.
+     * Test that the block returns promo info
      * @group unit
      * @group block
      * @group wfo-promo-block
@@ -32,16 +33,79 @@ final class WFOPromoBlockTest extends Base
     {
         $this->onLocationRoute();
 
-        // Setup fetching the actual node.
-        $story = $this->createStub(ContentEntityInterface::class);
-
-        $story->method("id")->willReturn(94);
+        $promo = (object) [
+            "field_wfo" => (object) [
+                "entity" => (object) [
+                    "name" => (object) [
+                        "value" => "WFO name",
+                    ],
+                    "field_wfo_code" => (object) [
+                        "value" => "WFO code",
+                    ],
+                ],
+            ],
+            "body" => "WFO information body",
+            "field_phone_number_opt" => "phone number entity",
+            "field_facebook_url" => "facebook url entity",
+            "field_twitter_url" => "twitter url entity",
+            "field_youtube_url" => "youtube url entity",
+        ];
 
         $this->entityService
             ->method("getLatestNodeFromWFO")
-            ->willReturn($story);
+            ->willReturn($promo);
 
-        $expected = ["node" => 94];
+        $expected = [
+            "name" => "WFO name",
+            "code" => "WFO code",
+            "about" => "WFO information body",
+            "phone" => "phone number entity",
+            "social" => [
+                "facebook" => "facebook url entity",
+                "twitter" => "twitter url entity",
+                "youtube" => "youtube url entity",
+            ],
+        ];
+
+        $actual = $this->block->build();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test that the block returns WFO name and code if there is no WFO info
+     * @group unit
+     * @group block
+     * @group wfo-promo-block
+     */
+    public function testReturnsWFOIfNoPromo(): void
+    {
+        $this->onLocationRoute();
+
+        $promo = null;
+
+        $this->entityService->method("getLatestNodeFromWFO")->willReturn(null);
+
+        // Setup fetching the actual node.
+        $wfoTaxonomyTerm = $this->createStub(ContentEntityInterface::class);
+
+        $wfoName = $this->createStub(TypedDataInterface::class);
+        $wfoName->method("getString")->willReturn("WFO name");
+
+        $wfoTaxonomyTerm
+            ->method("get")
+            ->will($this->returnValueMap([["name", $wfoName]]));
+
+        $this->entityService
+            ->method("getWFOEntity")
+            ->willReturn($wfoTaxonomyTerm);
+
+        $expected = [
+            "name" => "WFO name",
+            "code" => "WFO",
+            "phone" => false,
+            "social" => false,
+        ];
 
         $actual = $this->block->build();
 

--- a/web/modules/weather_blocks/src/Plugin/Block/WFOPromoBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/WFOPromoBlock.php
@@ -28,14 +28,54 @@ class WFOPromoBlock extends WeatherBlockBase
                 "wfo_info",
             );
 
-            // If we actually have a story, pass its ID on for the template
+            // If there is WFO info, pull out the parts that should be rendered
+            // in the WFO promo block on the forecast page.
             if ($promo) {
+                $name = $promo->field_wfo->entity->name->value;
+                $code = $promo->field_wfo->entity->field_wfo_code->value;
+
+                $about = $promo->body;
+                $phone = $promo->field_phone_number_opt ?? false;
+
+                $facebook = $promo->field_facebook_url ?? false;
+                $twitter = $promo->field_twitter_url ?? false;
+                $youtube = $promo->field_youtube_url ?? false;
+
+                $social = false;
+                if ($facebook || $twitter || $youtube) {
+                    $social = [
+                        "facebook" => $facebook,
+                        "twitter" => $twitter,
+                        "youtube" => $youtube,
+                    ];
+                }
+
                 return [
-                    "node" => $promo->id(),
+                    "name" => $name,
+                    "code" => $code,
+                    "about" => $about,
+                    "phone" => $phone,
+                    "social" => $social,
+                ];
+            }
+
+            // If there's not a WFO info, just return the name and code.
+            $taxonomyTerm = $this->entityTypeService->getWFOEntity($grid->wfo);
+            if (count($taxonomyTerm) > 0) {
+                $term = array_pop($taxonomyTerm);
+                $name = $term->get("name")->getString();
+
+                return [
+                    "name" => $name,
+                    "code" => $grid->wfo,
+                    "phone" => false,
+                    "social" => false,
                 ];
             }
         }
 
+        // If we get here, it's because either the location doesn't have a grid
+        // point and thus no WFO, or else because we don't know about the WFO.
         return [];
     }
 }

--- a/web/modules/weather_blocks/src/Plugin/Block/WFOPromoBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/WFOPromoBlock.php
@@ -25,7 +25,7 @@ class WFOPromoBlock extends WeatherBlockBase
 
             $promo = $this->entityTypeService->getLatestNodeFromWFO(
                 $grid->wfo,
-                "wfo_promo",
+                "wfo_info",
             );
 
             // If we actually have a story, pass its ID on for the template

--- a/web/modules/weather_blocks/src/Plugin/Block/WFOPromoBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/WFOPromoBlock.php
@@ -61,9 +61,8 @@ class WFOPromoBlock extends WeatherBlockBase
 
             // If there's not a WFO info, just return the name and code.
             $taxonomyTerm = $this->entityTypeService->getWFOEntity($grid->wfo);
-            if (count($taxonomyTerm) > 0) {
-                $term = array_pop($taxonomyTerm);
-                $name = $term->get("name")->getString();
+            if ($taxonomyTerm) {
+                $name = $taxonomyTerm->get("name")->getString();
 
                 return [
                     "name" => $name,

--- a/web/modules/weather_data/src/Service/WeatherEntityService.php
+++ b/web/modules/weather_data/src/Service/WeatherEntityService.php
@@ -90,4 +90,12 @@ class WeatherEntityService
 
         return $this->getLatestNodeByTerm($termID, "field_wfo", $nodeType);
     }
+
+    public function getWFOEntity($wfo)
+    {
+        $term = $this->entityTypeManager
+            ->getStorage("taxonomy_term")
+            ->loadByProperties(["field_wfo_code" => $wfo]);
+        return $term;
+    }
 }

--- a/web/modules/weather_data/src/Service/WeatherEntityService.php
+++ b/web/modules/weather_data/src/Service/WeatherEntityService.php
@@ -96,6 +96,9 @@ class WeatherEntityService
         $term = $this->entityTypeManager
             ->getStorage("taxonomy_term")
             ->loadByProperties(["field_wfo_code" => $wfo]);
-        return $term;
+        if (count($term) > 0) {
+            return array_pop($term);
+        }
+        return false;
     }
 }

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-wfo-promo.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-wfo-promo.html.twig
@@ -1,1 +1,28 @@
-{{ drupal_entity("node", content.node) }}
+<div class="grid-container padding-x-2">
+  <div class="grid-row">
+    <div class="grid-col tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
+      <h3 class="wx-visual-h2 text-normal text-primary-darker"> {{ "Your Local Forecast Office" | t }} </h3>
+      <h4 class="wx-visual-h3 margin-bottom-1"><a href="/offices/{{ content.code }}">{{ content.name }}</a></h4>
+      <p class="line-height-sans-4 margin-top-0">
+        {{ content.about | view }}
+      </p>
+      
+      {% set hasPhone = content.phone | length %}
+      {% if hasPhone > 0 %}
+      {{ content.phone | view }}
+      {% endif %}
+
+      {% if content.social is not same as false %}
+      <p class="font-family-mono font-mono-sm text-bold text-primary-darker text-uppercase margin-bottom-1">
+        {{ "Find us on" | t }}
+      </p>
+        <ul class="usa-list usa-list--unstyled"> 
+          {{ content.social.facebook| view }}
+          {{ content.social.youtube | view }}
+          {{ content.social.twitter | view }}
+        </ul>
+      {% endif %}
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## What does this PR do? 🛠️

Instead of returning a WFO promo node, the WFO promo block now returns information from a corresponding WFO info node. The WFO promo block template is also updated so that instead of simply being a pass-through to a node template, the promo template now does layout itself.

WFO promo if there is no WFO info node:
![image](https://github.com/user-attachments/assets/16251939-97c3-4276-8323-6283d32cf6b7)

WFO promo if there is a WFO info node:

![image](https://github.com/user-attachments/assets/13be1ee8-4cd2-44b4-ad40-db1642ea4d62)

- closes #1471