### PR TITLE
[Interop layer] Adds a JSON schema doc describing the interop layer's output

### DIFF
--- a/api-interop-layer/interop-layer.schema.json
+++ b/api-interop-layer/interop-layer.schema.json
@@ -1,0 +1,747 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weather.gov/interop.schema.json",
+  "title": "weather.gov API interoperability layer",
+  "description": "The results of querying for a specific latitude and longitude",
+  "type": "object",
+  "properties": {
+    "alerts": {
+      "title": "Point alerts",
+      "description": "Alerts that are applicable to the given lat/lon.",
+      "type": "object",
+      "properties": {
+        "items": {
+          "title": "List of alerts",
+          "description": "The alerts themselves",
+          "type": "array",
+          "items": {
+            "title": "Alert",
+            "type": "object",
+            "properties": {
+              "metadata": {
+                "title": "Alert metadata",
+                "description": "Prioritization and categorization metadata",
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "title": "Alert level",
+                    "description": "Alert level information",
+                    "type": "object",
+                    "properties": {
+                      "priority": {
+                        "description": "The priority of this alert relative to others. Lower numbers are higher priority.",
+                        "type": "integer"
+                      },
+                      "text": {
+                        "$ref": "#/$defs/alert/level"
+                      }
+                    },
+                    "required": ["priority", "text"]
+                  },
+                  "kind": {
+                    "$ref": "#/$defs/alert/level"
+                  },
+                  "priority": {
+                    "description": "The priority of this alert relative to others. Lower numbers are higher priority.",
+                    "type": "integer"
+                  }
+                },
+                "required": ["level", "kind", "priority"]
+              },
+              "id": {
+                "description": "ID of this alert. NOTE: may not be globally unique",
+                "type": "string"
+              },
+              "event": {
+                "description": "The alert event, such as 'Severe Thunderstorm Warning.'",
+                "type": "string"
+              },
+              "sender": {
+                "description": "The government office responsible for issuing this alert. Usually a NWS office, but sometimes state or local civil authorities.",
+                "type": "string"
+              },
+              "locations": {
+                "title": "Alert locations",
+                "description": "A list of counties by state region and cities, if an alert description includes embedded location information.",
+                "type": "object",
+                "properties": {
+                  "regions": {
+                    "title": "List of regions",
+                    "description": "A list of state regions covered by this alert, as derived from the alert description.",
+                    "type": "array",
+                    "items": {
+                      "title": "Alert location",
+                      "type": "object",
+                      "properties": {
+                        "area": {
+                          "description": "The name of a state region covered by this alert, as derived from the alert description.",
+                          "type": "string"
+                        },
+                        "counties": {
+                          "title": "List of counties",
+                          "description": "A list of counties within this state region covered by this alert, as derived from the alert description.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": ["area", "counties"]
+                    }
+                  },
+                  "cities": {
+                    "title": "List of cities",
+                    "description": "A list of cities impacted by this alert, as derived from the alert description.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["regions", "cities"]
+              },
+              "description": {
+                "title": "List of parsed content nodes",
+                "description": "The alert description, parsed into content nodes.",
+                "type": "array",
+                "items": {
+                  "title": "Parsed content node",
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "description": "The kind of content node",
+                      "type": "string",
+                      "enum": ["heading", "paragraph"]
+                    },
+                    "nodes": {
+                      "title": "List of parsed in-paragraph nodes",
+                      "description": "For paragraph nodes, the list of content nodes that go into the paragraph.",
+                      "type": "array",
+                      "items": {
+                        "title": "Parsed in-paragraph node",
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "description": "The type of in-paragraph content node.",
+                            "type": "string",
+                            "enum": ["text", "link"]
+                          },
+                          "text": {
+                            "description": "For text nodes, the textual content.",
+                            "type": "string"
+                          },
+                          "url": {
+                            "description": "For link nodes, the URL.",
+                            "type": "string"
+                          },
+                          "external": {
+                            "description": "For link nodes, whether the link is for a site outside of weather.gov.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": ["type"]
+                      }
+                    },
+                    "text": {
+                      "description": "For heading nodes, the textual content of the node",
+                      "type": "string"
+                    }
+                  },
+                  "required": ["type"]
+                }
+              },
+              "instruction": {
+                "description": "Safety instructions associated with the alert",
+                "type": "string"
+              },
+              "area": {
+                "title": "List of areas",
+                "description": "A list of areas affected by this alert, as provided by the origin.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sent": {
+                "description": "When the alert was initially sent.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "effective": {
+                "description": "When the alert becomes effective.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "onset": {
+                "description": "When the conditions described in the alert are forecast to begin.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "expires": {
+                "description": "When the alert will expire. NOTE: this is NOT when the hazardous conditions are forecast to end.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "ends": {
+                "description": "When the conditions described in the alert are forecast to end.",
+                "type": ["string", "null"],
+                "format": "date-time"
+              },
+              "finish": {
+                "description": "When the alert will no longer displayed on weather.gov, as derived from the expires and ends properties.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "geometry": {
+                "description": "GeoJSON GeometryCollection representing the area covered by this alert.",
+                "$ref": "https://geojson.org/schema/GeometryCollection.json"
+              },
+              "duration": {
+                "description": "When the alert will no longer be displayed on weather.gov, in human-friendly text based on the timezone of the alert area.",
+                "type": "string"
+              },
+              "timing": {
+                "title": "Alert timing",
+                "description": "Human-friendly text describing the beginning and completion of the alert, based on the timezone of the alert area.",
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "type": "string"
+                  },
+                  "end": {
+                    "type": "string"
+                  }
+                },
+                "required": ["start", "end"]
+              }
+            },
+            "required": [
+              "id",
+              "event",
+              "sender",
+              "description",
+              "instruction",
+              "area",
+              "sent",
+              "effective",
+              "onset",
+              "expires",
+              "ends",
+              "finish",
+              "geometry",
+              "duration",
+              "timing"
+            ]
+          }
+        },
+        "highestLevel": {
+          "$ref": "#/$defs/alert/level"
+        }
+      },
+      "required": ["items", "highestLevel"]
+    },
+    "point": {
+      "title": "Point",
+      "description": "Information about the point",
+      "type": "object",
+      "properties": {
+        "latitude": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "longitude": {
+          "type": "number",
+          "minimum": -360,
+          "maximum": 360
+        }
+      },
+      "required": ["latitude", "longitude"]
+    },
+    "place": {
+      "title": "Place",
+      "description": "Information about the place at the described point, as close as we know.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "City or other municipal name.",
+          "type": "string"
+        },
+        "state": {
+          "description": "2-letter abbreviation of the state or territory.",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 2
+        },
+        "stateName": {
+          "description": "Full name of the state.",
+          "type": "string"
+        },
+        "county": {
+          "description": "Full name of the county.",
+          "type": "string"
+        },
+        "timezone": {
+          "description": "Full tzdb name of the timezone at this point, as best we know.",
+          "type": "string"
+        },
+        "stateFIPS": {
+          "description": "2-digit FIPS code for this state.",
+          "type": "string",
+          "pattern": "^\\d{2}$"
+        },
+        "countyFIPS": {
+          "description": "5-digit FIPS code for this county. Note that this value has the state FIPS code prepended to the usual 3-digit county FIPS code.",
+          "type": "string",
+          "pattern": "^\\d{5}$"
+        },
+        "fullName": {
+          "description": "The full name of this place, with state or territory abbreviation.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "state",
+        "stateName",
+        "county",
+        "timezone",
+        "stateFIPS",
+        "countyFIPS",
+        "fullName"
+      ]
+    },
+    "grid": {
+      "title": "NWS Grid",
+      "description": "The NWS grid cell that this point falls in.",
+      "type": "object",
+      "properties": {
+        "wfo": {
+          "description": "The NWS weather forecasting office (WFO) that serves this point.",
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "x": {
+          "description": "WFO grid X coordinate.",
+          "type": "integer"
+        },
+        "y": {
+          "description": "WFO grid Y coordinate.",
+          "type": "integer"
+        },
+        "geometry": {
+          "description": "GeoJSON Polygon representing the area covered by this WFO grid cell.",
+          "$ref": "https://geojson.org/schema/Polygon.json"
+        },
+        "elevation": {
+          "description": "Elevation of this grid point.",
+          "$ref": "#/$defs/measures/distance"
+        }
+      },
+      "required": ["wfo", "x", "y", "geometry", "elevation"]
+    },
+    "observed": {
+      "title": "Observations",
+      "description": "Most-recently observed conditions for this location from the nearest approved observation station.",
+      "type": "object",
+      "properties": {
+        "timestamp": {
+          "description": "When the observation was recorded.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "icon": {
+          "$ref": "#/$defs/icon"
+        },
+        "description": {
+          "description": "Textual description of the observed conditions, if available.",
+          "type": "string"
+        },
+        "station": {
+          "title": "Observation station",
+          "description": "Metadata about the observation station that reported this data.",
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "The 4-character ID for the observation station.",
+              "type": "string",
+              "pattern": "^[A-Z0-9]{4}$"
+            },
+            "name": {
+              "description": "The full name of the observation station.",
+              "type": "string"
+            },
+            "elevation": {
+              "description": "The elevation at the observation station.",
+              "$ref": "#/$defs/measures/distance"
+            },
+            "distance": {
+              "description": "The flat-ground distance between the observation station and the requested point.",
+              "$ref": "#/$defs/measures/distance"
+            }
+          },
+          "required": ["id", "name", "elevation", "distance"]
+        },
+        "data": {
+          "title": "Observation data",
+          "description": "The observed data. The full list of properties is not provided here as it is taken directly from the NWS public API and is not controlled by weather.gov. The data provided by the NWS public API is converted into US and SI units.",
+          "type": "object"
+        }
+      },
+      "required": ["timestamp", "icon", "station", "data"]
+    },
+    "forecast": {
+      "title": "Forecast",
+      "description": "Forecast for this point.",
+      "type": "object",
+      "properties": {
+        "generated": {
+          "description": "When the forecast was generated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "description": "When the forecast was last updated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "valid": {
+          "description": "When the forecast is valid. This is a combination of ISO 8601 date-time and duration, in the form 'date-time/duration'.",
+          "type": "string"
+        },
+        "days": {
+          "title": "List of daily forecasts",
+          "description": "The daily forecasts for each day in the forecast period.",
+          "type": "array",
+          "items": {
+            "title": "Daily forecast",
+            "type": "object",
+            "properties": {
+              "start": {
+                "description": "The starting time for this daily forecast.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "end": {
+                "description": "The ending time for this daily forecast.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "periods": {
+                "title": "List of daily forecast periods",
+                "description": "The periods of the daily forecast, such as overnight, day, and night.",
+                "type": "array",
+                "items": {
+                  "title": "Daily forecast period",
+                  "type": "object",
+                  "properties": {
+                    "start": {
+                      "description": "The starting time for this period of the daily forecast.",
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "end": {
+                      "description": "The ending time for this period of the daily forecast.",
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "isDaytime": {
+                      "description": "Whether this period represents the daytime period. A period can be daytime, nighttime, or overnight.",
+                      "type": "boolean"
+                    },
+                    "isOvernight": {
+                      "description": "Whether this period represents the overnight period. A period can be daytime, nighttime, or overnight.",
+                      "type": "boolean"
+                    },
+                    "monthAndDay": {
+                      "description": "The short month name (eg, Jan, Feb, etc.) and day number that this forecast period applies to. Formatted in en-US locale.",
+                      "type": "string",
+                      "pattern": "^[A-Z][a-z]{2} d{1,2}$"
+                    },
+                    "dayName": {
+                      "description": "The name of the day this forecast period applies to, or 'Today' if it's the current day. Uses English day names.",
+                      "type": "string",
+                      "pattern": "^[A-Z][a-z]+$"
+                    },
+                    "timeLabel": {
+                      "description": "Textual representation of the hour range covered by this period, in the timezone of the location.",
+                      "type": "string",
+                      "pattern": "^1?[0-9]-1?[0-9]$"
+                    },
+                    "data": {
+                      "title": "Daily forecast period data",
+                      "description": "The forecast data for this period.",
+                      "type": "object",
+                      "properties": {
+                        "icon": {
+                          "$ref": "#/$defs/icon"
+                        },
+                        "description": {
+                          "description": "Textual description of the forecast period conditions.",
+                          "type": "text"
+                        },
+                        "temperature": {
+                          "description": "Forecast temperature for this forecast period.",
+                          "$ref": "#/$defs/measures/temperature"
+                        },
+                        "probabilityOfPrecipitation": {
+                          "description": "Forecast probability of precipitation for this forecast period.",
+                          "type": "integer"
+                        },
+                        "windSpeed": {
+                          "description": "Forecast wind speed for this forecast period.",
+                          "$ref": "#/$defs/measures/speed"
+                        },
+                        "windDirection": {
+                          "description": "Forecast wind direction for this forecast period, in cardinal/ordinal direction (eg, N, NW, WNW, etc.).",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "qpf": {
+                "title": "List of hourly QPFs",
+                "description": "Forecast quantitative precipitation for this forecast period. Note that QPF is delivered in multi-hour totals rather than individual-hour totals, so it must be treated differently than other forecast period data.",
+                "type": "array",
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/measures/length"
+                  }
+                ],
+                "items": {
+                  "title": "QPF",
+                  "type": "object",
+                  "properties": {
+                    "start": {
+                      "description": "The starting time for this QPF forecast.",
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "end": {
+                      "description": "The ending time for this QPF forecast.",
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "startHour": {
+                      "description": "The starting hour in the timezone of the forecast, in AM/PM.",
+                      "type": "string",
+                      "pattern": "^1?\\d (A|P)M$"
+                    },
+                    "endHour": {
+                      "description": "The ending hour in the timezone of the forecast, in AM/PM.",
+                      "type": "string",
+                      "pattern": "^1?\\d (A|P)M$"
+                    }
+                  }
+                }
+              },
+              "hours": {
+                "title": "List of hourly forecasts",
+                "description": "Hourly forecast for each hour of this daily forecast period. The full list of properties is not provided here as it is taken directly from the NWS public API and is not controlled by weather.gov. The properties listed below are created by weather.gov and are the only guaranteed properties.",
+                "type": "array",
+                "items": {
+                  "title": "Hourly forecast",
+                  "type": "object",
+                  "properties": {
+                    "time": {
+                      "description": "The time at which this hourly forecast begins.",
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "hour": {
+                      "description": "Human-friendly hour when the hourly forecast begins. Eg, '6 AM",
+                      "type": "string",
+                      "pattern": "^1?\\d (A|P)M$"
+                    },
+                    "icon": {
+                      "$ref": "#/$defs/icon"
+                    }
+                  },
+                  "required": ["time", "hour"]
+                }
+              },
+              "alerts": {
+                "title": "Daily forecast alerts",
+                "description": "Information about alerts that are valid during this forecast day.",
+                "type": "object",
+                "properties": {
+                  "metadata": {
+                    "title": "Daily forecast alert metadata",
+                    "description": "Top-level metadata about the alerts for this forecast day.",
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "description": "The number of alerts that are applicable to this forecast day.",
+                        "type": "integer"
+                      },
+                      "highest": {
+                        "$ref": "#/$defs/alert/level"
+                      }
+                    }
+                  },
+                  "items": {
+                    "title": "List of alerts",
+                    "description": "List of alerts.",
+                    "type": "array",
+                    "items": {
+                      "title": "Daily forecast alert",
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "description": "An ID for this alert. NOTE: this may not be globally unique.",
+                          "type": "string"
+                        },
+                        "event": {
+                          "description": "The event type for the alert. Eg, 'Severe Thunderstorm Warning,' etc.",
+                          "type": "string"
+                        },
+                        "level": {
+                          "$ref": "#/$defs/alert/level"
+                        },
+                        "offset": {
+                          "description": "The number of hours after the first whole hour covered by this forecast period when the alert will begin.",
+                          "type": "integer"
+                        },
+                        "duration": {
+                          "description": "The number of hours that this alert will be active after the first whole hour of this forecast period, up to the total number of hours remaining in the forecast period.",
+                          "type": "integer"
+                        },
+                        "remainder": {
+                          "description": "The number of hours that this alert will be active in excess of the duration property.",
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required": ["start", "end", "periods", "qpf", "hours", "alerts"]
+          }
+        }
+      },
+      "required": ["generated", "updated", "valid", "days"]
+    },
+    "satellite": {
+      "title": "Satellite",
+      "description": "Information about satellite imagery for this point.",
+      "type": "object",
+      "properties": {
+        "gif": {
+          "description": "URL to the 600x600 geocolor GIF of the most recent satellite for this point.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "@metadata": {
+      "title": "Response metadata",
+      "description": "Metadata about the response itself.",
+      "type": "object",
+      "properties": {
+        "timing": {
+          "title": "Response timing",
+          "description": "The time spent answering the request.",
+          "type": "object",
+          "properties": {
+            "e2e": {
+              "description": "Total time spent, in seconds.",
+              "type": "number"
+            },
+            "api": {
+              "title": "Response API timing",
+              "description": "Time spent making and receiving each request and response to the NWS public API. Keys are the API URLs and values are the times in seconds.",
+              "type": "object"
+            }
+          }
+        },
+        "size": {
+          "description": "The uncompressed size of the data being returned, excluding the metadata, in bytes.",
+          "type": "integer"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "alert": {
+      "kind": {
+        "description": "The kind of alert",
+        "type": "string",
+        "enum": ["land", "marine", "other"]
+      },
+      "level": {
+        "description": "The alert level, as defined by weather.gov.",
+        "type": "string",
+        "enum": ["warning", "watch", "other"]
+      }
+    },
+    "icon": {
+      "title": "Icon",
+      "description": "Information about the icon that represents this forecast period's conditions.",
+      "type": "object",
+      "properties": {
+        "icon": {
+          "description": "The icon filename, as used by weather.gov.",
+          "type": "string"
+        },
+        "base": {
+          "description": "The basename of the icon (without file extension).",
+          "type": "string"
+        }
+      }
+    },
+    "measures": {
+      "distance": {
+        "title": "Distance",
+        "type": "object",
+        "properties": {
+          "m": {
+            "description": "Elevation, in meters.",
+            "type": "number"
+          },
+          "ft": {
+            "description": "Elevation, in ft.",
+            "type": "number"
+          },
+          "mi": {
+            "description": "Elevation, in miles.",
+            "type": "number"
+          }
+        },
+        "required": ["m", "ft", "mi"]
+      },
+      "speed": {
+        "title": "Speed",
+        "type": "object",
+        "properties": {
+          "mph": {
+            "description": "Speed, in miles per hour.",
+            "type": "integer"
+          },
+          "km/h": {
+            "description": "Speed, in kilometers per hour.",
+            "type": "integer"
+          }
+        },
+        "required": ["mph", "km/h"]
+      },
+      "temperature": {
+        "title": "Temperature",
+        "type": "object",
+        "properties": {
+          "degF": {
+            "description": "Temperature, in degrees Fahrenheit.",
+            "type": "integer"
+          },
+          "degC": {
+            "description": "Temperature, in degrees Celsius.",
+            "type": "integer"
+          }
+        },
+        "required": ["degF", "degC"]
+      }
+    }
+  }
+}

--- a/docs/dev/interop/README.md
+++ b/docs/dev/interop/README.md
@@ -1,0 +1,103 @@
+# README
+
+## Top-level Schemas
+
+* [weather.gov API interoperability layer](./interop-layer.md "The results of querying for a specific latitude and longitude") – `https://weather.gov/interop.schema.json`
+
+## Other Schemas
+
+### Objects
+
+* [Alert](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert.md) – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items`
+
+* [Alert level](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level.md "Alert level information") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level`
+
+* [Alert location](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location.md) – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items`
+
+* [Alert locations](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations.md "A list of counties by state region and cities, if an alert description includes embedded location information") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations`
+
+* [Alert metadata](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata.md "Prioritization and categorization metadata") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata`
+
+* [Alert timing](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing.md "Human-friendly text describing the beginning and completion of the alert, based on the timezone of the alert area") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing`
+
+* [Daily forecast](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast.md) – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items`
+
+* [Daily forecast alert](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert.md) – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items`
+
+* [Daily forecast alert metadata](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata.md "Top-level metadata about the alerts for this forecast day") – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata`
+
+* [Daily forecast alerts](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts.md "Information about alerts that are valid during this forecast day") – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts`
+
+* [Daily forecast period](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period.md) – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items`
+
+* [Daily forecast period data](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data.md "The forecast data for this period") – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data`
+
+* [Distance](./interop-layer-defs-measures-distance.md) – `https://weather.gov/interop.schema.json#/$defs/measures/distance`
+
+* [Forecast](./interop-layer-properties-forecast.md "Forecast for this point") – `https://weather.gov/interop.schema.json#/properties/forecast`
+
+* [Hourly forecast](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast.md) – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items`
+
+* [Icon](./interop-layer-defs-icon.md "Information about the icon that represents this forecast period's conditions") – `https://weather.gov/interop.schema.json#/$defs/icon`
+
+* [NWS Grid](./interop-layer-properties-nws-grid.md "The NWS grid cell that this point falls in") – `https://weather.gov/interop.schema.json#/properties/grid`
+
+* [Observation data](./interop-layer-properties-observations-properties-observation-data.md "The observed data") – `https://weather.gov/interop.schema.json#/properties/observed/properties/data`
+
+* [Observation station](./interop-layer-properties-observations-properties-observation-station.md "Metadata about the observation station that reported this data") – `https://weather.gov/interop.schema.json#/properties/observed/properties/station`
+
+* [Observations](./interop-layer-properties-observations.md "Most-recently observed conditions for this location from the nearest approved observation station") – `https://weather.gov/interop.schema.json#/properties/observed`
+
+* [Parsed content node](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node.md) – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items`
+
+* [Parsed in-paragraph node](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node.md) – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items`
+
+* [Place](./interop-layer-properties-place.md "Information about the place at the described point, as close as we know") – `https://weather.gov/interop.schema.json#/properties/place`
+
+* [Point](./interop-layer-properties-point.md "Information about the point") – `https://weather.gov/interop.schema.json#/properties/point`
+
+* [Point alerts](./interop-layer-properties-point-alerts.md "Alerts that are applicable to the given lat/lon") – `https://weather.gov/interop.schema.json#/properties/alerts`
+
+* [QPF](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf.md) – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items`
+
+* [Response API timing](./interop-layer-properties-response-metadata-properties-response-timing-properties-response-api-timing.md "Time spent making and receiving each request and response to the NWS public API") – `https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing/properties/api`
+
+* [Response metadata](./interop-layer-properties-response-metadata.md "Metadata about the response itself") – `https://weather.gov/interop.schema.json#/properties/@metadata`
+
+* [Response timing](./interop-layer-properties-response-metadata-properties-response-timing.md "The time spent answering the request") – `https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing`
+
+* [Satellite](./interop-layer-properties-satellite.md "Information about satellite imagery for this point") – `https://weather.gov/interop.schema.json#/properties/satellite`
+
+* [Speed](./interop-layer-defs-measures-speed.md) – `https://weather.gov/interop.schema.json#/$defs/measures/speed`
+
+* [Temperature](./interop-layer-defs-measures-temperature.md) – `https://weather.gov/interop.schema.json#/$defs/measures/temperature`
+
+### Arrays
+
+* [List of alerts](./interop-layer-properties-point-alerts-properties-list-of-alerts.md "The alerts themselves") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items`
+
+* [List of alerts](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts.md "List of alerts") – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items`
+
+* [List of areas](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-areas.md "A list of areas affected by this alert, as provided by the origin") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/area`
+
+* [List of cities](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-cities.md "A list of cities impacted by this alert, as derived from the alert description") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/cities`
+
+* [List of counties](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-list-of-counties.md "A list of counties within this state region covered by this alert, as derived from the alert description") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items/properties/counties`
+
+* [List of daily forecast periods](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods.md "The periods of the daily forecast, such as overnight, day, and night") – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods`
+
+* [List of daily forecasts](./interop-layer-properties-forecast-properties-list-of-daily-forecasts.md "The daily forecasts for each day in the forecast period") – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days`
+
+* [List of hourly QPFs](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs.md "Forecast quantitative precipitation for this forecast period") – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf`
+
+* [List of hourly forecasts](./interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts.md "Hourly forecast for each hour of this daily forecast period") – `https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours`
+
+* [List of parsed content nodes](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes.md "The alert description, parsed into content nodes") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description`
+
+* [List of parsed in-paragraph nodes](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes.md "For paragraph nodes, the list of content nodes that go into the paragraph") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes`
+
+* [List of regions](./interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions.md "A list of state regions covered by this alert, as derived from the alert description") – `https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions`
+
+## Version Note
+
+The schemas linked above follow the JSON Schema Spec version: `https://json-schema.org/draft/2020-12/schema`

--- a/docs/dev/interop/interop-layer-defs-alert-kind.md
+++ b/docs/dev/interop/interop-layer-defs-alert-kind.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/alert/kind
+```
+
+The kind of alert
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## kind Type
+
+`string`
+
+## kind Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value      | Explanation |
+| :--------- | :---------- |
+| `"land"`   |             |
+| `"marine"` |             |
+| `"other"`  |             |

--- a/docs/dev/interop/interop-layer-defs-alert-level.md
+++ b/docs/dev/interop/interop-layer-defs-alert-level.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/alert/level
+```
+
+The alert level, as defined by weather.gov.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## level Type
+
+`string`
+
+## level Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |

--- a/docs/dev/interop/interop-layer-defs-alert.md
+++ b/docs/dev/interop/interop-layer-defs-alert.md
@@ -1,0 +1,15 @@
+# Untitled undefined type in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/alert
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## alert Type
+
+unknown

--- a/docs/dev/interop/interop-layer-defs-icon-properties-base.md
+++ b/docs/dev/interop/interop-layer-defs-icon-properties-base.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/icon/properties/base
+```
+
+The basename of the icon (without file extension).
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## base Type
+
+`string`

--- a/docs/dev/interop/interop-layer-defs-icon-properties-icon.md
+++ b/docs/dev/interop/interop-layer-defs-icon-properties-icon.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/icon/properties/icon
+```
+
+The icon filename, as used by weather.gov.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## icon Type
+
+`string`

--- a/docs/dev/interop/interop-layer-defs-icon.md
+++ b/docs/dev/interop/interop-layer-defs-icon.md
@@ -1,0 +1,58 @@
+# Icon Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/icon
+```
+
+Information about the icon that represents this forecast period's conditions.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## icon Type
+
+`object` ([Icon](interop-layer-defs-icon.md))
+
+# icon Properties
+
+| Property      | Type     | Required | Nullable       | Defined by                                                                                                                                                 |
+| :------------ | :------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [icon](#icon) | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-icon-properties-icon.md "https://weather.gov/interop.schema.json#/$defs/icon/properties/icon") |
+| [base](#base) | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-icon-properties-base.md "https://weather.gov/interop.schema.json#/$defs/icon/properties/base") |
+
+## icon
+
+The icon filename, as used by weather.gov.
+
+`icon`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-icon-properties-icon.md "https://weather.gov/interop.schema.json#/$defs/icon/properties/icon")
+
+### icon Type
+
+`string`
+
+## base
+
+The basename of the icon (without file extension).
+
+`base`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-icon-properties-base.md "https://weather.gov/interop.schema.json#/$defs/icon/properties/base")
+
+### base Type
+
+`string`

--- a/docs/dev/interop/interop-layer-defs-measures-distance-properties-ft.md
+++ b/docs/dev/interop/interop-layer-defs-measures-distance-properties-ft.md
@@ -1,0 +1,15 @@
+# Untitled number in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/distance/properties/ft
+```
+
+Elevation, in ft.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## ft Type
+
+`number`

--- a/docs/dev/interop/interop-layer-defs-measures-distance-properties-m.md
+++ b/docs/dev/interop/interop-layer-defs-measures-distance-properties-m.md
@@ -1,0 +1,15 @@
+# Untitled number in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/distance/properties/m
+```
+
+Elevation, in meters.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## m Type
+
+`number`

--- a/docs/dev/interop/interop-layer-defs-measures-distance-properties-mi.md
+++ b/docs/dev/interop/interop-layer-defs-measures-distance-properties-mi.md
@@ -1,0 +1,15 @@
+# Untitled number in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/distance/properties/mi
+```
+
+Elevation, in miles.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## mi Type
+
+`number`

--- a/docs/dev/interop/interop-layer-defs-measures-distance.md
+++ b/docs/dev/interop/interop-layer-defs-measures-distance.md
@@ -1,0 +1,77 @@
+# Distance Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/distance
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## distance Type
+
+`object` ([Distance](interop-layer-defs-measures-distance.md))
+
+# distance Properties
+
+| Property  | Type     | Required | Nullable       | Defined by                                                                                                                                                                       |
+| :-------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [m](#m)   | `number` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-distance-properties-m.md "https://weather.gov/interop.schema.json#/$defs/measures/distance/properties/m")   |
+| [ft](#ft) | `number` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-distance-properties-ft.md "https://weather.gov/interop.schema.json#/$defs/measures/distance/properties/ft") |
+| [mi](#mi) | `number` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-distance-properties-mi.md "https://weather.gov/interop.schema.json#/$defs/measures/distance/properties/mi") |
+
+## m
+
+Elevation, in meters.
+
+`m`
+
+* is required
+
+* Type: `number`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-distance-properties-m.md "https://weather.gov/interop.schema.json#/$defs/measures/distance/properties/m")
+
+### m Type
+
+`number`
+
+## ft
+
+Elevation, in ft.
+
+`ft`
+
+* is required
+
+* Type: `number`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-distance-properties-ft.md "https://weather.gov/interop.schema.json#/$defs/measures/distance/properties/ft")
+
+### ft Type
+
+`number`
+
+## mi
+
+Elevation, in miles.
+
+`mi`
+
+* is required
+
+* Type: `number`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-distance-properties-mi.md "https://weather.gov/interop.schema.json#/$defs/measures/distance/properties/mi")
+
+### mi Type
+
+`number`

--- a/docs/dev/interop/interop-layer-defs-measures-speed-properties-h.md
+++ b/docs/dev/interop/interop-layer-defs-measures-speed-properties-h.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/speed/properties/km/h
+```
+
+Speed, in kilometers per hour.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## h Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-defs-measures-speed-properties-mph.md
+++ b/docs/dev/interop/interop-layer-defs-measures-speed-properties-mph.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/speed/properties/mph
+```
+
+Speed, in miles per hour.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## mph Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-defs-measures-speed.md
+++ b/docs/dev/interop/interop-layer-defs-measures-speed.md
@@ -1,0 +1,58 @@
+# Speed Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/speed
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## speed Type
+
+`object` ([Speed](interop-layer-defs-measures-speed.md))
+
+# speed Properties
+
+| Property     | Type      | Required | Nullable       | Defined by                                                                                                                                                                   |
+| :----------- | :-------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [mph](#mph)  | `integer` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-speed-properties-mph.md "https://weather.gov/interop.schema.json#/$defs/measures/speed/properties/mph") |
+| [km/h](#kmh) | `integer` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-speed-properties-h.md "https://weather.gov/interop.schema.json#/$defs/measures/speed/properties/km/h")  |
+
+## mph
+
+Speed, in miles per hour.
+
+`mph`
+
+* is required
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-speed-properties-mph.md "https://weather.gov/interop.schema.json#/$defs/measures/speed/properties/mph")
+
+### mph Type
+
+`integer`
+
+## km/h
+
+Speed, in kilometers per hour.
+
+`km/h`
+
+* is required
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-speed-properties-h.md "https://weather.gov/interop.schema.json#/$defs/measures/speed/properties/km/h")
+
+### h Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-defs-measures-temperature-properties-degc.md
+++ b/docs/dev/interop/interop-layer-defs-measures-temperature-properties-degc.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/temperature/properties/degC
+```
+
+Temperature, in degrees Celsius.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## degC Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-defs-measures-temperature-properties-degf.md
+++ b/docs/dev/interop/interop-layer-defs-measures-temperature-properties-degf.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/temperature/properties/degF
+```
+
+Temperature, in degrees Fahrenheit.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## degF Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-defs-measures-temperature.md
+++ b/docs/dev/interop/interop-layer-defs-measures-temperature.md
@@ -1,0 +1,58 @@
+# Temperature Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures/temperature
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## temperature Type
+
+`object` ([Temperature](interop-layer-defs-measures-temperature.md))
+
+# temperature Properties
+
+| Property      | Type      | Required | Nullable       | Defined by                                                                                                                                                                                 |
+| :------------ | :-------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [degF](#degf) | `integer` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-temperature-properties-degf.md "https://weather.gov/interop.schema.json#/$defs/measures/temperature/properties/degF") |
+| [degC](#degc) | `integer` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-temperature-properties-degc.md "https://weather.gov/interop.schema.json#/$defs/measures/temperature/properties/degC") |
+
+## degF
+
+Temperature, in degrees Fahrenheit.
+
+`degF`
+
+* is required
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-temperature-properties-degf.md "https://weather.gov/interop.schema.json#/$defs/measures/temperature/properties/degF")
+
+### degF Type
+
+`integer`
+
+## degC
+
+Temperature, in degrees Celsius.
+
+`degC`
+
+* is required
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-temperature-properties-degc.md "https://weather.gov/interop.schema.json#/$defs/measures/temperature/properties/degC")
+
+### degC Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-defs-measures.md
+++ b/docs/dev/interop/interop-layer-defs-measures.md
@@ -1,0 +1,15 @@
+# Untitled undefined type in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs/measures
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## measures Type
+
+unknown

--- a/docs/dev/interop/interop-layer-defs.md
+++ b/docs/dev/interop/interop-layer-defs.md
@@ -1,0 +1,15 @@
+# Untitled undefined type in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/$defs
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## $defs Type
+
+unknown

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-generated.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-generated.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/generated
+```
+
+When the forecast was generated.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## generated Type
+
+`string`
+
+## generated Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata-properties-count.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata-properties-count.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata/properties/count
+```
+
+The number of alerts that are applicable to this forecast day.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## count Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata-properties-highest.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata-properties-highest.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata/properties/highest
+```
+
+The alert level, as defined by weather.gov.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## highest Type
+
+`string`
+
+## highest Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata.md
@@ -1,0 +1,68 @@
+# Daily forecast alert metadata Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata
+```
+
+Top-level metadata about the alerts for this forecast day.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## metadata Type
+
+`object` ([Daily forecast alert metadata](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata.md))
+
+# metadata Properties
+
+| Property            | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                                                                  |
+| :------------------ | :-------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [count](#count)     | `integer` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata-properties-count.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata/properties/count")     |
+| [highest](#highest) | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata-properties-highest.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata/properties/highest") |
+
+## count
+
+The number of alerts that are applicable to this forecast day.
+
+`count`
+
+* is optional
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata-properties-count.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata/properties/count")
+
+### count Type
+
+`integer`
+
+## highest
+
+The alert level, as defined by weather.gov.
+
+`highest`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata-properties-highest.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata/properties/highest")
+
+### highest Type
+
+`string`
+
+### highest Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-duration.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-duration.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/duration
+```
+
+The number of hours that this alert will be active after the first whole hour of this forecast period, up to the total number of hours remaining in the forecast period.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## duration Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-event.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-event.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/event
+```
+
+The event type for the alert. Eg, 'Severe Thunderstorm Warning,' etc.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## event Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-id.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-id.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/id
+```
+
+An ID for this alert. NOTE: this may not be globally unique.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## id Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-level.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-level.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/level
+```
+
+The alert level, as defined by weather.gov.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## level Type
+
+`string`
+
+## level Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-offset.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-offset.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/offset
+```
+
+The number of hours after the first whole hour covered by this forecast period when the alert will begin.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## offset Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-remainder.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-remainder.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/remainder
+```
+
+The number of hours that this alert will be active in excess of the duration property.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## remainder Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert.md
@@ -1,0 +1,144 @@
+# Daily forecast alert Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object` ([Daily forecast alert](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert.md))
+
+# items Properties
+
+| Property                | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                                                                               |
+| :---------------------- | :-------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [id](#id)               | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-id.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/id")               |
+| [event](#event)         | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-event.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/event")         |
+| [level](#level)         | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-level.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/level")         |
+| [offset](#offset)       | `integer` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-offset.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/offset")       |
+| [duration](#duration)   | `integer` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-duration.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/duration")   |
+| [remainder](#remainder) | `integer` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-remainder.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/remainder") |
+
+## id
+
+An ID for this alert. NOTE: this may not be globally unique.
+
+`id`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-id.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/id")
+
+### id Type
+
+`string`
+
+## event
+
+The event type for the alert. Eg, 'Severe Thunderstorm Warning,' etc.
+
+`event`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-event.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/event")
+
+### event Type
+
+`string`
+
+## level
+
+The alert level, as defined by weather.gov.
+
+`level`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-level.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/level")
+
+### level Type
+
+`string`
+
+### level Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |
+
+## offset
+
+The number of hours after the first whole hour covered by this forecast period when the alert will begin.
+
+`offset`
+
+* is optional
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-offset.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/offset")
+
+### offset Type
+
+`integer`
+
+## duration
+
+The number of hours that this alert will be active after the first whole hour of this forecast period, up to the total number of hours remaining in the forecast period.
+
+`duration`
+
+* is optional
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-duration.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/duration")
+
+### duration Type
+
+`integer`
+
+## remainder
+
+The number of hours that this alert will be active in excess of the duration property.
+
+`remainder`
+
+* is optional
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert-properties-remainder.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items/items/properties/remainder")
+
+### remainder Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts.md
@@ -1,0 +1,15 @@
+# List of alerts Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items
+```
+
+List of alerts.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object[]` ([Daily forecast alert](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert.md))

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts.md
@@ -1,0 +1,58 @@
+# Daily forecast alerts Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts
+```
+
+Information about alerts that are valid during this forecast day.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## alerts Type
+
+`object` ([Daily forecast alerts](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts.md))
+
+# alerts Properties
+
+| Property              | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                            |
+| :-------------------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [metadata](#metadata) | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata") |
+| [items](#items)       | `array`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items")                   |
+
+## metadata
+
+Top-level metadata about the alerts for this forecast day.
+
+`metadata`
+
+* is optional
+
+* Type: `object` ([Daily forecast alert metadata](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/metadata")
+
+### metadata Type
+
+`object` ([Daily forecast alert metadata](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-daily-forecast-alert-metadata.md))
+
+## items
+
+List of alerts.
+
+`items`
+
+* is optional
+
+* Type: `object[]` ([Daily forecast alert](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts/properties/items")
+
+### items Type
+
+`object[]` ([Daily forecast alert](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts-properties-list-of-alerts-daily-forecast-alert.md))

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-end.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-end.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/end
+```
+
+The ending time for this daily forecast.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## end Type
+
+`string`
+
+## end Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-description.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-description.md
@@ -1,0 +1,15 @@
+# Untitled text in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/description
+```
+
+Textual description of the forecast period conditions.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## description Type
+
+`text`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-probabilityofprecipitation.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-probabilityofprecipitation.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/probabilityOfPrecipitation
+```
+
+Forecast probability of precipitation for this forecast period.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## probabilityOfPrecipitation Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-winddirection.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-winddirection.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/windDirection
+```
+
+Forecast wind direction for this forecast period, in cardinal/ordinal direction (eg, N, NW, WNW, etc.).
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## windDirection Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data.md
@@ -1,0 +1,134 @@
+# Daily forecast period data Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data
+```
+
+The forecast data for this period.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## data Type
+
+`object` ([Daily forecast period data](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data.md))
+
+# data Properties
+
+| Property                                                  | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| :-------------------------------------------------------- | :-------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [icon](#icon)                                             | `object`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-icon.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/icon")                                                                                                                                                                                                                               |
+| [description](#description)                               | `text`    | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-description.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/description")                               |
+| [temperature](#temperature)                               | `object`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-temperature.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/temperature")                                                                                                                                                                                                        |
+| [probabilityOfPrecipitation](#probabilityofprecipitation) | `integer` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-probabilityofprecipitation.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/probabilityOfPrecipitation") |
+| [windSpeed](#windspeed)                                   | `object`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-speed.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/windSpeed")                                                                                                                                                                                                                |
+| [windDirection](#winddirection)                           | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-winddirection.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/windDirection")                           |
+
+## icon
+
+Information about the icon that represents this forecast period's conditions.
+
+`icon`
+
+* is optional
+
+* Type: `object` ([Icon](interop-layer-defs-icon.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-icon.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/icon")
+
+### icon Type
+
+`object` ([Icon](interop-layer-defs-icon.md))
+
+## description
+
+Textual description of the forecast period conditions.
+
+`description`
+
+* is optional
+
+* Type: `text`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-description.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/description")
+
+### description Type
+
+`text`
+
+## temperature
+
+Forecast temperature for this forecast period.
+
+`temperature`
+
+* is optional
+
+* Type: `object` ([Temperature](interop-layer-defs-measures-temperature.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-temperature.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/temperature")
+
+### temperature Type
+
+`object` ([Temperature](interop-layer-defs-measures-temperature.md))
+
+## probabilityOfPrecipitation
+
+Forecast probability of precipitation for this forecast period.
+
+`probabilityOfPrecipitation`
+
+* is optional
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-probabilityofprecipitation.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/probabilityOfPrecipitation")
+
+### probabilityOfPrecipitation Type
+
+`integer`
+
+## windSpeed
+
+Forecast wind speed for this forecast period.
+
+`windSpeed`
+
+* is optional
+
+* Type: `object` ([Speed](interop-layer-defs-measures-speed.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-speed.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/windSpeed")
+
+### windSpeed Type
+
+`object` ([Speed](interop-layer-defs-measures-speed.md))
+
+## windDirection
+
+Forecast wind direction for this forecast period, in cardinal/ordinal direction (eg, N, NW, WNW, etc.).
+
+`windDirection`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data-properties-winddirection.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data/properties/windDirection")
+
+### windDirection Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-dayname.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-dayname.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/dayName
+```
+
+The name of the day this forecast period applies to, or 'Today' if it's the current day. Uses English day names.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## dayName Type
+
+`string`
+
+## dayName Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^[A-Z][a-z]+$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5BA-Z%5D%5Ba-z%5D%2B%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-end.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-end.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/end
+```
+
+The ending time for this period of the daily forecast.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## end Type
+
+`string`
+
+## end Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-isdaytime.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-isdaytime.md
@@ -1,0 +1,15 @@
+# Untitled boolean in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/isDaytime
+```
+
+Whether this period represents the daytime period. A period can be daytime, nighttime, or overnight.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## isDaytime Type
+
+`boolean`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-isovernight.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-isovernight.md
@@ -1,0 +1,15 @@
+# Untitled boolean in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/isOvernight
+```
+
+Whether this period represents the overnight period. A period can be daytime, nighttime, or overnight.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## isOvernight Type
+
+`boolean`

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-monthandday.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-monthandday.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/monthAndDay
+```
+
+The short month name (eg, Jan, Feb, etc.) and day number that this forecast period applies to. Formatted in en-US locale.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## monthAndDay Type
+
+`string`
+
+## monthAndDay Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^[A-Z][a-z]{2} d{1,2}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5BA-Z%5D%5Ba-z%5D%7B2%7D%20d%7B1%2C2%7D%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-start.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-start.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/start
+```
+
+The starting time for this period of the daily forecast.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## start Type
+
+`string`
+
+## start Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-timelabel.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-timelabel.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/timeLabel
+```
+
+Textual representation of the hour range covered by this period, in the timezone of the location.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## timeLabel Type
+
+`string`
+
+## timeLabel Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^1?[0-9]-1?[0-9]$
+```
+
+[try pattern](https://regexr.com/?expression=%5E1%3F%5B0-9%5D-1%3F%5B0-9%5D%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period.md
@@ -1,0 +1,210 @@
+# Daily forecast period Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object` ([Daily forecast period](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period.md))
+
+# items Properties
+
+| Property                    | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                                                           |
+| :-------------------------- | :-------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [start](#start)             | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-start.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/start")                     |
+| [end](#end)                 | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-end.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/end")                         |
+| [isDaytime](#isdaytime)     | `boolean` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-isdaytime.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/isDaytime")             |
+| [isOvernight](#isovernight) | `boolean` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-isovernight.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/isOvernight")         |
+| [monthAndDay](#monthandday) | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-monthandday.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/monthAndDay")         |
+| [dayName](#dayname)         | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-dayname.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/dayName")                 |
+| [timeLabel](#timelabel)     | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-timelabel.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/timeLabel")             |
+| [data](#data)               | `object`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data") |
+
+## start
+
+The starting time for this period of the daily forecast.
+
+`start`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-start.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/start")
+
+### start Type
+
+`string`
+
+### start Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## end
+
+The ending time for this period of the daily forecast.
+
+`end`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-end.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/end")
+
+### end Type
+
+`string`
+
+### end Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## isDaytime
+
+Whether this period represents the daytime period. A period can be daytime, nighttime, or overnight.
+
+`isDaytime`
+
+* is optional
+
+* Type: `boolean`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-isdaytime.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/isDaytime")
+
+### isDaytime Type
+
+`boolean`
+
+## isOvernight
+
+Whether this period represents the overnight period. A period can be daytime, nighttime, or overnight.
+
+`isOvernight`
+
+* is optional
+
+* Type: `boolean`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-isovernight.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/isOvernight")
+
+### isOvernight Type
+
+`boolean`
+
+## monthAndDay
+
+The short month name (eg, Jan, Feb, etc.) and day number that this forecast period applies to. Formatted in en-US locale.
+
+`monthAndDay`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-monthandday.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/monthAndDay")
+
+### monthAndDay Type
+
+`string`
+
+### monthAndDay Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^[A-Z][a-z]{2} d{1,2}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5BA-Z%5D%5Ba-z%5D%7B2%7D%20d%7B1%2C2%7D%24 "try regular expression with regexr.com")
+
+## dayName
+
+The name of the day this forecast period applies to, or 'Today' if it's the current day. Uses English day names.
+
+`dayName`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-dayname.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/dayName")
+
+### dayName Type
+
+`string`
+
+### dayName Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^[A-Z][a-z]+$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5BA-Z%5D%5Ba-z%5D%2B%24 "try regular expression with regexr.com")
+
+## timeLabel
+
+Textual representation of the hour range covered by this period, in the timezone of the location.
+
+`timeLabel`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-timelabel.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/timeLabel")
+
+### timeLabel Type
+
+`string`
+
+### timeLabel Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^1?[0-9]-1?[0-9]$
+```
+
+[try pattern](https://regexr.com/?expression=%5E1%3F%5B0-9%5D-1%3F%5B0-9%5D%24 "try regular expression with regexr.com")
+
+## data
+
+The forecast data for this period.
+
+`data`
+
+* is optional
+
+* Type: `object` ([Daily forecast period data](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods/items/properties/data")
+
+### data Type
+
+`object` ([Daily forecast period data](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period-properties-daily-forecast-period-data.md))

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods.md
@@ -1,0 +1,15 @@
+# List of daily forecast periods Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods
+```
+
+The periods of the daily forecast, such as overnight, day, and night.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## periods Type
+
+`object[]` ([Daily forecast period](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period.md))

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast-properties-hour.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast-properties-hour.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items/properties/hour
+```
+
+Human-friendly hour when the hourly forecast begins. Eg, '6 AM
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## hour Type
+
+`string`
+
+## hour Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^1?\d (A|P)M$
+```
+
+[try pattern](https://regexr.com/?expression=%5E1%3F%5Cd%20\(A%7CP\)M%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast-properties-time.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast-properties-time.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items/properties/time
+```
+
+The time at which this hourly forecast begins.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## time Type
+
+`string`
+
+## time Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast.md
@@ -1,0 +1,91 @@
+# Hourly forecast Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object` ([Hourly forecast](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast.md))
+
+# items Properties
+
+| Property      | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                       |
+| :------------ | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [time](#time) | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast-properties-time.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items/properties/time") |
+| [hour](#hour) | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast-properties-hour.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items/properties/hour") |
+| [icon](#icon) | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-icon.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items/properties/icon")                                                                                                                                 |
+
+## time
+
+The time at which this hourly forecast begins.
+
+`time`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast-properties-time.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items/properties/time")
+
+### time Type
+
+`string`
+
+### time Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## hour
+
+Human-friendly hour when the hourly forecast begins. Eg, '6 AM
+
+`hour`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast-properties-hour.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items/properties/hour")
+
+### hour Type
+
+`string`
+
+### hour Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^1?\d (A|P)M$
+```
+
+[try pattern](https://regexr.com/?expression=%5E1%3F%5Cd%20\(A%7CP\)M%24 "try regular expression with regexr.com")
+
+## icon
+
+Information about the icon that represents this forecast period's conditions.
+
+`icon`
+
+* is optional
+
+* Type: `object` ([Icon](interop-layer-defs-icon.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-icon.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours/items/properties/icon")
+
+### icon Type
+
+`object` ([Icon](interop-layer-defs-icon.md))

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts.md
@@ -1,0 +1,15 @@
+# List of hourly forecasts Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours
+```
+
+Hourly forecast for each hour of this daily forecast period. The full list of properties is not provided here as it is taken directly from the NWS public API and is not controlled by weather.gov. The properties listed below are created by weather.gov and are the only guaranteed properties.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## hours Type
+
+`object[]` ([Hourly forecast](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast.md))

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-allof-0.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-allof-0.md
@@ -1,0 +1,15 @@
+# Untitled undefined type in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/allOf/0
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## 0 Type
+
+unknown

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-end.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-end.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/end
+```
+
+The ending time for this QPF forecast.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## end Type
+
+`string`
+
+## end Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-endhour.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-endhour.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/endHour
+```
+
+The ending hour in the timezone of the forecast, in AM/PM.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## endHour Type
+
+`string`
+
+## endHour Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^1?\d (A|P)M$
+```
+
+[try pattern](https://regexr.com/?expression=%5E1%3F%5Cd%20\(A%7CP\)M%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-start.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-start.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/start
+```
+
+The starting time for this QPF forecast.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## start Type
+
+`string`
+
+## start Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-starthour.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-starthour.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/startHour
+```
+
+The starting hour in the timezone of the forecast, in AM/PM.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## startHour Type
+
+`string`
+
+## startHour Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^1?\d (A|P)M$
+```
+
+[try pattern](https://regexr.com/?expression=%5E1%3F%5Cd%20\(A%7CP\)M%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf.md
@@ -1,0 +1,124 @@
+# QPF Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object` ([QPF](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf.md))
+
+# items Properties
+
+| Property                | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                              |
+| :---------------------- | :------- | :------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [start](#start)         | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-start.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/start")         |
+| [end](#end)             | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-end.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/end")             |
+| [startHour](#starthour) | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-starthour.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/startHour") |
+| [endHour](#endhour)     | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-endhour.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/endHour")     |
+
+## start
+
+The starting time for this QPF forecast.
+
+`start`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-start.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/start")
+
+### start Type
+
+`string`
+
+### start Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## end
+
+The ending time for this QPF forecast.
+
+`end`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-end.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/end")
+
+### end Type
+
+`string`
+
+### end Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## startHour
+
+The starting hour in the timezone of the forecast, in AM/PM.
+
+`startHour`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-starthour.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/startHour")
+
+### startHour Type
+
+`string`
+
+### startHour Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^1?\d (A|P)M$
+```
+
+[try pattern](https://regexr.com/?expression=%5E1%3F%5Cd%20\(A%7CP\)M%24 "try regular expression with regexr.com")
+
+## endHour
+
+The ending hour in the timezone of the forecast, in AM/PM.
+
+`endHour`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf-properties-endhour.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf/items/properties/endHour")
+
+### endHour Type
+
+`string`
+
+### endHour Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^1?\d (A|P)M$
+```
+
+[try pattern](https://regexr.com/?expression=%5E1%3F%5Cd%20\(A%7CP\)M%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs.md
@@ -1,0 +1,19 @@
+# List of hourly QPFs Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf
+```
+
+Forecast quantitative precipitation for this forecast period. Note that QPF is delivered in multi-hour totals rather than individual-hour totals, so it must be treated differently than other forecast period data.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## qpf Type
+
+`object[]` ([QPF](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf.md))
+
+all of
+
+* [Untitled undefined type in weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-allof-0.md "check type definition")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-start.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-start.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/start
+```
+
+The starting time for this daily forecast.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## start Type
+
+`string`
+
+## start Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast.md
@@ -1,0 +1,146 @@
+# Daily forecast Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object` ([Daily forecast](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast.md))
+
+# items Properties
+
+| Property            | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                         |
+| :------------------ | :------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [start](#start)     | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-start.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/start")                            |
+| [end](#end)         | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-end.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/end")                                |
+| [periods](#periods) | `array`  | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods") |
+| [qpf](#qpf)         | Merged   | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf")                |
+| [hours](#hours)     | `array`  | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours")         |
+| [alerts](#alerts)   | `object` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts")           |
+
+## start
+
+The starting time for this daily forecast.
+
+`start`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-start.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/start")
+
+### start Type
+
+`string`
+
+### start Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## end
+
+The ending time for this daily forecast.
+
+`end`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-end.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/end")
+
+### end Type
+
+`string`
+
+### end Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## periods
+
+The periods of the daily forecast, such as overnight, day, and night.
+
+`periods`
+
+* is required
+
+* Type: `object[]` ([Daily forecast period](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/periods")
+
+### periods Type
+
+`object[]` ([Daily forecast period](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-daily-forecast-periods-daily-forecast-period.md))
+
+## qpf
+
+Forecast quantitative precipitation for this forecast period. Note that QPF is delivered in multi-hour totals rather than individual-hour totals, so it must be treated differently than other forecast period data.
+
+`qpf`
+
+* is required
+
+* Type: `object[]` ([QPF](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/qpf")
+
+### qpf Type
+
+`object[]` ([QPF](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-qpf.md))
+
+all of
+
+* [Untitled undefined type in weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-qpfs-allof-0.md "check type definition")
+
+## hours
+
+Hourly forecast for each hour of this daily forecast period. The full list of properties is not provided here as it is taken directly from the NWS public API and is not controlled by weather.gov. The properties listed below are created by weather.gov and are the only guaranteed properties.
+
+`hours`
+
+* is required
+
+* Type: `object[]` ([Hourly forecast](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/hours")
+
+### hours Type
+
+`object[]` ([Hourly forecast](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-list-of-hourly-forecasts-hourly-forecast.md))
+
+## alerts
+
+Information about alerts that are valid during this forecast day.
+
+`alerts`
+
+* is required
+
+* Type: `object` ([Daily forecast alerts](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days/items/properties/alerts")
+
+### alerts Type
+
+`object` ([Daily forecast alerts](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast-properties-daily-forecast-alerts.md))

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-list-of-daily-forecasts.md
@@ -1,0 +1,15 @@
+# List of daily forecasts Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/days
+```
+
+The daily forecasts for each day in the forecast period.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## days Type
+
+`object[]` ([Daily forecast](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast.md))

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-updated.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-updated.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/updated
+```
+
+When the forecast was last updated.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## updated Type
+
+`string`
+
+## updated Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-forecast-properties-valid.md
+++ b/docs/dev/interop/interop-layer-properties-forecast-properties-valid.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast/properties/valid
+```
+
+When the forecast is valid. This is a combination of ISO 8601 date-time and duration, in the form 'date-time/duration'.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## valid Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-forecast.md
+++ b/docs/dev/interop/interop-layer-properties-forecast.md
@@ -1,0 +1,104 @@
+# Forecast Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/forecast
+```
+
+Forecast for this point.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## forecast Type
+
+`object` ([Forecast](interop-layer-properties-forecast.md))
+
+# forecast Properties
+
+| Property                | Type     | Required | Nullable       | Defined by                                                                                                                                                                                       |
+| :---------------------- | :------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [generated](#generated) | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-generated.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/generated")          |
+| [updated](#updated)     | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-updated.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/updated")              |
+| [valid](#valid)         | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-valid.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/valid")                  |
+| [days](#days)           | `array`  | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days") |
+
+## generated
+
+When the forecast was generated.
+
+`generated`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-generated.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/generated")
+
+### generated Type
+
+`string`
+
+### generated Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## updated
+
+When the forecast was last updated.
+
+`updated`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-updated.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/updated")
+
+### updated Type
+
+`string`
+
+### updated Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## valid
+
+When the forecast is valid. This is a combination of ISO 8601 date-time and duration, in the form 'date-time/duration'.
+
+`valid`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-valid.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/valid")
+
+### valid Type
+
+`string`
+
+## days
+
+The daily forecasts for each day in the forecast period.
+
+`days`
+
+* is required
+
+* Type: `object[]` ([Daily forecast](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast-properties-list-of-daily-forecasts.md "https://weather.gov/interop.schema.json#/properties/forecast/properties/days")
+
+### days Type
+
+`object[]` ([Daily forecast](interop-layer-properties-forecast-properties-list-of-daily-forecasts-daily-forecast.md))

--- a/docs/dev/interop/interop-layer-properties-nws-grid-properties-geometry.md
+++ b/docs/dev/interop/interop-layer-properties-nws-grid-properties-geometry.md
@@ -1,0 +1,15 @@
+# Untitled undefined type in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/grid/properties/geometry
+```
+
+GeoJSON Polygon representing the area covered by this WFO grid cell.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## geometry Type
+
+unknown

--- a/docs/dev/interop/interop-layer-properties-nws-grid-properties-wfo.md
+++ b/docs/dev/interop/interop-layer-properties-nws-grid-properties-wfo.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/grid/properties/wfo
+```
+
+The NWS weather forecasting office (WFO) that serves this point.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## wfo Type
+
+`string`
+
+## wfo Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^[A-Z]{3}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5BA-Z%5D%7B3%7D%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-nws-grid-properties-x.md
+++ b/docs/dev/interop/interop-layer-properties-nws-grid-properties-x.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/grid/properties/x
+```
+
+WFO grid X coordinate.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## x Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-nws-grid-properties-y.md
+++ b/docs/dev/interop/interop-layer-properties-nws-grid-properties-y.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/grid/properties/y
+```
+
+WFO grid Y coordinate.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## y Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-nws-grid.md
+++ b/docs/dev/interop/interop-layer-properties-nws-grid.md
@@ -1,0 +1,125 @@
+# NWS Grid Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/grid
+```
+
+The NWS grid cell that this point falls in.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## grid Type
+
+`object` ([NWS Grid](interop-layer-properties-nws-grid.md))
+
+# grid Properties
+
+| Property                | Type          | Required | Nullable       | Defined by                                                                                                                                                                        |
+| :---------------------- | :------------ | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [wfo](#wfo)             | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-nws-grid-properties-wfo.md "https://weather.gov/interop.schema.json#/properties/grid/properties/wfo")           |
+| [x](#x)                 | `integer`     | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-nws-grid-properties-x.md "https://weather.gov/interop.schema.json#/properties/grid/properties/x")               |
+| [y](#y)                 | `integer`     | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-nws-grid-properties-y.md "https://weather.gov/interop.schema.json#/properties/grid/properties/y")               |
+| [geometry](#geometry)   | Not specified | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-nws-grid-properties-geometry.md "https://weather.gov/interop.schema.json#/properties/grid/properties/geometry") |
+| [elevation](#elevation) | `object`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-distance.md "https://weather.gov/interop.schema.json#/properties/grid/properties/elevation")                 |
+
+## wfo
+
+The NWS weather forecasting office (WFO) that serves this point.
+
+`wfo`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-nws-grid-properties-wfo.md "https://weather.gov/interop.schema.json#/properties/grid/properties/wfo")
+
+### wfo Type
+
+`string`
+
+### wfo Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^[A-Z]{3}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5BA-Z%5D%7B3%7D%24 "try regular expression with regexr.com")
+
+## x
+
+WFO grid X coordinate.
+
+`x`
+
+* is required
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-nws-grid-properties-x.md "https://weather.gov/interop.schema.json#/properties/grid/properties/x")
+
+### x Type
+
+`integer`
+
+## y
+
+WFO grid Y coordinate.
+
+`y`
+
+* is required
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-nws-grid-properties-y.md "https://weather.gov/interop.schema.json#/properties/grid/properties/y")
+
+### y Type
+
+`integer`
+
+## geometry
+
+GeoJSON Polygon representing the area covered by this WFO grid cell.
+
+`geometry`
+
+* is required
+
+* Type: unknown
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-nws-grid-properties-geometry.md "https://weather.gov/interop.schema.json#/properties/grid/properties/geometry")
+
+### geometry Type
+
+unknown
+
+## elevation
+
+Elevation of this grid point.
+
+`elevation`
+
+* is required
+
+* Type: `object` ([Distance](interop-layer-defs-measures-distance.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-distance.md "https://weather.gov/interop.schema.json#/properties/grid/properties/elevation")
+
+### elevation Type
+
+`object` ([Distance](interop-layer-defs-measures-distance.md))

--- a/docs/dev/interop/interop-layer-properties-observations-properties-description.md
+++ b/docs/dev/interop/interop-layer-properties-observations-properties-description.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/observed/properties/description
+```
+
+Textual description of the observed conditions, if available.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## description Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-observations-properties-observation-data.md
+++ b/docs/dev/interop/interop-layer-properties-observations-properties-observation-data.md
@@ -1,0 +1,15 @@
+# Observation data Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/observed/properties/data
+```
+
+The observed data. The full list of properties is not provided here as it is taken directly from the NWS public API and is not controlled by weather.gov. The data provided by the NWS public API is converted into US and SI units.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## data Type
+
+`object` ([Observation data](interop-layer-properties-observations-properties-observation-data.md))

--- a/docs/dev/interop/interop-layer-properties-observations-properties-observation-station-properties-id.md
+++ b/docs/dev/interop/interop-layer-properties-observations-properties-observation-station-properties-id.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/id
+```
+
+The 4-character ID for the observation station.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## id Type
+
+`string`
+
+## id Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^[A-Z0-9]{4}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5BA-Z0-9%5D%7B4%7D%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-observations-properties-observation-station-properties-name.md
+++ b/docs/dev/interop/interop-layer-properties-observations-properties-observation-station-properties-name.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/name
+```
+
+The full name of the observation station.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## name Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-observations-properties-observation-station.md
+++ b/docs/dev/interop/interop-layer-properties-observations-properties-observation-station.md
@@ -1,0 +1,106 @@
+# Observation station Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/observed/properties/station
+```
+
+Metadata about the observation station that reported this data.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## station Type
+
+`object` ([Observation station](interop-layer-properties-observations-properties-observation-station.md))
+
+# station Properties
+
+| Property                | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                          |
+| :---------------------- | :------- | :------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [id](#id)               | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-observations-properties-observation-station-properties-id.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/id")     |
+| [name](#name)           | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-observations-properties-observation-station-properties-name.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/name") |
+| [elevation](#elevation) | `object` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-distance.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/elevation")                                            |
+| [distance](#distance)   | `object` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-measures-distance.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/distance")                                             |
+
+## id
+
+The 4-character ID for the observation station.
+
+`id`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-observations-properties-observation-station-properties-id.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/id")
+
+### id Type
+
+`string`
+
+### id Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^[A-Z0-9]{4}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5BA-Z0-9%5D%7B4%7D%24 "try regular expression with regexr.com")
+
+## name
+
+The full name of the observation station.
+
+`name`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-observations-properties-observation-station-properties-name.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/name")
+
+### name Type
+
+`string`
+
+## elevation
+
+The elevation at the observation station.
+
+`elevation`
+
+* is required
+
+* Type: `object` ([Distance](interop-layer-defs-measures-distance.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-distance.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/elevation")
+
+### elevation Type
+
+`object` ([Distance](interop-layer-defs-measures-distance.md))
+
+## distance
+
+The flat-ground distance between the observation station and the requested point.
+
+`distance`
+
+* is required
+
+* Type: `object` ([Distance](interop-layer-defs-measures-distance.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-measures-distance.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station/properties/distance")
+
+### distance Type
+
+`object` ([Distance](interop-layer-defs-measures-distance.md))

--- a/docs/dev/interop/interop-layer-properties-observations-properties-timestamp.md
+++ b/docs/dev/interop/interop-layer-properties-observations-properties-timestamp.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/observed/properties/timestamp
+```
+
+When the observation was recorded.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## timestamp Type
+
+`string`
+
+## timestamp Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-observations.md
+++ b/docs/dev/interop/interop-layer-properties-observations.md
@@ -1,0 +1,119 @@
+# Observations Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/observed
+```
+
+Most-recently observed conditions for this location from the nearest approved observation station.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## observed Type
+
+`object` ([Observations](interop-layer-properties-observations.md))
+
+# observed Properties
+
+| Property                    | Type     | Required | Nullable       | Defined by                                                                                                                                                                                          |
+| :-------------------------- | :------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [timestamp](#timestamp)     | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-observations-properties-timestamp.md "https://weather.gov/interop.schema.json#/properties/observed/properties/timestamp")         |
+| [icon](#icon)               | `object` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-icon.md "https://weather.gov/interop.schema.json#/properties/observed/properties/icon")                                                 |
+| [description](#description) | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-observations-properties-description.md "https://weather.gov/interop.schema.json#/properties/observed/properties/description")     |
+| [station](#station)         | `object` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-observations-properties-observation-station.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station") |
+| [data](#data)               | `object` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-observations-properties-observation-data.md "https://weather.gov/interop.schema.json#/properties/observed/properties/data")       |
+
+## timestamp
+
+When the observation was recorded.
+
+`timestamp`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-observations-properties-timestamp.md "https://weather.gov/interop.schema.json#/properties/observed/properties/timestamp")
+
+### timestamp Type
+
+`string`
+
+### timestamp Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## icon
+
+Information about the icon that represents this forecast period's conditions.
+
+`icon`
+
+* is required
+
+* Type: `object` ([Icon](interop-layer-defs-icon.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-icon.md "https://weather.gov/interop.schema.json#/properties/observed/properties/icon")
+
+### icon Type
+
+`object` ([Icon](interop-layer-defs-icon.md))
+
+## description
+
+Textual description of the observed conditions, if available.
+
+`description`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-observations-properties-description.md "https://weather.gov/interop.schema.json#/properties/observed/properties/description")
+
+### description Type
+
+`string`
+
+## station
+
+Metadata about the observation station that reported this data.
+
+`station`
+
+* is required
+
+* Type: `object` ([Observation station](interop-layer-properties-observations-properties-observation-station.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-observations-properties-observation-station.md "https://weather.gov/interop.schema.json#/properties/observed/properties/station")
+
+### station Type
+
+`object` ([Observation station](interop-layer-properties-observations-properties-observation-station.md))
+
+## data
+
+The observed data. The full list of properties is not provided here as it is taken directly from the NWS public API and is not controlled by weather.gov. The data provided by the NWS public API is converted into US and SI units.
+
+`data`
+
+* is required
+
+* Type: `object` ([Observation data](interop-layer-properties-observations-properties-observation-data.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-observations-properties-observation-data.md "https://weather.gov/interop.schema.json#/properties/observed/properties/data")
+
+### data Type
+
+`object` ([Observation data](interop-layer-properties-observations-properties-observation-data.md))

--- a/docs/dev/interop/interop-layer-properties-place-properties-county.md
+++ b/docs/dev/interop/interop-layer-properties-place-properties-county.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/place/properties/county
+```
+
+Full name of the county.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## county Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-place-properties-countyfips.md
+++ b/docs/dev/interop/interop-layer-properties-place-properties-countyfips.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/place/properties/countyFIPS
+```
+
+5-digit FIPS code for this county. Note that this value has the state FIPS code prepended to the usual 3-digit county FIPS code.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## countyFIPS Type
+
+`string`
+
+## countyFIPS Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^\d{5}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5Cd%7B5%7D%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-place-properties-fullname.md
+++ b/docs/dev/interop/interop-layer-properties-place-properties-fullname.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/place/properties/fullName
+```
+
+The full name of this place, with state or territory abbreviation.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## fullName Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-place-properties-name.md
+++ b/docs/dev/interop/interop-layer-properties-place-properties-name.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/place/properties/name
+```
+
+City or other municipal name.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## name Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-place-properties-state.md
+++ b/docs/dev/interop/interop-layer-properties-place-properties-state.md
@@ -1,0 +1,21 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/place/properties/state
+```
+
+2-letter abbreviation of the state or territory.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## state Type
+
+`string`
+
+## state Constraints
+
+**maximum length**: the maximum number of characters for this string is: `2`
+
+**minimum length**: the minimum number of characters for this string is: `2`

--- a/docs/dev/interop/interop-layer-properties-place-properties-statefips.md
+++ b/docs/dev/interop/interop-layer-properties-place-properties-statefips.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/place/properties/stateFIPS
+```
+
+2-digit FIPS code for this state.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## stateFIPS Type
+
+`string`
+
+## stateFIPS Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^\d{2}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5Cd%7B2%7D%24 "try regular expression with regexr.com")

--- a/docs/dev/interop/interop-layer-properties-place-properties-statename.md
+++ b/docs/dev/interop/interop-layer-properties-place-properties-statename.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/place/properties/stateName
+```
+
+Full name of the state.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## stateName Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-place-properties-timezone.md
+++ b/docs/dev/interop/interop-layer-properties-place-properties-timezone.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/place/properties/timezone
+```
+
+Full tzdb name of the timezone at this point, as best we know.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## timezone Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-place.md
+++ b/docs/dev/interop/interop-layer-properties-place.md
@@ -1,0 +1,198 @@
+# Place Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/place
+```
+
+Information about the place at the described point, as close as we know.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## place Type
+
+`object` ([Place](interop-layer-properties-place.md))
+
+# place Properties
+
+| Property                  | Type     | Required | Nullable       | Defined by                                                                                                                                                                          |
+| :------------------------ | :------- | :------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [name](#name)             | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-place-properties-name.md "https://weather.gov/interop.schema.json#/properties/place/properties/name")             |
+| [state](#state)           | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-place-properties-state.md "https://weather.gov/interop.schema.json#/properties/place/properties/state")           |
+| [stateName](#statename)   | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-place-properties-statename.md "https://weather.gov/interop.schema.json#/properties/place/properties/stateName")   |
+| [county](#county)         | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-place-properties-county.md "https://weather.gov/interop.schema.json#/properties/place/properties/county")         |
+| [timezone](#timezone)     | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-place-properties-timezone.md "https://weather.gov/interop.schema.json#/properties/place/properties/timezone")     |
+| [stateFIPS](#statefips)   | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-place-properties-statefips.md "https://weather.gov/interop.schema.json#/properties/place/properties/stateFIPS")   |
+| [countyFIPS](#countyfips) | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-place-properties-countyfips.md "https://weather.gov/interop.schema.json#/properties/place/properties/countyFIPS") |
+| [fullName](#fullname)     | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-place-properties-fullname.md "https://weather.gov/interop.schema.json#/properties/place/properties/fullName")     |
+
+## name
+
+City or other municipal name.
+
+`name`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-place-properties-name.md "https://weather.gov/interop.schema.json#/properties/place/properties/name")
+
+### name Type
+
+`string`
+
+## state
+
+2-letter abbreviation of the state or territory.
+
+`state`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-place-properties-state.md "https://weather.gov/interop.schema.json#/properties/place/properties/state")
+
+### state Type
+
+`string`
+
+### state Constraints
+
+**maximum length**: the maximum number of characters for this string is: `2`
+
+**minimum length**: the minimum number of characters for this string is: `2`
+
+## stateName
+
+Full name of the state.
+
+`stateName`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-place-properties-statename.md "https://weather.gov/interop.schema.json#/properties/place/properties/stateName")
+
+### stateName Type
+
+`string`
+
+## county
+
+Full name of the county.
+
+`county`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-place-properties-county.md "https://weather.gov/interop.schema.json#/properties/place/properties/county")
+
+### county Type
+
+`string`
+
+## timezone
+
+Full tzdb name of the timezone at this point, as best we know.
+
+`timezone`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-place-properties-timezone.md "https://weather.gov/interop.schema.json#/properties/place/properties/timezone")
+
+### timezone Type
+
+`string`
+
+## stateFIPS
+
+2-digit FIPS code for this state.
+
+`stateFIPS`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-place-properties-statefips.md "https://weather.gov/interop.schema.json#/properties/place/properties/stateFIPS")
+
+### stateFIPS Type
+
+`string`
+
+### stateFIPS Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^\d{2}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5Cd%7B2%7D%24 "try regular expression with regexr.com")
+
+## countyFIPS
+
+5-digit FIPS code for this county. Note that this value has the state FIPS code prepended to the usual 3-digit county FIPS code.
+
+`countyFIPS`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-place-properties-countyfips.md "https://weather.gov/interop.schema.json#/properties/place/properties/countyFIPS")
+
+### countyFIPS Type
+
+`string`
+
+### countyFIPS Constraints
+
+**pattern**: the string must match the following regular expression:&#x20;
+
+```regexp
+^\d{5}$
+```
+
+[try pattern](https://regexr.com/?expression=%5E%5Cd%7B5%7D%24 "try regular expression with regexr.com")
+
+## fullName
+
+The full name of this place, with state or territory abbreviation.
+
+`fullName`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-place-properties-fullname.md "https://weather.gov/interop.schema.json#/properties/place/properties/fullName")
+
+### fullName Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-highestlevel.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-highestlevel.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/highestLevel
+```
+
+The alert level, as defined by weather.gov.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## highestLevel Type
+
+`string`
+
+## highestLevel Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-cities-items.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-cities-items.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/cities/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-cities.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-cities.md
@@ -1,0 +1,15 @@
+# List of cities Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/cities
+```
+
+A list of cities impacted by this alert, as derived from the alert description.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## cities Type
+
+`string[]`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-area.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-area.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items/properties/area
+```
+
+The name of a state region covered by this alert, as derived from the alert description.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## area Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-list-of-counties-items.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-list-of-counties-items.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items/properties/counties/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-list-of-counties.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-list-of-counties.md
@@ -1,0 +1,15 @@
+# List of counties Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items/properties/counties
+```
+
+A list of counties within this state region covered by this alert, as derived from the alert description.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## counties Type
+
+`string[]`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location.md
@@ -1,0 +1,58 @@
+# Alert location Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object` ([Alert location](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location.md))
+
+# items Properties
+
+| Property              | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                                                                |
+| :-------------------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [area](#area)         | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-area.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items/properties/area")                 |
+| [counties](#counties) | `array`  | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-list-of-counties.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items/properties/counties") |
+
+## area
+
+The name of a state region covered by this alert, as derived from the alert description.
+
+`area`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-area.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items/properties/area")
+
+### area Type
+
+`string`
+
+## counties
+
+A list of counties within this state region covered by this alert, as derived from the alert description.
+
+`counties`
+
+* is required
+
+* Type: `string[]`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location-properties-list-of-counties.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions/items/properties/counties")
+
+### counties Type
+
+`string[]`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions.md
@@ -1,0 +1,15 @@
+# List of regions Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions
+```
+
+A list of state regions covered by this alert, as derived from the alert description.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## regions Type
+
+`object[]` ([Alert location](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location.md))

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations.md
@@ -1,0 +1,58 @@
+# Alert locations Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations
+```
+
+A list of counties by state region and cities, if an alert description includes embedded location information.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## locations Type
+
+`object` ([Alert locations](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations.md))
+
+# locations Properties
+
+| Property            | Type    | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                           |
+| :------------------ | :------ | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [regions](#regions) | `array` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions") |
+| [cities](#cities)   | `array` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-cities.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/cities")   |
+
+## regions
+
+A list of state regions covered by this alert, as derived from the alert description.
+
+`regions`
+
+* is required
+
+* Type: `object[]` ([Alert location](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/regions")
+
+### regions Type
+
+`object[]` ([Alert location](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-regions-alert-location.md))
+
+## cities
+
+A list of cities impacted by this alert, as derived from the alert description.
+
+`cities`
+
+* is required
+
+* Type: `string[]`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations-properties-list-of-cities.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations/properties/cities")
+
+### cities Type
+
+`string[]`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level-properties-priority.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level-properties-priority.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level/properties/priority
+```
+
+The priority of this alert relative to others. Lower numbers are higher priority.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## priority Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level-properties-text.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level-properties-text.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level/properties/text
+```
+
+The alert level, as defined by weather.gov.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## text Type
+
+`string`
+
+## text Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level.md
@@ -1,0 +1,68 @@
+# Alert level Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level
+```
+
+Alert level information
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## level Type
+
+`object` ([Alert level](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level.md))
+
+# level Properties
+
+| Property              | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                           |
+| :-------------------- | :-------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [priority](#priority) | `integer` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level-properties-priority.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level/properties/priority") |
+| [text](#text)         | `string`  | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level-properties-text.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level/properties/text")         |
+
+## priority
+
+The priority of this alert relative to others. Lower numbers are higher priority.
+
+`priority`
+
+* is required
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level-properties-priority.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level/properties/priority")
+
+### priority Type
+
+`integer`
+
+## text
+
+The alert level, as defined by weather.gov.
+
+`text`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level-properties-text.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level/properties/text")
+
+### text Type
+
+`string`
+
+### text Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-kind.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-kind.md
@@ -1,0 +1,25 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/kind
+```
+
+The alert level, as defined by weather.gov.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## kind Type
+
+`string`
+
+## kind Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-priority.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-priority.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/priority
+```
+
+The priority of this alert relative to others. Lower numbers are higher priority.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## priority Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata.md
@@ -1,0 +1,87 @@
+# Alert metadata Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata
+```
+
+Prioritization and categorization metadata
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## metadata Type
+
+`object` ([Alert metadata](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata.md))
+
+# metadata Properties
+
+| Property              | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                   |
+| :-------------------- | :-------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [level](#level)       | `object`  | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level") |
+| [kind](#kind)         | `string`  | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-kind.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/kind")         |
+| [priority](#priority) | `integer` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-priority.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/priority") |
+
+## level
+
+Alert level information
+
+`level`
+
+* is required
+
+* Type: `object` ([Alert level](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/level")
+
+### level Type
+
+`object` ([Alert level](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-alert-level.md))
+
+## kind
+
+The alert level, as defined by weather.gov.
+
+`kind`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-kind.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/kind")
+
+### kind Type
+
+`string`
+
+### kind Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |
+
+## priority
+
+The priority of this alert relative to others. Lower numbers are higher priority.
+
+`priority`
+
+* is required
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata-properties-priority.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata/properties/priority")
+
+### priority Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing-properties-end.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing-properties-end.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing/properties/end
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## end Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing-properties-start.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing-properties-start.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing/properties/start
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## start Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing.md
@@ -1,0 +1,58 @@
+# Alert timing Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing
+```
+
+Human-friendly text describing the beginning and completion of the alert, based on the timezone of the alert area.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## timing Type
+
+`object` ([Alert timing](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing.md))
+
+# timing Properties
+
+| Property        | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                         |
+| :-------------- | :------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [start](#start) | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing-properties-start.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing/properties/start") |
+| [end](#end)     | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing-properties-end.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing/properties/end")     |
+
+## start
+
+
+
+`start`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing-properties-start.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing/properties/start")
+
+### start Type
+
+`string`
+
+## end
+
+
+
+`end`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing-properties-end.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing/properties/end")
+
+### end Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-duration.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-duration.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/duration
+```
+
+When the alert will no longer be displayed on weather.gov, in human-friendly text based on the timezone of the alert area.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## duration Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-effective.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-effective.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/effective
+```
+
+When the alert becomes effective.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## effective Type
+
+`string`
+
+## effective Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-ends.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-ends.md
@@ -1,0 +1,19 @@
+# Untitled undefined type in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/ends
+```
+
+When the conditions described in the alert are forecast to end.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## ends Type
+
+`string`
+
+## ends Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-event.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-event.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/event
+```
+
+The alert event, such as 'Severe Thunderstorm Warning.'
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## event Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-expires.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-expires.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/expires
+```
+
+When the alert will expire. NOTE: this is NOT when the hazardous conditions are forecast to end.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## expires Type
+
+`string`
+
+## expires Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-finish.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-finish.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/finish
+```
+
+When the alert will no longer displayed on weather.gov, as derived from the expires and ends properties.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## finish Type
+
+`string`
+
+## finish Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-geometry.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-geometry.md
@@ -1,0 +1,15 @@
+# Untitled undefined type in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/geometry
+```
+
+GeoJSON GeometryCollection representing the area covered by this alert.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## geometry Type
+
+unknown

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-id.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-id.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/id
+```
+
+ID of this alert. NOTE: may not be globally unique
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## id Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-instruction.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-instruction.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/instruction
+```
+
+Safety instructions associated with the alert
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## instruction Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-areas-items.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-areas-items.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/area/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-areas.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-areas.md
@@ -1,0 +1,15 @@
+# List of areas Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/area
+```
+
+A list of areas affected by this alert, as provided by the origin.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## area Type
+
+`string[]`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-external.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-external.md
@@ -1,0 +1,15 @@
+# Untitled boolean in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/external
+```
+
+For link nodes, whether the link is for a site outside of weather.gov.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## external Type
+
+`boolean`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-text.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-text.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/text
+```
+
+For text nodes, the textual content.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## text Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-type.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-type.md
@@ -1,0 +1,24 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/type
+```
+
+The type of in-paragraph content node.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## type Type
+
+`string`
+
+## type Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value    | Explanation |
+| :------- | :---------- |
+| `"text"` |             |
+| `"link"` |             |

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-url.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-url.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/url
+```
+
+For link nodes, the URL.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## url Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node.md
@@ -1,0 +1,105 @@
+# Parsed in-paragraph node Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object` ([Parsed in-paragraph node](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node.md))
+
+# items Properties
+
+| Property              | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| :-------------------- | :-------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [type](#type)         | `string`  | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-type.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/type")         |
+| [text](#text)         | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-text.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/text")         |
+| [url](#url)           | `string`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-url.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/url")           |
+| [external](#external) | `boolean` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-external.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/external") |
+
+## type
+
+The type of in-paragraph content node.
+
+`type`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-type.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/type")
+
+### type Type
+
+`string`
+
+### type Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value    | Explanation |
+| :------- | :---------- |
+| `"text"` |             |
+| `"link"` |             |
+
+## text
+
+For text nodes, the textual content.
+
+`text`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-text.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/text")
+
+### text Type
+
+`string`
+
+## url
+
+For link nodes, the URL.
+
+`url`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-url.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/url")
+
+### url Type
+
+`string`
+
+## external
+
+For link nodes, whether the link is for a site outside of weather.gov.
+
+`external`
+
+* is optional
+
+* Type: `boolean`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node-properties-external.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes/items/properties/external")
+
+### external Type
+
+`boolean`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes.md
@@ -1,0 +1,15 @@
+# List of parsed in-paragraph nodes Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes
+```
+
+For paragraph nodes, the list of content nodes that go into the paragraph.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## nodes Type
+
+`object[]` ([Parsed in-paragraph node](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node.md))

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-text.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-text.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/text
+```
+
+For heading nodes, the textual content of the node
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## text Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-type.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-type.md
@@ -1,0 +1,24 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/type
+```
+
+The kind of content node
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## type Type
+
+`string`
+
+## type Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value         | Explanation |
+| :------------ | :---------- |
+| `"heading"`   |             |
+| `"paragraph"` |             |

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node.md
@@ -1,0 +1,86 @@
+# Parsed content node Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object` ([Parsed content node](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node.md))
+
+# items Properties
+
+| Property        | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                                                    |
+| :-------------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [type](#type)   | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-type.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/type")                               |
+| [nodes](#nodes) | `array`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes") |
+| [text](#text)   | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-text.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/text")                               |
+
+## type
+
+The kind of content node
+
+`type`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-type.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/type")
+
+### type Type
+
+`string`
+
+### type Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value         | Explanation |
+| :------------ | :---------- |
+| `"heading"`   |             |
+| `"paragraph"` |             |
+
+## nodes
+
+For paragraph nodes, the list of content nodes that go into the paragraph.
+
+`nodes`
+
+* is optional
+
+* Type: `object[]` ([Parsed in-paragraph node](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/nodes")
+
+### nodes Type
+
+`object[]` ([Parsed in-paragraph node](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-list-of-parsed-in-paragraph-nodes-parsed-in-paragraph-node.md))
+
+## text
+
+For heading nodes, the textual content of the node
+
+`text`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node-properties-text.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description/items/properties/text")
+
+### text Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes.md
@@ -1,0 +1,15 @@
+# List of parsed content nodes Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description
+```
+
+The alert description, parsed into content nodes.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## description Type
+
+`object[]` ([Parsed content node](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node.md))

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-onset.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-onset.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/onset
+```
+
+When the conditions described in the alert are forecast to begin.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## onset Type
+
+`string`
+
+## onset Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-sender.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-sender.md
@@ -1,0 +1,15 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/sender
+```
+
+The government office responsible for issuing this alert. Usually a NWS office, but sometimes state or local civil authorities.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## sender Type
+
+`string`

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-sent.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-sent.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/sent
+```
+
+When the alert was initially sent.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## sent Type
+
+`string`
+
+## sent Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts-alert.md
@@ -1,0 +1,367 @@
+# Alert Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object` ([Alert](interop-layer-properties-point-alerts-properties-list-of-alerts-alert.md))
+
+# items Properties
+
+| Property                    | Type          | Required | Nullable       | Defined by                                                                                                                                                                                                                                                            |
+| :-------------------------- | :------------ | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [metadata](#metadata)       | `object`      | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata")                  |
+| [id](#id)                   | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-id.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/id")                                    |
+| [event](#event)             | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-event.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/event")                              |
+| [sender](#sender)           | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-sender.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/sender")                            |
+| [locations](#locations)     | `object`      | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations")                |
+| [description](#description) | `array`       | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description") |
+| [instruction](#instruction) | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-instruction.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/instruction")                  |
+| [area](#area)               | `array`       | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-areas.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/area")                       |
+| [sent](#sent)               | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-sent.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/sent")                                |
+| [effective](#effective)     | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-effective.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/effective")                      |
+| [onset](#onset)             | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-onset.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/onset")                              |
+| [expires](#expires)         | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-expires.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/expires")                          |
+| [ends](#ends)               | `string`      | Required | can be null    | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-ends.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/ends")                                |
+| [finish](#finish)           | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-finish.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/finish")                            |
+| [geometry](#geometry)       | Not specified | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-geometry.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/geometry")                        |
+| [duration](#duration)       | `string`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-duration.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/duration")                        |
+| [timing](#timing)           | `object`      | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing")                      |
+
+## metadata
+
+Prioritization and categorization metadata
+
+`metadata`
+
+* is optional
+
+* Type: `object` ([Alert metadata](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/metadata")
+
+### metadata Type
+
+`object` ([Alert metadata](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-metadata.md))
+
+## id
+
+ID of this alert. NOTE: may not be globally unique
+
+`id`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-id.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/id")
+
+### id Type
+
+`string`
+
+## event
+
+The alert event, such as 'Severe Thunderstorm Warning.'
+
+`event`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-event.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/event")
+
+### event Type
+
+`string`
+
+## sender
+
+The government office responsible for issuing this alert. Usually a NWS office, but sometimes state or local civil authorities.
+
+`sender`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-sender.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/sender")
+
+### sender Type
+
+`string`
+
+## locations
+
+A list of counties by state region and cities, if an alert description includes embedded location information.
+
+`locations`
+
+* is optional
+
+* Type: `object` ([Alert locations](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/locations")
+
+### locations Type
+
+`object` ([Alert locations](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-locations.md))
+
+## description
+
+The alert description, parsed into content nodes.
+
+`description`
+
+* is required
+
+* Type: `object[]` ([Parsed content node](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/description")
+
+### description Type
+
+`object[]` ([Parsed content node](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-parsed-content-nodes-parsed-content-node.md))
+
+## instruction
+
+Safety instructions associated with the alert
+
+`instruction`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-instruction.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/instruction")
+
+### instruction Type
+
+`string`
+
+## area
+
+A list of areas affected by this alert, as provided by the origin.
+
+`area`
+
+* is required
+
+* Type: `string[]`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-list-of-areas.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/area")
+
+### area Type
+
+`string[]`
+
+## sent
+
+When the alert was initially sent.
+
+`sent`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-sent.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/sent")
+
+### sent Type
+
+`string`
+
+### sent Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## effective
+
+When the alert becomes effective.
+
+`effective`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-effective.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/effective")
+
+### effective Type
+
+`string`
+
+### effective Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## onset
+
+When the conditions described in the alert are forecast to begin.
+
+`onset`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-onset.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/onset")
+
+### onset Type
+
+`string`
+
+### onset Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## expires
+
+When the alert will expire. NOTE: this is NOT when the hazardous conditions are forecast to end.
+
+`expires`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-expires.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/expires")
+
+### expires Type
+
+`string`
+
+### expires Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## ends
+
+When the conditions described in the alert are forecast to end.
+
+`ends`
+
+* is required
+
+* Type: `string`
+
+* can be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-ends.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/ends")
+
+### ends Type
+
+`string`
+
+### ends Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## finish
+
+When the alert will no longer displayed on weather.gov, as derived from the expires and ends properties.
+
+`finish`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-finish.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/finish")
+
+### finish Type
+
+`string`
+
+### finish Constraints
+
+**date time**: the string must be a date time string, according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339 "check the specification")
+
+## geometry
+
+GeoJSON GeometryCollection representing the area covered by this alert.
+
+`geometry`
+
+* is required
+
+* Type: unknown
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-geometry.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/geometry")
+
+### geometry Type
+
+unknown
+
+## duration
+
+When the alert will no longer be displayed on weather.gov, in human-friendly text based on the timezone of the alert area.
+
+`duration`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-duration.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/duration")
+
+### duration Type
+
+`string`
+
+## timing
+
+Human-friendly text describing the beginning and completion of the alert, based on the timezone of the alert area.
+
+`timing`
+
+* is required
+
+* Type: `object` ([Alert timing](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items/items/properties/timing")
+
+### timing Type
+
+`object` ([Alert timing](interop-layer-properties-point-alerts-properties-list-of-alerts-alert-properties-alert-timing.md))

--- a/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts-properties-list-of-alerts.md
@@ -1,0 +1,15 @@
+# List of alerts Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts/properties/items
+```
+
+The alerts themselves
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## items Type
+
+`object[]` ([Alert](interop-layer-properties-point-alerts-properties-list-of-alerts-alert.md))

--- a/docs/dev/interop/interop-layer-properties-point-alerts.md
+++ b/docs/dev/interop/interop-layer-properties-point-alerts.md
@@ -1,0 +1,68 @@
+# Point alerts Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/alerts
+```
+
+Alerts that are applicable to the given lat/lon.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## alerts Type
+
+`object` ([Point alerts](interop-layer-properties-point-alerts.md))
+
+# alerts Properties
+
+| Property                      | Type     | Required | Nullable       | Defined by                                                                                                                                                                                      |
+| :---------------------------- | :------- | :------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [items](#items)               | `array`  | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items")      |
+| [highestLevel](#highestlevel) | `string` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-highestlevel.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/highestLevel") |
+
+## items
+
+The alerts themselves
+
+`items`
+
+* is required
+
+* Type: `object[]` ([Alert](interop-layer-properties-point-alerts-properties-list-of-alerts-alert.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-list-of-alerts.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/items")
+
+### items Type
+
+`object[]` ([Alert](interop-layer-properties-point-alerts-properties-list-of-alerts-alert.md))
+
+## highestLevel
+
+The alert level, as defined by weather.gov.
+
+`highestLevel`
+
+* is required
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts-properties-highestlevel.md "https://weather.gov/interop.schema.json#/properties/alerts/properties/highestLevel")
+
+### highestLevel Type
+
+`string`
+
+### highestLevel Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value       | Explanation |
+| :---------- | :---------- |
+| `"warning"` |             |
+| `"watch"`   |             |
+| `"other"`   |             |

--- a/docs/dev/interop/interop-layer-properties-point-properties-latitude.md
+++ b/docs/dev/interop/interop-layer-properties-point-properties-latitude.md
@@ -1,0 +1,21 @@
+# Untitled number in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/point/properties/latitude
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## latitude Type
+
+`number`
+
+## latitude Constraints
+
+**maximum**: the value of this number must smaller than or equal to: `90`
+
+**minimum**: the value of this number must greater than or equal to: `-90`

--- a/docs/dev/interop/interop-layer-properties-point-properties-longitude.md
+++ b/docs/dev/interop/interop-layer-properties-point-properties-longitude.md
@@ -1,0 +1,21 @@
+# Untitled number in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/point/properties/longitude
+```
+
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## longitude Type
+
+`number`
+
+## longitude Constraints
+
+**maximum**: the value of this number must smaller than or equal to: `360`
+
+**minimum**: the value of this number must greater than or equal to: `-360`

--- a/docs/dev/interop/interop-layer-properties-point.md
+++ b/docs/dev/interop/interop-layer-properties-point.md
@@ -1,0 +1,70 @@
+# Point Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/point
+```
+
+Information about the point
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## point Type
+
+`object` ([Point](interop-layer-properties-point.md))
+
+# point Properties
+
+| Property                | Type     | Required | Nullable       | Defined by                                                                                                                                                                        |
+| :---------------------- | :------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [latitude](#latitude)   | `number` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-properties-latitude.md "https://weather.gov/interop.schema.json#/properties/point/properties/latitude")   |
+| [longitude](#longitude) | `number` | Required | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-properties-longitude.md "https://weather.gov/interop.schema.json#/properties/point/properties/longitude") |
+
+## latitude
+
+
+
+`latitude`
+
+* is required
+
+* Type: `number`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-properties-latitude.md "https://weather.gov/interop.schema.json#/properties/point/properties/latitude")
+
+### latitude Type
+
+`number`
+
+### latitude Constraints
+
+**maximum**: the value of this number must smaller than or equal to: `90`
+
+**minimum**: the value of this number must greater than or equal to: `-90`
+
+## longitude
+
+
+
+`longitude`
+
+* is required
+
+* Type: `number`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-properties-longitude.md "https://weather.gov/interop.schema.json#/properties/point/properties/longitude")
+
+### longitude Type
+
+`number`
+
+### longitude Constraints
+
+**maximum**: the value of this number must smaller than or equal to: `360`
+
+**minimum**: the value of this number must greater than or equal to: `-360`

--- a/docs/dev/interop/interop-layer-properties-response-metadata-properties-response-timing-properties-e2e.md
+++ b/docs/dev/interop/interop-layer-properties-response-metadata-properties-response-timing-properties-e2e.md
@@ -1,0 +1,15 @@
+# Untitled number in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing/properties/e2e
+```
+
+Total time spent, in seconds.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## e2e Type
+
+`number`

--- a/docs/dev/interop/interop-layer-properties-response-metadata-properties-response-timing-properties-response-api-timing.md
+++ b/docs/dev/interop/interop-layer-properties-response-metadata-properties-response-timing-properties-response-api-timing.md
@@ -1,0 +1,15 @@
+# Response API timing Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing/properties/api
+```
+
+Time spent making and receiving each request and response to the NWS public API. Keys are the API URLs and values are the times in seconds.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## api Type
+
+`object` ([Response API timing](interop-layer-properties-response-metadata-properties-response-timing-properties-response-api-timing.md))

--- a/docs/dev/interop/interop-layer-properties-response-metadata-properties-response-timing.md
+++ b/docs/dev/interop/interop-layer-properties-response-metadata-properties-response-timing.md
@@ -1,0 +1,58 @@
+# Response timing Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing
+```
+
+The time spent answering the request.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## timing Type
+
+`object` ([Response timing](interop-layer-properties-response-metadata-properties-response-timing.md))
+
+# timing Properties
+
+| Property    | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                         |
+| :---------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [e2e](#e2e) | `number` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-response-metadata-properties-response-timing-properties-e2e.md "https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing/properties/e2e")                 |
+| [api](#api) | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-response-metadata-properties-response-timing-properties-response-api-timing.md "https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing/properties/api") |
+
+## e2e
+
+Total time spent, in seconds.
+
+`e2e`
+
+* is optional
+
+* Type: `number`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-response-metadata-properties-response-timing-properties-e2e.md "https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing/properties/e2e")
+
+### e2e Type
+
+`number`
+
+## api
+
+Time spent making and receiving each request and response to the NWS public API. Keys are the API URLs and values are the times in seconds.
+
+`api`
+
+* is optional
+
+* Type: `object` ([Response API timing](interop-layer-properties-response-metadata-properties-response-timing-properties-response-api-timing.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-response-metadata-properties-response-timing-properties-response-api-timing.md "https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing/properties/api")
+
+### api Type
+
+`object` ([Response API timing](interop-layer-properties-response-metadata-properties-response-timing-properties-response-api-timing.md))

--- a/docs/dev/interop/interop-layer-properties-response-metadata-properties-size.md
+++ b/docs/dev/interop/interop-layer-properties-response-metadata-properties-size.md
@@ -1,0 +1,15 @@
+# Untitled integer in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/@metadata/properties/size
+```
+
+The uncompressed size of the data being returned, excluding the metadata, in bytes.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## size Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-response-metadata.md
+++ b/docs/dev/interop/interop-layer-properties-response-metadata.md
@@ -1,0 +1,58 @@
+# Response metadata Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/@metadata
+```
+
+Metadata about the response itself.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## @metadata Type
+
+`object` ([Response metadata](interop-layer-properties-response-metadata.md))
+
+# @metadata Properties
+
+| Property          | Type      | Required | Nullable       | Defined by                                                                                                                                                                                           |
+| :---------------- | :-------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [timing](#timing) | `object`  | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-response-metadata-properties-response-timing.md "https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing") |
+| [size](#size)     | `integer` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-response-metadata-properties-size.md "https://weather.gov/interop.schema.json#/properties/@metadata/properties/size")              |
+
+## timing
+
+The time spent answering the request.
+
+`timing`
+
+* is optional
+
+* Type: `object` ([Response timing](interop-layer-properties-response-metadata-properties-response-timing.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-response-metadata-properties-response-timing.md "https://weather.gov/interop.schema.json#/properties/@metadata/properties/timing")
+
+### timing Type
+
+`object` ([Response timing](interop-layer-properties-response-metadata-properties-response-timing.md))
+
+## size
+
+The uncompressed size of the data being returned, excluding the metadata, in bytes.
+
+`size`
+
+* is optional
+
+* Type: `integer`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-response-metadata-properties-size.md "https://weather.gov/interop.schema.json#/properties/@metadata/properties/size")
+
+### size Type
+
+`integer`

--- a/docs/dev/interop/interop-layer-properties-satellite-properties-gif.md
+++ b/docs/dev/interop/interop-layer-properties-satellite-properties-gif.md
@@ -1,0 +1,19 @@
+# Untitled string in weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/satellite/properties/gif
+```
+
+URL to the 600x600 geocolor GIF of the most recent satellite for this point.
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## gif Type
+
+`string`
+
+## gif Constraints
+
+**URI**: the string must be a URI, according to [RFC 3986](https://tools.ietf.org/html/rfc3986 "check the specification")

--- a/docs/dev/interop/interop-layer-properties-satellite.md
+++ b/docs/dev/interop/interop-layer-properties-satellite.md
@@ -1,0 +1,43 @@
+# Satellite Schema
+
+```txt
+https://weather.gov/interop.schema.json#/properties/satellite
+```
+
+Information about satellite imagery for this point.
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                                 |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :--------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json\*](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## satellite Type
+
+`object` ([Satellite](interop-layer-properties-satellite.md))
+
+# satellite Properties
+
+| Property    | Type     | Required | Nullable       | Defined by                                                                                                                                                                    |
+| :---------- | :------- | :------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [gif](#gif) | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-satellite-properties-gif.md "https://weather.gov/interop.schema.json#/properties/satellite/properties/gif") |
+
+## gif
+
+URL to the 600x600 geocolor GIF of the most recent satellite for this point.
+
+`gif`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-satellite-properties-gif.md "https://weather.gov/interop.schema.json#/properties/satellite/properties/gif")
+
+### gif Type
+
+`string`
+
+### gif Constraints
+
+**URI**: the string must be a URI, according to [RFC 3986](https://tools.ietf.org/html/rfc3986 "check the specification")

--- a/docs/dev/interop/interop-layer.md
+++ b/docs/dev/interop/interop-layer.md
@@ -1,0 +1,245 @@
+# weather.gov API interoperability layer Schema
+
+```txt
+https://weather.gov/interop.schema.json
+```
+
+The results of querying for a specific latitude and longitude
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                                               |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [interop-layer.schema.json](../../../api-interop-layer/interop-layer.schema.json "open original schema") |
+
+## weather.gov API interoperability layer Type
+
+`object` ([weather.gov API interoperability layer](interop-layer.md))
+
+# weather.gov API interoperability layer Properties
+
+| Property                | Type     | Required | Nullable       | Defined by                                                                                                                                              |
+| :---------------------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [alerts](#alerts)       | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point-alerts.md "https://weather.gov/interop.schema.json#/properties/alerts")         |
+| [point](#point)         | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-point.md "https://weather.gov/interop.schema.json#/properties/point")                 |
+| [place](#place)         | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-place.md "https://weather.gov/interop.schema.json#/properties/place")                 |
+| [grid](#grid)           | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-nws-grid.md "https://weather.gov/interop.schema.json#/properties/grid")               |
+| [observed](#observed)   | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-observations.md "https://weather.gov/interop.schema.json#/properties/observed")       |
+| [forecast](#forecast)   | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-forecast.md "https://weather.gov/interop.schema.json#/properties/forecast")           |
+| [satellite](#satellite) | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-satellite.md "https://weather.gov/interop.schema.json#/properties/satellite")         |
+| [@metadata](#metadata)  | `object` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-properties-response-metadata.md "https://weather.gov/interop.schema.json#/properties/@metadata") |
+
+## alerts
+
+Alerts that are applicable to the given lat/lon.
+
+`alerts`
+
+* is optional
+
+* Type: `object` ([Point alerts](interop-layer-properties-point-alerts.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point-alerts.md "https://weather.gov/interop.schema.json#/properties/alerts")
+
+### alerts Type
+
+`object` ([Point alerts](interop-layer-properties-point-alerts.md))
+
+## point
+
+Information about the point
+
+`point`
+
+* is optional
+
+* Type: `object` ([Point](interop-layer-properties-point.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-point.md "https://weather.gov/interop.schema.json#/properties/point")
+
+### point Type
+
+`object` ([Point](interop-layer-properties-point.md))
+
+## place
+
+Information about the place at the described point, as close as we know.
+
+`place`
+
+* is optional
+
+* Type: `object` ([Place](interop-layer-properties-place.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-place.md "https://weather.gov/interop.schema.json#/properties/place")
+
+### place Type
+
+`object` ([Place](interop-layer-properties-place.md))
+
+## grid
+
+The NWS grid cell that this point falls in.
+
+`grid`
+
+* is optional
+
+* Type: `object` ([NWS Grid](interop-layer-properties-nws-grid.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-nws-grid.md "https://weather.gov/interop.schema.json#/properties/grid")
+
+### grid Type
+
+`object` ([NWS Grid](interop-layer-properties-nws-grid.md))
+
+## observed
+
+Most-recently observed conditions for this location from the nearest approved observation station.
+
+`observed`
+
+* is optional
+
+* Type: `object` ([Observations](interop-layer-properties-observations.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-observations.md "https://weather.gov/interop.schema.json#/properties/observed")
+
+### observed Type
+
+`object` ([Observations](interop-layer-properties-observations.md))
+
+## forecast
+
+Forecast for this point.
+
+`forecast`
+
+* is optional
+
+* Type: `object` ([Forecast](interop-layer-properties-forecast.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-forecast.md "https://weather.gov/interop.schema.json#/properties/forecast")
+
+### forecast Type
+
+`object` ([Forecast](interop-layer-properties-forecast.md))
+
+## satellite
+
+Information about satellite imagery for this point.
+
+`satellite`
+
+* is optional
+
+* Type: `object` ([Satellite](interop-layer-properties-satellite.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-satellite.md "https://weather.gov/interop.schema.json#/properties/satellite")
+
+### satellite Type
+
+`object` ([Satellite](interop-layer-properties-satellite.md))
+
+## @metadata
+
+Metadata about the response itself.
+
+`@metadata`
+
+* is optional
+
+* Type: `object` ([Response metadata](interop-layer-properties-response-metadata.md))
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-properties-response-metadata.md "https://weather.gov/interop.schema.json#/properties/@metadata")
+
+### @metadata Type
+
+`object` ([Response metadata](interop-layer-properties-response-metadata.md))
+
+# weather.gov API interoperability layer Definitions
+
+## Definitions group alert
+
+Reference this group by using
+
+```json
+{"$ref":"https://weather.gov/interop.schema.json#/$defs/alert"}
+```
+
+| Property | Type | Required | Nullable | Defined by |
+| :------- | :--- | :------- | :------- | :--------- |
+
+## Definitions group icon
+
+Reference this group by using
+
+```json
+{"$ref":"https://weather.gov/interop.schema.json#/$defs/icon"}
+```
+
+| Property      | Type     | Required | Nullable       | Defined by                                                                                                                                                 |
+| :------------ | :------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [icon](#icon) | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-icon-properties-icon.md "https://weather.gov/interop.schema.json#/$defs/icon/properties/icon") |
+| [base](#base) | `string` | Optional | cannot be null | [weather.gov API interoperability layer](interop-layer-defs-icon-properties-base.md "https://weather.gov/interop.schema.json#/$defs/icon/properties/base") |
+
+### icon
+
+The icon filename, as used by weather.gov.
+
+`icon`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-icon-properties-icon.md "https://weather.gov/interop.schema.json#/$defs/icon/properties/icon")
+
+#### icon Type
+
+`string`
+
+### base
+
+The basename of the icon (without file extension).
+
+`base`
+
+* is optional
+
+* Type: `string`
+
+* cannot be null
+
+* defined in: [weather.gov API interoperability layer](interop-layer-defs-icon-properties-base.md "https://weather.gov/interop.schema.json#/$defs/icon/properties/base")
+
+#### base Type
+
+`string`
+
+## Definitions group measures
+
+Reference this group by using
+
+```json
+{"$ref":"https://weather.gov/interop.schema.json#/$defs/measures"}
+```
+
+| Property | Type | Required | Nullable | Defined by |
+| :------- | :--- | :------- | :------- | :--------- |


### PR DESCRIPTION
## What does this PR do? 🛠️

In addition to the big ol' JSON schema doc, I also used an open source tool to render it as markdown:

```bash
npx @adobe/jsonschema2md -d api-interop-layer -o docs/dev/interop -x -
```

- closes #1610