### PR TITLE
[Interop layer] Fix a bug in the observations handler

### DIFF
--- a/api-interop-layer/data/obs/valid.js
+++ b/api-interop-layer/data/obs/valid.js
@@ -3,7 +3,8 @@ export default (observation) => {
     return false;
   }
 
-  if (observation.temperature.value === null) {
+  // The temperature must exist and must not be null.
+  if (observation.temperature?.value === null) {
     return false;
   }
   return true;


### PR DESCRIPTION
## What does this PR do? 🛠️

The observation handler assumed that if the observations endpoint returned data, it would be a list of one or more `features` each with a `properties` property. However, it is possible to receive a list of zero `features`, and we didn't account for that. Now we do.

Testing of this will get rolled into #1606 