### PR TITLE
Handle weird extraneous newlines in AFD temp/pops table

### DIFF
--- a/web/modules/weather_data/src/Service/AFDParser.php
+++ b/web/modules/weather_data/src/Service/AFDParser.php
@@ -263,6 +263,11 @@ class AFDParser
             return;
         }
 
+        // There could be whitespace between the TEMP/POPS header and the actual
+        // data, so clean that up first. There *shouldn't* be, but we've seen it
+        // happen, so guard against it.
+        $str = trim($str);
+
         $lines = explode("\n", $str);
         $rx = "/^[^\d]*(.+)/";
         $rows = [];

--- a/web/modules/weather_data/src/Service/Test/AFDParser.php.test
+++ b/web/modules/weather_data/src/Service/Test/AFDParser.php.test
@@ -325,6 +325,45 @@ final class AFDParserTest extends TestCase
     /**
      * @group unit
      * @group afd-parser
+     * @group unit2
+     */
+    public function testPOPsTableWithLeadingNewline(): void
+    {
+        $raw = "Place A   1 2 3 4 / 5 6 7 8
+                Place B   0 9  8 7 / 6   5 4  3";
+        // Remove leading spaces on test data.
+        $raw = preg_replace("/^\s*/m", "", $raw);
+        // Put in a leading newline.
+        $raw = "\n$raw";
+
+        $expected = [
+            [
+                "type" => "temps-table",
+                "rows" => [
+                    [
+                        "type" => "temps-table-row",
+                        "numbers" => ["1", "2", "3", "4", "5", "6", "7", "8"],
+                        "name" => "Place A",
+                    ],
+                    [
+                        "type" => "temps-table-row",
+                        "numbers" => ["0", "9", "8", "7", "6", "5", "4", "3"],
+                        "name" => "Place B",
+                    ],
+                ],
+            ],
+        ];
+
+        $parser = new AFDParser($raw);
+        $actual = [];
+        $parser->parseTempsTableContent($raw, $actual);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @group unit
+     * @group afd-parser
      */
     public function testGetStructureForTwig(): void
     {


### PR DESCRIPTION
## What does this PR do? 🛠️

The policy document says the temp/pops table should follow immediately after the heading element, so that's what we parsed for, but it turns out sometimes there's a newline in between them. This PR adds a test to catch that case and slightly modifies the parser to handle it gracefully.