### PR TITLE
AFD 404s (and other things!)

### DIFF
--- a/tests/playwright/e2e/afd-page.spec.js
+++ b/tests/playwright/e2e/afd-page.spec.js
@@ -27,6 +27,20 @@ const OVERALL_REFERENCES = JSON.parse(
 const firstId = OKX_REFERENCES["@graph"][0].id;
 
 describe("AFD Page Tests", () => {
+  describe("Not Found (404) tests", () => {
+    test("Displays a 404 page for an invalid / expired AFD id", async ({ page }) => {
+      const response = await page.goto("http://localhost:8080/afd/OKX/invalid-afd-id.json");
+
+      expect(response.status()).toBe(404);
+    });
+
+    test("Displays a 404 page for a listing of AFDs at an invalid WFO", async ({ page }) => {
+      const response = await page.goto("http://localhost:8080/afd/WWW");
+
+      expect(response.status()).toBe(404);
+    });
+  });
+
   describe("Partial HTML routes", () => {
     test("Can retrieve <option> elements html partial for version listing", async ({
       page,

--- a/web/modules/weather_data/src/Service/DataLayer.php
+++ b/web/modules/weather_data/src/Service/DataLayer.php
@@ -80,7 +80,7 @@ class DataLayer
                 // First thing we need to do is get the WFO information for this
                 // lat/lon.
                 $url = "/points/$lat,$lon";
-                [$responseOrError, $statusCode, $isError] = $this->fetch($url)->wait();
+                [$response, $statusCode, $isError] = $this->fetch($url)->wait();
                 if ($isError) {
                     return;
                 }
@@ -116,6 +116,14 @@ class DataLayer
                 // We also don't have to catch anything because our fetch()
                 // method never rejects. Hooray?
                 $responses = Utils::unwrap($responses);
+                $responses = array_map(
+                    function($responseData){
+                        // The first item in the array
+                        // is the actual response std object
+                        return $responseData[0];
+                    },
+                    $responses
+                );
 
                 $station =
                     $responses["stations"]->features[0]->properties
@@ -409,7 +417,7 @@ class DataLayer
             "https://cdn.star.nesdis.noaa.gov/WFO/catalogs/WFO_02_" .
             $wfo .
             "_catalog.json";
-        $response = $this->fetch($url)->wait();
+        [$response, , ] = $this->fetch($url)->wait();
         return $response;
     }
 

--- a/web/modules/weather_data/src/Service/DataLayer.php
+++ b/web/modules/weather_data/src/Service/DataLayer.php
@@ -80,8 +80,8 @@ class DataLayer
                 // First thing we need to do is get the WFO information for this
                 // lat/lon.
                 $url = "/points/$lat,$lon";
-                $response = $this->fetch($url)->wait();
-                if (property_exists($response, "error")) {
+                [$responseOrError, $statusCode, $isError] = $this->fetch($url)->wait();
+                if ($isError) {
                     return;
                 }
 

--- a/web/modules/weather_routes/src/Controller/AFDController.php
+++ b/web/modules/weather_routes/src/Controller/AFDController.php
@@ -52,8 +52,8 @@ final class AFDController extends ControllerBase
             $id = $this->request->getCurrentRequest()->query->get("id");
             $wfo_code = $this->request->getCurrentRequest()->query->get("wfo");
             $current = $this->request
-                            ->getCurrentRequest()
-                            ->query->get("current-id");
+                ->getCurrentRequest()
+                ->query->get("current-id");
 
             // If the AFD id of the referer page is the same as the requested
             // id, this means we really just want to update the WFO
@@ -89,12 +89,10 @@ final class AFDController extends ControllerBase
         } catch (Exception $e) {
             throw new NotFoundHttpException();
         }
-        
     }
 
     public function byOfficeAndId($wfo_code, $afd_id)
     {
-        
         try {
             $versions = $this->weatherData->getLatestAFDReferences($wfo_code);
             $afd = $this->weatherData->getAFDById($afd_id);
@@ -185,7 +183,7 @@ final class AFDController extends ControllerBase
     public function markupOnlyById($afd_id)
     {
         $afd = $this->weatherData->getAFDById($afd_id);
-        if(!$afd){
+        if (!$afd) {
             throw new NotFoundHttpException();
         }
         $build = [

--- a/web/modules/weather_routes/src/Controller/AFDController.php
+++ b/web/modules/weather_routes/src/Controller/AFDController.php
@@ -48,63 +48,72 @@ final class AFDController extends ControllerBase
 
     public function afdDefault()
     {
-        $id = $this->request->getCurrentRequest()->query->get("id");
-        $wfo_code = $this->request->getCurrentRequest()->query->get("wfo");
-        $current = $this->request
-            ->getCurrentRequest()
-            ->query->get("current-id");
+        try {
+            $id = $this->request->getCurrentRequest()->query->get("id");
+            $wfo_code = $this->request->getCurrentRequest()->query->get("wfo");
+            $current = $this->request
+                            ->getCurrentRequest()
+                            ->query->get("current-id");
 
-        // If the AFD id of the referer page is the same as the requested
-        // id, this means we really just want to update the WFO
-        if ($current == $id) {
-            $id = null;
-        }
-
-        if ($id && $wfo_code) {
-            return new RedirectResponse("/afd/" . $wfo_code . "/" . $id);
-        } elseif ($wfo_code) {
-            return new RedirectResponse("/afd/" . $wfo_code);
-        } elseif ($id) {
-            // In this case, we just have the id and not the WFO.
-            // We can attempt to pre-fetch the AFD and parse
-            // the WFO from its body
-            $afd = $this->weatherData->getAFDById($id);
-            $extracted_code = $this->weatherData->getWFOFromAFD($afd);
-            if ($afd && $extracted_code) {
-                return new RedirectResponse(
-                    "/afd/" . $extracted_code . "/" . $afd["id"],
-                );
+            // If the AFD id of the referer page is the same as the requested
+            // id, this means we really just want to update the WFO
+            if ($current == $id) {
+                $id = null;
             }
-        }
 
-        // In the catch-all case, we grab the most recent AFDs from
-        // everywhere, and return a link to the viewer set up for the
-        // first encountered AFD (using its WFO and WFO versions)
-        $refs = $this->weatherData->getLatestAFDReferences();
-        $id = $refs[0]["id"];
-        $afd = $this->weatherData->getAFDById($id);
-        $wfo = $this->weatherData->getWFOFromAFD($afd);
-        return new RedirectResponse("/afd/" . $wfo . "/" . $id);
+            if ($id && $wfo_code) {
+                return new RedirectResponse("/afd/" . $wfo_code . "/" . $id);
+            } elseif ($wfo_code) {
+                return new RedirectResponse("/afd/" . $wfo_code);
+            } elseif ($id) {
+                // In this case, we just have the id and not the WFO.
+                // We can attempt to pre-fetch the AFD and parse
+                // the WFO from its body
+                $afd = $this->weatherData->getAFDById($id);
+                $extracted_code = $this->weatherData->getWFOFromAFD($afd);
+                if ($afd && $extracted_code) {
+                    return new RedirectResponse(
+                        "/afd/" . $extracted_code . "/" . $afd["id"],
+                    );
+                }
+            }
+
+            // In the catch-all case, we grab the most recent AFDs from
+            // everywhere, and return a link to the viewer set up for the
+            // first encountered AFD (using its WFO and WFO versions)
+            $refs = $this->weatherData->getLatestAFDReferences();
+            $id = $refs[0]["id"];
+            $afd = $this->weatherData->getAFDById($id);
+            $wfo = $this->weatherData->getWFOFromAFD($afd);
+            return new RedirectResponse("/afd/" . $wfo . "/" . $id);
+        } catch (Exception $e) {
+            throw new NotFoundHttpException();
+        }
+        
     }
 
     public function byOfficeAndId($wfo_code, $afd_id)
     {
-        $versions = $this->weatherData->getLatestAFDReferences($wfo_code);
-        $afd = $this->weatherData->getAFDById($afd_id);
-        if (!$afd) {
-            // This is where you 404
-            return;
-        }
-        $allWfos = $this->weatherData->getAllWFOs();
-        $versions = $this->weatherData->getLatestAFDReferences($wfo_code);
+        
+        try {
+            $versions = $this->weatherData->getLatestAFDReferences($wfo_code);
+            $afd = $this->weatherData->getAFDById($afd_id);
+            if (!$afd) {
+                throw new NotFoundHttpException();
+            }
+            $allWfos = $this->weatherData->getAllWFOs();
+            $versions = $this->weatherData->getLatestAFDReferences($wfo_code);
 
-        return [
-            "#theme" => "weather_routes_afd",
-            "#wfo" => $wfo_code,
-            "#afd" => $afd,
-            "#wfo_list" => $allWfos,
-            "#version_list" => $versions,
-        ];
+            return [
+                "#theme" => "weather_routes_afd",
+                "#wfo" => $wfo_code,
+                "#afd" => $afd,
+                "#wfo_list" => $allWfos,
+                "#version_list" => $versions,
+            ];
+        } catch (Exception $e) {
+            throw new NotFoundHttpException();
+        }
     }
 
     /**
@@ -123,13 +132,19 @@ final class AFDController extends ControllerBase
             return new RedirectResponse("/afd/" . $wfo_code . "/" . $id);
         }
 
-        // Otherwise, grab all of the current versions for the WFO
-        // and use the most recent one as the id
-        $versions = $this->weatherData->getLatestAFDReferences($wfo_code);
-        if ($versions && count($versions)) {
-            return new RedirectResponse(
-                "/afd/" . $wfo_code . "/" . $versions[0]["id"],
-            );
+        try {
+            // Otherwise, grab all of the current versions for the WFO
+            // and use the most recent one as the id
+            $versions = $this->weatherData->getLatestAFDReferences($wfo_code);
+            if ($versions && count($versions)) {
+                return new RedirectResponse(
+                    "/afd/" . $wfo_code . "/" . $versions[0]["id"],
+                );
+            } else {
+                throw new NotFoundHttpException();
+            }
+        } catch (Exception $e) {
+            throw new NotFoundHttpException();
         }
     }
 
@@ -139,25 +154,28 @@ final class AFDController extends ControllerBase
      */
     public function byId($afd_id)
     {
-        $afd = $this->weatherData->getAFDById($afd_id);
-        if (!$afd) {
-            // This is where you 404
-            return;
-        }
-        $wfo = $this->weatherData->getWFOFromAFD($afd);
-        $versions = [];
-        if ($wfo) {
-            $versions = $this->weatherData->getLatestAFDReferences($wfo);
-        }
-        $allWfos = $this->weatherData->getAllWFOs();
+        try {
+            $afd = $this->weatherData->getAFDById($afd_id);
+            if (!$afd) {
+                throw new NotFoundHttpException();
+            }
+            $wfo = $this->weatherData->getWFOFromAFD($afd);
+            $versions = [];
+            if ($wfo) {
+                $versions = $this->weatherData->getLatestAFDReferences($wfo);
+            }
+            $allWfos = $this->weatherData->getAllWFOs();
 
-        return [
-            "#theme" => "weather_routes_afd",
-            "#wfo" => $wfo,
-            "#afd" => $afd,
-            "#wfo_list" => $allWfos,
-            "#version_list" => $versions,
-        ];
+            return [
+                "#theme" => "weather_routes_afd",
+                "#wfo" => $wfo,
+                "#afd" => $afd,
+                "#wfo_list" => $allWfos,
+                "#version_list" => $versions,
+            ];
+        } catch (Exception $e) {
+            throw new NotFoundHttpException();
+        }
     }
 
     /**
@@ -167,6 +185,9 @@ final class AFDController extends ControllerBase
     public function markupOnlyById($afd_id)
     {
         $afd = $this->weatherData->getAFDById($afd_id);
+        if(!$afd){
+            throw new NotFoundHttpException();
+        }
         $build = [
             "#theme" => "weather_routes_afd_partial",
             "#wfo" => "UNK",

--- a/web/modules/weather_routes/weather_routes.routing.yml
+++ b/web/modules/weather_routes/weather_routes.routing.yml
@@ -25,7 +25,7 @@ weather_routes.grid:
     # Public endpoint
     _access: 'TRUE'
     # Validate path parameters
-    wfo: '^[A-Za-z][A-Za-z][A-Za-z]$'
+    wfo: '^[A-Za-z]{3}$'
     gridX: '^[0-9]*$'
     gridY: '^[0-9]*$'
 
@@ -46,7 +46,7 @@ weather_routes.grid.legacy:
     # Public endpoint
     _access: 'TRUE'
     # Validate path parameters
-    wfo: '^[A-Za-z][A-Za-z][A-Za-z]$'
+    wfo: '^[A-Za-z]{3}$'
     gridX: '^[0-9]*$'
     gridY: '^[0-9]*$'
 
@@ -75,7 +75,7 @@ weather_routes.afd.wfo_id:
     no_cache: 'TRUE'
   requirements:
     _access: 'TRUE'
-    wfo_code: '^[A-Za-z][A-Za-z][A-Za-z]$'
+    wfo_code: '^[A-Za-z]{3}$'
 
 weather_routes.afd.by_office:
   path: '/afd/{wfo_code}'
@@ -85,7 +85,7 @@ weather_routes.afd.by_office:
     no_cache: 'TRUE'
   requirements:
     _access: 'TRUE'
-    wfo_code: '^[A-Za-z][A-Za-z][A-Za-z]$'
+    wfo_code: '^[A-Za-z]{3}$'
 
 
 weather_routes.afd.wx.id:
@@ -105,7 +105,7 @@ weather_routes.afd.wx.versions:
     no_cache: 'TRUE'
   requirements:
     _access: 'TRUE'
-    wfo_code: '^[A-Za-z][A-Za-z][A-Za-z]$'
+    wfo_code: '^[A-Za-z]{3}$'
   
 weather_routes.weather_info.content:
   path: '/offices/{wfo}'
@@ -114,4 +114,4 @@ weather_routes.weather_info.content:
   requirements:
     # Public endpoint
     _access: 'TRUE'
-    wfo: '^[A-Za-z][A-Za-z][A-Za-z]$'
+    wfo: '^[A-Za-z]{3}$'

--- a/web/modules/weather_routes/weather_routes.routing.yml
+++ b/web/modules/weather_routes/weather_routes.routing.yml
@@ -75,6 +75,7 @@ weather_routes.afd.wfo_id:
     no_cache: 'TRUE'
   requirements:
     _access: 'TRUE'
+    wfo_code: '^[A-Za-z][A-Za-z][A-Za-z]$'
 
 weather_routes.afd.by_office:
   path: '/afd/{wfo_code}'
@@ -84,6 +85,7 @@ weather_routes.afd.by_office:
     no_cache: 'TRUE'
   requirements:
     _access: 'TRUE'
+    wfo_code: '^[A-Za-z][A-Za-z][A-Za-z]$'
 
 
 weather_routes.afd.wx.id:
@@ -103,6 +105,7 @@ weather_routes.afd.wx.versions:
     no_cache: 'TRUE'
   requirements:
     _access: 'TRUE'
+    wfo_code: '^[A-Za-z][A-Za-z][A-Za-z]$'
   
 weather_routes.weather_info.content:
   path: '/offices/{wfo}'


### PR DESCRIPTION
## What does this PR do? 🛠️
Deals with #1729, in addition to more general problems with API response handling.

## What does the reviewer need to know? 🤔
Before this PR, the `DataLayer`'s `fetch` function was treating API responses of 4xx and 5xx both as generic `500` errors. Those generic errors are difficult to properly "catch" and reason about in the Drupal routing system.
  
We have changed this so that we make the appropriate distinction. Additionally, the result of `fetch` is more comprehensive (an array of information, including whether or not the result was an error-level response).
  
Finally, we have wrapped some of the more API-request-heavy parts of the AFD controller in try blocks. All exceptions caught from API requests here will trigger a `NotFoundHttpException()`, which will lead to the generic 404 page.

## Surfaced Issues
In addition to the source ticket, we also identified #1818 (in which the API does not respond as one might expect).