### PR TITLE
Remove custom logic for determining which X axis ticks to display

### DIFF
--- a/web/themes/new_weather_theme/assets/js/charts/hourly-humidity.js
+++ b/web/themes/new_weather_theme/assets/js/charts/hourly-humidity.js
@@ -64,7 +64,7 @@ for (const container of chartContainers) {
     },
 
     data: {
-      labels: times.map((v) => (Number.parseInt(v, 10) % 2 === 0 ? v : "")),
+      labels: times,
       datasets: [
         {
           label: "Humidity",

--- a/web/themes/new_weather_theme/assets/js/charts/hourly-pops.js
+++ b/web/themes/new_weather_theme/assets/js/charts/hourly-pops.js
@@ -60,7 +60,7 @@ for (const container of chartContainers) {
     },
 
     data: {
-      labels: times.map((v) => (Number.parseInt(v, 10) % 2 === 0 ? v : "")),
+      labels: times,
       datasets: [
         {
           label: "Chance of precipitation",


### PR DESCRIPTION
## What does this PR do? 🛠️

When we were building the temperature chart, we originally implemented logic to only show the even-numbered hours on the X axis. However, we bumped into a lot of weird behavior with that, so we opted to just let Chart.js figure it out. That seemed to work pretty well.

However, for the hourly precipitation chances and humidity charts, we left in that "only evens" logic. This PR removes that logic so that these two charts also behave like the temperature chart.

- closes #1766
