### PR TITLE
[Interop layer] Test updates

### DIFF
--- a/.github/workflows/code-standards.yaml
+++ b/.github/workflows/code-standards.yaml
@@ -242,16 +242,6 @@ jobs:
           path: playwright-report
           retention-days: 14
 
-      - name: Merge into HTML Report
-        run: npx playwright merge-reports --reporter html ./all-blob-reports
-
-      - name: Upload HTML report
-        uses: actions/upload-artifact@v4
-        with:
-          name: html-report--attempt-${{ github.run_attempt }}
-          path: playwright-report
-          retention-days: 14
-
   end-to-end-tests:
     name: end-to-end tests
     runs-on: ubuntu-latest

--- a/api-interop-layer/data/alerts/index.js
+++ b/api-interop-layer/data/alerts/index.js
@@ -67,6 +67,19 @@ export const updateAlerts = async () => {
     const alert = {
       metadata: alertKinds.get(rawAlert.properties.event.toLowerCase()),
     };
+
+    // If we get an alert type that we don't have a mapping for, capture that in
+    // logs. Default to a land alert with the lowest priority so we can at least
+    // still show it to users.
+    if (!alert.metadata) {
+      logger.warn(`Unknown alert type: ${rawAlert.properties.event}`);
+      alert.metadata = {
+        level: { priority: Number.MAX_SAFE_INTEGER, text: "other" },
+        kind: "land",
+        priority: Number.MAX_SAFE_INTEGER,
+      };
+    }
+
     // For now, we're only ingesting land alerts. Once we get into marine
     // alerts, we'll revisit this, but since we don't know what the use case
     // will be in the future, we'll just leave them out entirely for now.

--- a/api-interop-layer/data/index.js
+++ b/api-interop-layer/data/index.js
@@ -66,7 +66,7 @@ export const getDataForPoint = async (lat, lon) => {
       // How long will the alert last AFTER the start of the first hour of the
       // hourly forecast?
       const absoluteDuration = Math.ceil(
-        dayjs.duration(alert.finish.diff(start.add(offset, "hours"))).asHours(),
+        dayjs.duration(alert.finish.diff(start)).asHours() - offset,
       );
 
       // Cap the alert duration at the remaining hours in the forecast.

--- a/api-interop-layer/data/obs/index.js
+++ b/api-interop-layer/data/obs/index.js
@@ -3,6 +3,7 @@ import { openDatabase } from "../db.js";
 import isObservationValid from "./valid.js";
 import { convertProperties } from "../../util/convert.js";
 import { fetchAPIJson } from "../../util/fetch.js";
+import { parseAPIIcon } from "../../util/icon.js";
 
 // document the translation layer; high level conceptual and some lower-level for eng
 // then we can figure out SDB resourcing and how we'd collaborate
@@ -75,7 +76,7 @@ export default async ({
         formatted: observation.timestamp,
         utc: dayjs(observation.timestamp),
       },
-      icon: observation.icon,
+      icon: parseAPIIcon(observation.icon),
       description: observation.textDescription,
       station: convertProperties({
         id: station.properties.stationIdentifier,

--- a/api-interop-layer/main.js
+++ b/api-interop-layer/main.js
@@ -13,6 +13,11 @@ const main = async () => {
     reply.status(500).send({ error: true });
   });
 
+  process.on("uncaughtException", (err) => {
+    logger.error("Uncaught exception");
+    logger.error(err);
+  });
+
   server.get("/", (_, response) => {
     response.send({ ok: true });
   });

--- a/tests/e2e/cypress/e2e/hourly-forecast-table.cy.js
+++ b/tests/e2e/cypress/e2e/hourly-forecast-table.cy.js
@@ -6,30 +6,30 @@ describe("Hourly forecast table tests", () => {
       cy.visit("/point/34.749/-92.275");
     });
 
-    it("Should have 2 alert rows on the hourly forecast", () => {
+    it("Should have 5 alert rows on the hourly forecast", () => {
       cy.get(
         `#daily ol li:first-of-type wx-hourly-table tr[data-row-name="alert"]`,
-      ).should("have.length", 2);
+      ).should("have.length", 5);
     });
 
     it("There is a Red Flag alert of the correct displayed duration", () => {
       // We expect there to be a red-flag alert that spans two hours
       // and that contains the correct event label
       cy.contains(
-        `#daily ol li:first-of-type wx-hourly-table tr[data-row-name="alert"]:nth-child(2) td[colspan]:nth-child(2)`,
+        `#daily ol li:first-of-type wx-hourly-table tr[data-row-name="alert"]:nth-child(4) td[colspan]:nth-child(2)`,
         "Red Flag Warning",
       )
         .invoke("attr", "colspan")
-        .should("equal", "2");
+        .should("equal", "3");
     });
 
     it("Has a Special Weather Statement that begins in the third hour and spans 5 hours", () => {
       cy.contains(
-        `#daily ol li:first-of-type wx-hourly-table tr[data-row-name="alert"]:nth-child(3) td[colspan]:nth-child(3)`,
+        `#daily ol li:first-of-type wx-hourly-table tr[data-row-name="alert"]:nth-child(6) td[colspan]:nth-child(3)`,
         "Special Weather Statement",
       )
         .invoke("attr", "colspan")
-        .should("equal", "5");
+        .should("equal", "6");
     });
 
     it("has a blizzard warning starting tomorrow", () => {
@@ -67,14 +67,16 @@ describe("Hourly forecast table tests", () => {
     it("Renders the expected min number of table rows", () => {
       cy.visit("/point/34.749/-92.275#daily");
       cy.get("#daily ol li:first-child wx-hourly-toggle").click();
-      cy.get("#daily ol li table.wx-precip-table tbody").each(($tbody, $idx) => {
-        // Our expectation is that up to five days should
-        // have precip data. Anything beyond that is not guaranteed
-        // at this point
-        if ($idx >= 4) {
-          cy.wrap($tbody).children("tr").should("exist");
-        }
-      });
+      cy.get("#daily ol li table.wx-precip-table tbody").each(
+        ($tbody, $idx) => {
+          // Our expectation is that up to five days should
+          // have precip data. Anything beyond that is not guaranteed
+          // at this point
+          if ($idx >= 4) {
+            cy.wrap($tbody).children("tr").should("exist");
+          }
+        },
+      );
     });
   });
 });

--- a/web/themes/new_weather_theme/assets/js/localizeTimestamps.js
+++ b/web/themes/new_weather_theme/assets/js/localizeTimestamps.js
@@ -31,10 +31,11 @@
     ],
   ]);
 
-  const timestamps = document.querySelectorAll("time[data-wx-local-time]");
-  for (let i = 0; i < timestamps.length; i += 1) {
-    const timestamp = timestamps[i];
+  const timestamps = Array.from(
+    document.querySelectorAll("time[data-wx-local-time]"),
+  ).filter((node) => node.getAttribute("datetime").length > 0);
 
+  timestamps.forEach((timestamp) => {
     const input = timestamp.getAttribute("datetime");
 
     const date = new Date(Date.parse(input));
@@ -42,5 +43,5 @@
     const formatter = timestamp.getAttribute("data-date-format") || "basic";
 
     timestamp.innerText = formatters.get(formatter).format(date);
-  }
+  });
 })();

