### PR TITLE
[HOTFIX] Raw AFD text

### DIFF
--- a/web/themes/new_weather_theme/templates/partials/afd.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/afd.html.twig
@@ -90,8 +90,3 @@
         </div>    
     {% endif %}
 </article>
-<div>
-    <pre>
-{{afd.productText}}
-    </pre>
-</div>


### PR DESCRIPTION
Oops -- the raw text is present on AFD views at the bottom of the page (I use this for debugging, and accidentally committed)