### PR TITLE
[Interop layer] Add top-level error handling to Drupal

### DIFF
--- a/web/modules/weather_data/weather_data.module
+++ b/web/modules/weather_data/weather_data.module
@@ -13,9 +13,13 @@ function weather_data_template_preprocess_default_variables_alter(&$variables)
         $weatherMetadata["point"] = ["lat" => $lat, "lon" => $lon];
 
         $fetch = $container->get("http_client");
-        $data = $fetch
-            ->get("http://api-interop-layer:8082/point/$lat/$lon")
-            ->getBody();
+        try {
+            $data = $fetch
+                ->get("http://api-interop-layer:8082/point/$lat/$lon")
+                ->getBody();
+        } catch (Throwable $e) {
+            $data = '{"error":true}';
+        }
 
         $variables["point"] = json_decode($data);
     }

--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -1,7 +1,9 @@
 <div class="layout-container grid-row height-full flex-column flex-no-wrap">
 
-  {{ attach_library("new_weather_theme/leaflet") }}
-  {{ attach_library('new_weather_theme/chartjs') }}
+  {% if not point.error %}
+    {{ attach_library("new_weather_theme/leaflet") }}
+    {{ attach_library('new_weather_theme/chartjs') }}
+  {% endif %}
   {{ attach_library('new_weather_theme/point-page') }}
 
   <header role="banner">
@@ -34,65 +36,73 @@
     </div>
     {% endif %}
 
-    <wx-tabbed-nav class="display-block position-relative">
-      <div id="tablist-label" class="usa-sr-only">{{ "Weather information sections" | t }}</div>
-      <div class="position-sticky top-0 z-500 bg-white border-base-light border-top-0 border-bottom-2px margin-y-0">
-        <div class="grid-container padding-x-0">
-         <div role="tablist" class="tab-buttons display-flex flex-row top-4 grid-col-12" aria-labelledby="tablist-label">
-          {% if point.alerts.items | length > 0 %}
-            <button role="tab" id="alerts-tab-button" class="tab-button" data-tab-name="alerts" aria-controls="alerts">{{ "Alerts" | t }}</button>
-          {% endif %}
-            <button role="tab" id="current-conditions-tab-button" class="tab-button" data-tab-name="current" aria-controls="current">{{ "Current" | t }}</button>
-            <button role="tab" id="daily-tab-button" class="tab-button" data-tab-name="daily" aria-controls="daily">{{ "7 Days" | t }}</button>
+    {% if point.error %}
+      {% set message = "Something went wrong loading this page. Unfortunately we don't have any more information to share right now, but we'll look into it. In the meantime, please try again in a few minutes." | t %}
+      <div class="grid-container padding-x-0 padding-y-2 grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
+        {% include '@new_weather_theme/partials/uswds-alert.html.twig' with { 'level': "error", body: message } %}
+      </div>
+    {% else %}
+      <wx-tabbed-nav class="display-block position-relative">
+        <div id="tablist-label" class="usa-sr-only">{{ "Weather information sections" | t }}</div>
+        <div class="position-sticky top-0 z-500 bg-white border-base-light border-top-0 border-bottom-2px margin-y-0">
+          <div class="grid-container padding-x-0">
+          <div role="tablist" class="tab-buttons display-flex flex-row top-4 grid-col-12" aria-labelledby="tablist-label">
+            {% if point.alerts.items | length > 0 %}
+              <button role="tab" id="alerts-tab-button" class="tab-button" data-tab-name="alerts" aria-controls="alerts">{{ "Alerts" | t }}</button>
+            {% endif %}
+              <button role="tab" id="current-conditions-tab-button" class="tab-button" data-tab-name="current" aria-controls="current">{{ "Current" | t }}</button>
+              <button role="tab" id="daily-tab-button" class="tab-button" data-tab-name="daily" aria-controls="daily">{{ "7 Days" | t }}</button>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="bg-base-lightest padding-top-3 padding-bottom-8">
-        {% if point.alerts.items | length > 0 %}
-        <div class="wx-tab-container wx-focus-offset-205" id="alerts" role="tabpanel" aria-labelledby="alerts-tab-button" tabindex="0">
-          {% include(directory ~ "/templates/point/alerts.html.twig") with { alerts: point.alerts.items } %}
-        </div>
-        {% endif %}
+        <div class="bg-base-lightest padding-top-3 padding-bottom-8">
+          {% if point.alerts.items | length > 0 %}
+          <div class="wx-tab-container wx-focus-offset-205" id="alerts" role="tabpanel" aria-labelledby="alerts-tab-button" tabindex="0">
+            {% include(directory ~ "/templates/point/alerts.html.twig") with { alerts: point.alerts.items } %}
+          </div>
+          {% endif %}
 