--- a/web/themes/new_weather_theme/templates/partials/location-search.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/location-search.html.twig
@@ -16,8 +16,8 @@
         </div>
         <div class="grid-row">
             <div class="tablet:grid-col-6">
-              <wx-combo-box class="z-top margin-top-1 tablet:margin-bottom-3 tablet:margin-right-105" id="search-combo-box" {% if place %}data-place="{{ place.name }}{% if place.state %}, {{ place.state }}{% endif %}"{% endif %}}>
-              </wx-combo-box>
+              <wx-combo-box-location class="z-top margin-top-1 tablet:margin-bottom-3 tablet:margin-right-105" id="search-combo-box" {% if place %}data-place="{{ place.name }}{% if place.state %}, {{ place.state }}{% endif %}"{% endif %}}>
+              </wx-combo-box-location>
             </div>
             <div class="font-sans-md text-primary-dark tablet:grid-col-6 margin-top-105 margin-bottom-105">
               <div class="grid-col">

--- a/web/themes/new_weather_theme/templates/point/observations.html.twig
+++ b/web/themes/new_weather_theme/templates/point/observations.html.twig
@@ -56,10 +56,10 @@
         </div>
         
         <div class="display-flex flex-align-center margin-bottom-2">
-          {% if content.icon.icon %}
+          {% if obs.icon.icon %}
           <div class="wx-icon margin-right-105 width-5 height-5">
             <svg role="img" aria-hidden="true" class="width-full height-full">
-              <use xlink:href="{{ "/" ~ directory ~ "/assets/images/spritesheet.svg#" ~ content.icon.base }}"></use>
+              <use xlink:href="{{ "/" ~ directory ~ "/assets/images/spritesheet.svg#" ~ obs.icon.base }}"></use>
             </svg>
           </div>
           {% endif %}


### PR DESCRIPTION
## What does this PR do? 🛠️

- updates some tests to reflect changes in how data is fetched, specifically the alert end-to-end tests, since they now return more alerts than previously.
  - this is because we fetch all active alerts, not just state-based alerts; some of the alerts in our non-Arkansas state-based alert files were, in fact, for Arkansas; merging those together resulted in more alerts. Rather than culling those, I opted to updated the tests
- bug fixes:
  - a bug where the observation icon was not being properly parsed, or displayed correctly in the Twig template
  - a bug where a timestamp element with an empty `datetime` property resulted in a console error
  - a bug where alerts with an unknown event type would crash the interop layer

## What does the reviewer need to know? 🤔
<!--- Include any local deployment instructions, navigation instructions, etc -->

## Screenshots (if appropriate): 📸

<!--- Make sure you add a subject matter expert to the Reviewers list -->
