### PR TITLE
[Interop layer] Fix charts

### DIFF
--- a/web/themes/new_weather_theme/templates/partials/hourly-table.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/hourly-table.html.twig
@@ -1,7 +1,13 @@
-{% set times = hours | map(h => h.time) | json_encode %}
-{% set temps = hours | map(h => h.temperature) | json_encode %}
-{% set feelsLike = hours | map(h => h.apparentTemperature) | json_encode %}
-{% set pops = hours | map(h => h.probabilityOfPrecipitation) | json_encode %}
+{#
+  Available variables:
+    hours - An array of all the hours that should be represented in the table.
+    alerts - An array of all the alerts that intersect with those hours.
+#}
+
+{% set times = hours | map(h => h.hour) | json_encode %}
+{% set temps = hours | map(h => h.temperature.degF) | json_encode %}
+{% set feelsLike = hours | map(h => h.apparentTemperature.degF) | json_encode %}
+{% set pops = hours | map(h => h.probabilityOfPrecipitation.percent) | json_encode %}
 
 <wx-hourly-table class="display-block position-relative margin-top-2 bg-white">
   <h5 class="wx-visual-h3 font-heading-md text-normal text-primary-darker margin-top-0 margin-bottom-205">Hourly forecast</h5>


### PR DESCRIPTION
## What does this PR do? 🛠️

The data returned by the interop layer is nested under unit properties, like this:

```js
{
  ...
  temperature: {
    degF: 32,
    degC: 0
  }
}
```

So when we map in the data for the charts, we need to account for that. No biggie.