### PR TITLE
Update the onboarding template to include adding the new teammate to the contributors list

### DIFF
--- a/.github/ISSUE_TEMPLATE/developer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/developer-onboarding.md
@@ -33,6 +33,7 @@ cf login -a api.fr.cloud.gov  --sso
 ### Steps for the onboarder
 - [ ] Ask an admin to add the onboardee to our [GitHub organization](https://github.com/orgs/weather-gov).
 - [ ] Add the onboardee to our [GitHub repository](https://github.com/weather-gov/weather.gov).
+- [ ] Add the onboardee to our [contributors list](https://github.com/weather-gov/weather.gov/blob/main/package.json#L6)
 - [ ] Add the onboardee to our cloud.gov org
 - [ ] Before you finalize the developer sandbox setup, [generate new metadata](../../docs/dev/authentication.md) for SAML communication
 - [ ] Setup the developer sandbox space with [sandbox script](./scripts/create_cloudgov_env.md).


### PR DESCRIPTION
## What does this PR do? 🛠️

When we onboard a new teammate, we should add them to the contributors list. We forgot once. That's too much. So let's add this step to our template to make it more likely that we do it properly next time.