### PR TITLE
[Interop layer] First iteration of abstraction for logging and monitoring

### DIFF
--- a/api-interop-layer/data/index.js
+++ b/api-interop-layer/data/index.js
@@ -4,8 +4,12 @@ import getObservations from "./obs/index.js";
 import getPoint from "./points.js";
 import getSatellite from "./satellite.js";
 import dayjs from "../util/day.js";
+import { createLogger } from "../util/monitoring/index.js";
+
+const logger = createLogger("forecast");
 
 export const getDataForPoint = async (lat, lon) => {
+  logger.verbose(`fetching forecast for ${lat}, ${lon}}`);
   const { point, place, grid } = await getPoint(lat, lon);
 
   const satellitePromise = getSatellite({ grid });

--- a/api-interop-layer/data/points.js
+++ b/api-interop-layer/data/points.js
@@ -1,7 +1,11 @@
 import { openDatabase } from "./db.js";
 import { fetchAPIJson } from "../util/fetch.js";
+import { createLogger } from "../util/monitoring/index.js";
+
+const logger = createLogger("point");
 
 export default async (latitude, longitude) => {
+  logger.verbose(`getting information for place at ${latitude}, ${longitude}`);
   const point = { latitude, longitude };
 
   const pointsPromise = fetchAPIJson(`/points/${latitude},${longitude}`).then(

--- a/api-interop-layer/data/satellite.js
+++ b/api-interop-layer/data/satellite.js
@@ -1,3 +1,7 @@
+import { createLogger } from "../util/monitoring/index.js";
+
+const logger = createLogger("satellite");
+
 export default async ({ grid: { wfo } }) => {
   try {
     const satelliteMetadata = await fetch(
@@ -13,8 +17,8 @@ export default async ({ grid: { wfo } }) => {
       };
     }
   } catch (e) {
-    console.log(`Error getting satellite metadata for ${wfo}`);
-    console.log(e.message);
+    logger.error(`Error getting satellite metadata for ${wfo}`);
+    logger.error(e.message);
   }
 
   return {};

--- a/api-interop-layer/main.js
+++ b/api-interop-layer/main.js
@@ -1,13 +1,15 @@
 import fastify from "fastify";
 import { getDataForPoint } from "./data/index.js";
 import { rest as alertsRest } from "./data/alerts/kinds.js";
+import { createLogger } from "./util/monitoring/index.js";
 
 const main = async () => {
   const port = process.env.PORT || 8082;
   const server = fastify();
+  const logger = createLogger("main");
 
   server.setErrorHandler((err, request, reply) => {
-    console.log(err);
+    logger.error(err);
     reply.status(500).send({ error: true });
   });
 
@@ -33,6 +35,8 @@ const main = async () => {
       },
     },
     handler: async (request, response) => {
+      logger.verbose(request.url);
+
       const { latitude, longitude } = request.params;
       performance.clearResourceTimings();
       const timer = performance.now();
@@ -62,7 +66,7 @@ const main = async () => {
   });
 
   await server.listen({ port, host: "0.0.0.0" });
-  console.log(`Listening on ${port}`);
+  logger.info(`Listening on ${port}`);
 };
 
 main();

--- a/api-interop-layer/util/fetch.js
+++ b/api-interop-layer/util/fetch.js
@@ -1,9 +1,17 @@
+import { createLogger } from "./monitoring/index.js";
 import { sleep } from "./sleep.js";
+
+const logger = createLogger("fetch wrapper");
 
 const BASE_URL = process.env.API_URL ?? "https://api.weather.gov";
 
-const internalFetch = async (path) =>
-  fetch(`${BASE_URL}${path}`).then((r) => r.json());
+const internalFetch = async (path) => {
+  logger.verbose(`making API request to ${path}`);
+  return fetch(`${BASE_URL}${path}`).then((r) => {
+    logger.verbose(`success from ${path}`);
+    return r.json();
+  });
+};
 
 export const fetchAPIJson = async (path, { wait = sleep } = {}) =>
   internalFetch(path)
@@ -12,7 +20,7 @@ export const fetchAPIJson = async (path, { wait = sleep } = {}) =>
     .catch(() => wait(204).then(() => internalFetch(path)))
     .catch(() => wait(337).then(() => internalFetch(path)))
     .catch((e) => {
-      console.log(e);
+      logger.error(e);
       throw e;
     });
 

--- a/api-interop-layer/util/monitoring/index.js
+++ b/api-interop-layer/util/monitoring/index.js
@@ -1,0 +1,37 @@
+const writeLog = (name, level, message) => {
+  /* eslint-disable no-console */
+  if (typeof message === "string") {
+    console.log(`[${name}] | ${level} | ${message} |`);
+  } else {
+    console.log(`[${name}] | ${level} |`);
+    console.log(message);
+    console.log("|");
+  }
+  /* eslint-enable no-console */
+};
+
+const logLevels = {
+  error: 1,
+  warn: 2,
+  info: 3,
+  verbose: 4,
+};
+
+const logLevel = logLevels[process.env.LOG_LEVEL] ?? logLevels.info;
+
+const noop = () => {};
+
+export const createLogger = (name) => ({
+  error:
+    logLevel >= logLevels.error ? (msg) => writeLog(name, "error", msg) : noop,
+  warn:
+    logLevel >= logLevels.warn ? (msg) => writeLog(name, "warn", msg) : noop,
+  info:
+    logLevel >= logLevels.info ? (msg) => writeLog(name, "info", msg) : noop,
+  verbose:
+    logLevel >= logLevels.verbose
+      ? (msg) => writeLog(name, "verbose", msg)
+      : noop,
+});
+
+export default { createLogger };


### PR DESCRIPTION
## What does this PR do? 🛠️

- Adds a super basic logger that just writes to the console, which may be sufficient for cloud.gov. The message format is meant to be machine-parseable even when it's multiple lines, but I don't care much about it, so if it's objectionable, we can change it.
- Removes `console.log` statements elsewhere in the interop layer and replaces them with the new logger calls. Also adds a bunch of verbose logs, just for funsies.
- Sets the default log level to `info` and supports changing it via environment variable.

I imagine #1593 could build on top of this?