### PR TITLE
Remove fix permissions recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ update-translations:
 	docker compose exec drupal drush locale:update
 	docker compose exec drupal drush cache:rebuild
 
-zap: update-settings zap-containers rebuild pause install-site load-spatial fix-permissions ## Delete the entire Docker environment and start from scratch.
+zap: update-settings zap-containers rebuild pause install-site load-spatial  ## Delete the entire Docker environment and start from scratch.
 zap-containers:
 	docker compose stop
 	docker compose rm -f
@@ -186,7 +186,3 @@ ci: composer-install
 composer-install: ## Installs dependencies from lock file
 	docker compose exec drupal composer install 
 
-### Fix file permissions
-fix-permissions: ## Updates owner in docker and mod in local
-	docker compose exec drupal chown -R www-data:www-data web/sites web/modules web/themes
-	chmod -R ug+rwx web/sites web/modules web/themes


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR removes the `fix-permission` recipe from the Makefile because running that command is creating a large set of changed files with git.  Suggested by @eric-gade 

## What does the reviewer need to know? 🤔
We may need to adjust file permissions manually without this in place. 
