### PR TITLE
Fix Anchorage WFO Promo links

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherEntityService.php
+++ b/web/modules/weather_data/src/Service/WeatherEntityService.php
@@ -123,15 +123,9 @@ class WeatherEntityService
      */
     public function normalizeAnchorageWFO(string $wfo): string
     {
-        $inAnchorageCodes = [
-            "aer",
-            "alu"
-        ];
-        $matches = in_array(
-            strtolower($wfo),
-            $inAnchorageCodes
-        );
-        if($matches){
+        $inAnchorageCodes = ["aer", "alu"];
+        $matches = in_array(strtolower($wfo), $inAnchorageCodes);
+        if ($matches) {
             return "AFC";
         }
         return $wfo;

--- a/web/modules/weather_data/src/Service/WeatherEntityService.php
+++ b/web/modules/weather_data/src/Service/WeatherEntityService.php
@@ -84,18 +84,20 @@ class WeatherEntityService
     public function getLatestNodeFromWFO($wfo, $nodeType)
     {
         // Get the ID for the WFO taxonomy term that matches our grid WFO.
+        $wfoCode = $this->normalizeAnchorageWFO($wfo);
         $termID = $this->entityTypeManager
             ->getStorage("taxonomy_term")
-            ->loadByProperties(["field_wfo_code" => $wfo]);
+            ->loadByProperties(["field_wfo_code" => $wfoCode]);
 
         return $this->getLatestNodeByTerm($termID, "field_wfo", $nodeType);
     }
 
     public function getWFOEntity($wfo)
     {
+        $wfoCode = $this->normalizeAnchorageWFO($wfo);
         $term = $this->entityTypeManager
             ->getStorage("taxonomy_term")
-            ->loadByProperties(["field_wfo_code" => $wfo]);
+            ->loadByProperties(["field_wfo_code" => $wfoCode]);
         if (count($term) > 0) {
             return array_pop($term);
         }
@@ -114,5 +116,24 @@ class WeatherEntityService
             ->getStorage("taxonomy_term")
             ->loadMultiple($ids);
         return $result;
+    }
+
+    /**
+     * Normalize WFOs for Alaska/Anchorage
+     */
+    public function normalizeAnchorageWFO(string $wfo): string
+    {
+        $inAnchorageCodes = [
+            "aer",
+            "alu"
+        ];
+        $matches = in_array(
+            strtolower($wfo),
+            $inAnchorageCodes
+        );
+        if($matches){
+            return "AFC";
+        }
+        return $wfo;
     }
 }

--- a/web/modules/weather_data/src/Service/WeatherTwigExtension.php
+++ b/web/modules/weather_data/src/Service/WeatherTwigExtension.php
@@ -9,23 +9,20 @@ use Twig\Extension\ExtensionInterface;
 
 class WeatherTwigExtension extends AbstractExtension
 {
-    
-    public function getFunctions(){
+    public function getFunctions()
+    {
         return [
             new TwigFunction(
                 "normalize_wfo",
-                [$this, 'normalizeWFO'],
-                ["is_safe" => ["html"]])
+                [$this, "normalizeWFO"],
+                ["is_safe" => ["html"]],
+            ),
         ];
     }
 
-    public function getFilters(){
-        return [
-            new TwigFilter(
-                "normalize_wfo",
-                [$this, "normalizeWFO"]
-            )
-        ];
+    public function getFilters()
+    {
+        return [new TwigFilter("normalize_wfo", [$this, "normalizeWFO"])];
     }
 
     /**
@@ -35,14 +32,11 @@ class WeatherTwigExtension extends AbstractExtension
     public function normalizeWFO(string $wfo)
     {
         $anchorageAlternates = ["alu", "aer"];
-        $isAlternate = in_array(
-            strtolower($wfo),
-            $anchorageAlternates
-        );
-        if($isAlternate){
+        $isAlternate = in_array(strtolower($wfo), $anchorageAlternates);
+        if ($isAlternate) {
             return "AFC";
         }
 
         return $wfo;
     }
-};
+}

--- a/web/modules/weather_data/src/Service/WeatherTwigExtension.php
+++ b/web/modules/weather_data/src/Service/WeatherTwigExtension.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\weather_data\Service;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+use Twig\Extension\ExtensionInterface;
+
+class WeatherTwigExtension extends AbstractExtension
+{
+    
+    public function getFunctions(){
+        return [
+            new TwigFunction(
+                "normalize_wfo",
+                [$this, 'normalizeWFO'],
+                ["is_safe" => ["html"]])
+        ];
+    }
+
+    public function getFilters(){
+        return [
+            new TwigFilter(
+                "normalize_wfo",
+                [$this, "normalizeWFO"]
+            )
+        ];
+    }
+
+    /**
+     * Handle the edge cases of WFO codes
+     * for Alaska/Anchorage
+     */
+    public function normalizeWFO(string $wfo)
+    {
+        $anchorageAlternates = ["alu", "aer"];
+        $isAlternate = in_array(
+            strtolower($wfo),
+            $anchorageAlternates
+        );
+        if($isAlternate){
+            return "AFC";
+        }
+
+        return $wfo;
+    }
+};

--- a/web/modules/weather_data/src/Service/WeatherTwigExtension.php
+++ b/web/modules/weather_data/src/Service/WeatherTwigExtension.php
@@ -31,7 +31,7 @@ class WeatherTwigExtension extends AbstractExtension
      */
     public function normalizeWFO($wfo)
     {
-        if (!$wfo){
+        if (!$wfo) {
             return "";
         }
         $anchorageAlternates = ["alu", "aer"];

--- a/web/modules/weather_data/src/Service/WeatherTwigExtension.php
+++ b/web/modules/weather_data/src/Service/WeatherTwigExtension.php
@@ -31,7 +31,7 @@ class WeatherTwigExtension extends AbstractExtension
      */
     public function normalizeWFO($wfo)
     {
-        if(!$wfo){
+        if (!$wfo){
             return "";
         }
         $anchorageAlternates = ["alu", "aer"];

--- a/web/modules/weather_data/src/Service/WeatherTwigExtension.php
+++ b/web/modules/weather_data/src/Service/WeatherTwigExtension.php
@@ -29,8 +29,11 @@ class WeatherTwigExtension extends AbstractExtension
      * Handle the edge cases of WFO codes
      * for Alaska/Anchorage
      */
-    public function normalizeWFO(string $wfo)
+    public function normalizeWFO($wfo)
     {
+        if(!$wfo){
+            return "";
+        }
         $anchorageAlternates = ["alu", "aer"];
         $isAlternate = in_array(strtolower($wfo), $anchorageAlternates);
         if ($isAlternate) {

--- a/web/modules/weather_data/weather_data.services.yml
+++ b/web/modules/weather_data/weather_data.services.yml
@@ -11,3 +11,7 @@ services:
   newrelic_metrics:
     class: Drupal\weather_data\Service\NewRelicMetrics
     arguments: ['@http_client']
+  weather_twig_extension:
+    class: Drupal\weather_data\Service\WeatherTwigExtension
+    tags:
+      - { name: twig.extension }

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-wfo-promo.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-wfo-promo.html.twig
@@ -2,7 +2,7 @@
   <div class="grid-row">
     <div class="grid-col tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
       <h3 class="wx-visual-h2 text-normal text-primary-darker"> {{ "Your Local Forecast Office" | t }} </h3>
-      <h4 class="wx-visual-h3 margin-bottom-1"><a class="usa-link" href="/offices/{{ content.code }}">{{ content.name }}</a></h4>
+      <h4 class="wx-visual-h3 margin-bottom-1"><a class="usa-link" href="/offices/{{ content.code | normalize_wfo }}">{{ content.name }}</a></h4>
       <p class="line-height-sans-4 margin-top-0">
         {{ content.about | view }}
       </p>

--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -80,7 +80,7 @@
                     <use
                       xlink:href="/{{ directory }}/assets/images/uswds/sprite.svg#info_outline"
                     ></use>
-                  </svg><a href="/afd/{{ weather.grid.wfo }}" class="usa-link">Area forecast discussion</a>
+                  </svg><a href="/afd/{{ weather.grid.wfo | normalize_wfo }}" class="usa-link">Area forecast discussion</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## What does this PR do? 🛠️
Fix for #1681 

## What does the reviewer need to know? 🤔
We "normalize" the WFO code -- meaning we make ALU and AER into AFC -- in two places:
- In the WFOPromoBlock code, so that it attempts to retrieve the information for the Anchorage WFO info page and links to it on a given point location page;
- In a new custom Twig filter, which lets us apply this transformation from within templates as needed

## Testing
These two links should have both (a) a correct AFD link at the top of the forecast daily page, and (b) The correct link and text at the bottom linking to "Your weather office" (Anchorage/AFC):
- http://localhost:8080/point/55.204/-162.704?#daily
- http://localhost:8080/point/61.217/-149.9?#daily