-        <div class="wx-tab-container wx-focus-offset-205" id="current" role="tabpanel" aria-labelledby="current-conditions-tab-button" tabindex="0">
-          {% include '@new_weather_theme/point/observations.html.twig' with { obs: point.observed } %}
-          {% include '@new_weather_theme/partials/radar.html.twig' with { point: point.point  } %}
-          {% include '@new_weather_theme/partials/satellite.html.twig' %}
-        </div>
+          <div class="wx-tab-container wx-focus-offset-205" id="current" role="tabpanel" aria-labelledby="current-conditions-tab-button" tabindex="0">
+            {% include '@new_weather_theme/point/observations.html.twig' with { obs: point.observed } %}
+            {% include '@new_weather_theme/partials/radar.html.twig' with { point: point.point  } %}
+            {% include '@new_weather_theme/partials/satellite.html.twig' %}
+          </div>
 
-         <div class="wx-tab-container wx-focus-offset-205" id="daily" role="tabpanel" aria-labelledby="daily-tab-button" tabindex="0">
-          <h2 class="usa-sr-only">7 days</h2>
-          {{ drupal_block("weathergov_weather_story", { wfo: point.grid.wfo }) }}
+          <div class="wx-tab-container wx-focus-offset-205" id="daily" role="tabpanel" aria-labelledby="daily-tab-button" tabindex="0">
+            <h2 class="usa-sr-only">7 days</h2>
+            {{ drupal_block("weathergov_weather_story", { wfo: point.grid.wfo }) }}
 
-          <div class="margin-x-2 tablet:margin-x-auto tablet:grid-container margin-bottom-4 padding-x-0 tablet:padding-x-2">
-            <div class="grid-row">
-              <div class="grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
-                <div class="bg-accent-cool-lightest border border-accent-cool-lighter padding-105" role="alert">
-                  <svg
-                    class="usa-icon height-3 width-3 text-accent-cool-dark margin-right-1"
-                    aria-hidden="true"
-                    focusable="false"
-                    role="img"
-                    style="vertical-align: middle;"
-                  >
-                    <use
-                      xlink:href="/{{ directory }}/assets/images/uswds/sprite.svg#info_outline"
-                    ></use>
-                  </svg><a href="/afd/{{ weather.grid.wfo }}" class="usa-link">Area forecast discussion</a>
+            <div class="margin-x-2 tablet:margin-x-auto tablet:grid-container margin-bottom-4 padding-x-0 tablet:padding-x-2">
+              <div class="grid-row">
+                <div class="grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
+                  <div class="bg-accent-cool-lightest border border-accent-cool-lighter padding-105" role="alert">
+                    <svg
+                      class="usa-icon height-3 width-3 text-accent-cool-dark margin-right-1"
+                      aria-hidden="true"
+                      focusable="false"
+                      role="img"
+                      style="vertical-align: middle;"
+                    >
+                      <use
+                        xlink:href="/{{ directory }}/assets/images/uswds/sprite.svg#info_outline"
+                      ></use>
+                    </svg><a href="/afd/{{ weather.grid.wfo }}" class="usa-link">Area forecast discussion</a>
+                  </div>
                 </div>
               </div>
             </div>
+
+            <h3 class="usa-sr-only">Daily forecast</h3>
+            {% include '@new_weather_theme/point/forecast.html.twig' with { forecast: point.forecast } %}
+
+            {{ drupal_block("weathergov_wfo_promo", { wfo: point.grid.wfo }) }}
           </div>
-
-          <h3 class="usa-sr-only">Daily forecast</h3>
-          {% include '@new_weather_theme/point/forecast.html.twig' with { forecast: point.forecast } %}
-
-          {{ drupal_block("weathergov_wfo_promo", { wfo: point.grid.wfo }) }}
         </div>
-      </div>
 
-    </wx-tabbed-nav>
+      </wx-tabbed-nav>
+    {% endif %}
+
   </main>
 
   {% include(directory ~ "/templates/layout/footer.html.twig") %}

--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -37,7 +37,7 @@
     {% endif %}
 
     {% if point.error %}
-      {% set message = "Something went wrong loading this page. Unfortunately we don't have any more information to share right now, but we'll look into it. In the meantime, please try again in a few minutes." | t %}
+      {% set message = "Something went wrong loading this page. Please try again in a few minutes." | t %}
       <div class="grid-container padding-x-0 padding-y-2 grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
         {% include '@new_weather_theme/partials/uswds-alert.html.twig' with { 'level': "error", body: message } %}
       </div>


### PR DESCRIPTION
## What does this PR do? 🛠️

In the current site, we catch API request failures and put an error block around them. With the switch to the interop layer, I forgot to add an exception handler. This PR adds a try/catch around the single call to the interop layer and modifies the point page template to show a top-level warning if that failed.

## What does the reviewer need to know? 🤔

@partly-igor I just slapped some text into the error box. Right now it says
> ~Something went wrong loading this page. Unfortunately we don't have any more information to share right now, but we'll look into it. In the meantime, please try again in a few minutes.~

> Something went wrong loading this page. Please try again in a few minutes.

Happy to change it to whatever.

## Screenshots (if appropriate): 📸

![image](https://github.com/user-attachments/assets/b0849774-d6e1-4b15-8dbe-c4d5732b4d7b)