### PR TITLE
Add mouseout event for charts to remove tooltip after hover

### DIFF
--- a/web/themes/new_weather_theme/assets/js/charts/hourly-dewpoint.js
+++ b/web/themes/new_weather_theme/assets/js/charts/hourly-dewpoint.js
@@ -30,7 +30,7 @@ for (const container of chartContainers) {
           display: false,
         },
         tooltip: {
-          events: ['click', 'mousemove'],
+          events: ['click', 'mousemove', 'mouseout'],
         },
       },
       scales: {

--- a/web/themes/new_weather_theme/assets/js/charts/hourly-humidity.js
+++ b/web/themes/new_weather_theme/assets/js/charts/hourly-humidity.js
@@ -37,7 +37,7 @@ for (const container of chartContainers) {
         tooltip: {
           xAlign: "center",
           yAlign: "bottom",
-          events: ['click','mousemove'],
+          events: ['click', 'mousemove', 'mouseout'],
         },
       },
       scales: {

--- a/web/themes/new_weather_theme/assets/js/charts/hourly-pops.js
+++ b/web/themes/new_weather_theme/assets/js/charts/hourly-pops.js
@@ -33,7 +33,7 @@ for (const container of chartContainers) {
         tooltip: {
           xAlign: "center",
           yAlign: "bottom",
-          events: ['click','mousemove'],
+          events: ['click', 'mousemove', 'mouseout'],
         },
       },
       scales: {

--- a/web/themes/new_weather_theme/assets/js/charts/hourly-temperature.js
+++ b/web/themes/new_weather_theme/assets/js/charts/hourly-temperature.js
@@ -33,7 +33,7 @@ for (const container of chartContainers) {
           display: false,
         },
         tooltip: {
-          events: ['click', 'mousemove'],
+          events: ['click', 'mousemove', 'mouseout'],
         },
       },
       scales: {

--- a/web/themes/new_weather_theme/assets/js/charts/hourly-wind.js
+++ b/web/themes/new_weather_theme/assets/js/charts/hourly-wind.js
@@ -123,7 +123,7 @@ for (const container of chartContainers) {
           display: false,
         },
         tooltip: {
-          events: ['click', 'mousemove'],
+          events: ['click', 'mousemove', 'mouseout'],
         },
       },
       layout: {

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -25,7 +25,7 @@ front-page:
         defer: true
 
 point-page:
-  version: 2024-10-09
+  version: 2024-10-09-2
   js:
     assets/js/point.page.js:
       attributes:


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR adds the `mouseout` event to the list of tooltip interaction events so that the tooltip is hidden once the user stops hovering over a chart. 

## What does the reviewer need to know? 🤔
<!--- Include any local deployment instructions, navigation instructions, etc -->

## Screenshots (if appropriate): 📸
Look no tooltip
![Screenshot while hovering on chart](https://github.com/user-attachments/assets/c05c2bf9-6b8b-4570-a00c-84ea8993d90c)
![Screenshot after moving away on chart](https://github.com/user-attachments/assets/c757080f-8431-41a3-9a45-68f5e8da6948)

