### PR TITLE
fix NR: use elvis instead of null operator

### DIFF
--- a/web/modules/weather_data/src/Service/NewRelicMetrics.php
+++ b/web/modules/weather_data/src/Service/NewRelicMetrics.php
@@ -58,7 +58,7 @@ class NewRelicMetrics
         $type = "gauge",
         $now = false,
     ) {
-        $now = $now ?? time();
+        $now = $now ?: time();
 
         $attributes["applicationName"] = $this->applicationName;
 


### PR DESCRIPTION
## What does this PR do? 🛠️

Send timestamps to New Relic properly.

Before: 

```json
[{"metrics":[{"name":"wx.observation","type":"gauge","value":2127.3710043474975,"timestamp":false,"attributes":{"withinGridCell":false,"stationIndex":0,"obsStation":"LBNL1","distance":2127.3710043474975,"usesReferencePoint":true,"applicationName":"local"}}]}]
```

After:

```json
[{"metrics":[{"name":"wx.observation","type":"gauge","value":2127.3710043474975,"timestamp":1725906130,"attributes":{"withinGridCell":false,"stationIndex":0,"obsStation":"LBNL1","distance":2127.3710043474975,"usesReferencePoint":true,"applicationName":"local"}}]}]
```

## What does the reviewer need to know? 🤔

The Elvis operator is a shorthand for ternary operator and is so called because it looks like Elvis with his signature hairstyle. ([Wikipedia](https://en.wikipedia.org/wiki/Elvis_operator))

Addresses https://github.com/weather-gov/weather.gov/issues/1447