### PR TITLE
Revert "Merge pull request #1829 from weather-gov/revert-beta-bundling"

### DIFF
--- a/.github/workflows/deploy-beta.yaml
+++ b/.github/workflows/deploy-beta.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: bundle javascript
+        uses: ./.github/actions/javascript-bundle
       - name: Deploy to cloud.gov sandbox
         uses: cloud-gov/cg-cli-tools@main
         env:


### PR DESCRIPTION
This reverts commit 988e89f9371ea0d24b43a2e18392b11b631144de, reversing changes made to 0f92d34ed96b142ddeb6938f915f4e1171054947.

## What does this PR do? 🛠️

Re-enable bundling for beta. Let's not merge till we know bundling works on staging.