### PR TITLE
Preserve spatial data when doing a zap

### DIFF
--- a/spatial-data/.gitignore
+++ b/spatial-data/.gitignore
@@ -1,0 +1,1 @@
+dump.mysql


### PR DESCRIPTION
## What does this PR do? 🛠️

This PR extends our `zap` utility to first dump the geospatial tables to a SQL file before destroying the database container. Then, after the database container is ready, it imports the geospatial tables from SQL. Finally, it runs the `load-spatial` command which will run any necessary updates. This should speed up our zaps quite a lot since spatial updates are so infrequent.
