### PR TITLE
do not do a rolling strategy for multiple apps

### DIFF
--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -33,7 +33,7 @@ jobs:
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: nws-weathergov
           cf_space: ${{ github.event.inputs.environment }}
-          cf_command: "push -f manifests/manifest-${{ github.event.inputs.environment }}.yaml --var newrelic-license='${{ secrets.NEWRELIC_LICENSE }}' --var allowed-ips='${{secrets.ALLOWED_IP_ADDRESSES}}' --strategy rolling"
+          cf_command: "push -f manifests/manifest-${{ github.event.inputs.environment }}.yaml --var newrelic-license='${{ secrets.NEWRELIC_LICENSE }}' --var allowed-ips='${{secrets.ALLOWED_IP_ADDRESSES}}'"
 
       - name: Run post-deploy steps in ${{ github.event.inputs.environment }} space
         uses: cloud-gov/cg-cli-tools@main


### PR DESCRIPTION
## What does this PR do? 🛠️

TIL but `cf` does not allow one to set strategy when deploying multiple apps. Not going to merge this just yet because I'm not sure how this will impact beta deploys yet.