### PR TITLE
Fix script bundling

### DIFF
--- a/web/themes/new_weather_theme/assets/js/components/alertMap.js
+++ b/web/themes/new_weather_theme/assets/js/components/alertMap.js
@@ -131,6 +131,11 @@ const checkForLeaflet = () => {
     // If addEventListener is called multiple times with identical arguments,
     // the listener will only be added the first time. So, it's safe to just
     // keep doing this until we're done.
+    //
+    // It's also possible that we got here before the DOM load event, in which
+    // case the Leaflet, ESRI, and ESRI vector script tags may not even be
+    // present yet. So... wait on that as well!
+    document.addEventListener("DOMContentLoaded", checkForLeaflet);
     document
       .querySelector("[data-wx-leaflet]")
       ?.addEventListener("load", checkForLeaflet);

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -63,12 +63,15 @@ leaflet:
     https://unpkg.com/leaflet@1.9.4/dist/leaflet.js:
       attributes:
         defer: true
+        id: data-wx-leaflet
     https://unpkg.com/esri-leaflet@3.0.12/dist/esri-leaflet.js:
       attributes:
         defer: true
+        id: data-wx-leaflet-esri
     https://unpkg.com/esri-leaflet-vector@4.2.3/dist/esri-leaflet-vector.js:
       attributes:
         defer: true
+        id: data-wx-leaflet-esri-vector
 
 digital-analytics-program:
   header: true


### PR DESCRIPTION
## What does this PR do? 🛠️

The Leaflet, ESRI and ESRI vector script tag `id` attributes were mistakenly removed, so the alert map module could never determine when those scripts had loaded. Additionally, Drupal controls the rendering order of our script tags so we cannot be certain that the DOM will be fully loaded when we load, so if Leaflet isn't already available, also attach a `DOMContentLoaded` event handler.

Alternatively, we could keep calling the Leaflet check on a timer, but in the even that Leaflet never loads, we'd just be burning CPU cycles on nothing. Using event-based loading is more processor-friendly.
