### PR TITLE
API interop layer deploy actions

### DIFF
--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -26,6 +26,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: bundle javascript
         uses: ./.github/actions/javascript-bundle
+
+      - name: Deploy api interop layer in ${{ github.event.inputs.environment }} space
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets[env.CF_USERNAME] }}
+          cf_password: ${{ secrets[env.CF_PASSWORD] }}
+          cf_org: nws-weathergov
+          cf_space: ${{ github.event.inputs.environment }}
+          cf_command: "push api-weathergov-${{ github.event.inputs.environment }} -f manifests/manifest-${{ github.event.inputs.environment }}.yaml --var newrelic-license='${{ secrets.NEWRELIC_LICENSE }}' --strategy rolling"
+
       - name: Deploy application in ${{ github.event.inputs.environment }} space
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -33,7 +43,7 @@ jobs:
           cf_password: ${{ secrets[env.CF_PASSWORD] }}
           cf_org: nws-weathergov
           cf_space: ${{ github.event.inputs.environment }}
-          cf_command: "push -f manifests/manifest-${{ github.event.inputs.environment }}.yaml --var newrelic-license='${{ secrets.NEWRELIC_LICENSE }}' --var allowed-ips='${{secrets.ALLOWED_IP_ADDRESSES}}' --strategy rolling"
+          cf_command: "push weathergov-${{ github.event.inputs.environment }} -f manifests/manifest-${{ github.event.inputs.environment }}.yaml --var newrelic-license='${{ secrets.NEWRELIC_LICENSE }}' --strategy rolling"
 
       - name: Run post-deploy steps in ${{ github.event.inputs.environment }} space
         uses: cloud-gov/cg-cli-tools@main

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -13,27 +13,40 @@ jobs:
   deploy-staging:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - name: bundle javascript
-          uses: ./.github/actions/javascript-bundle
-        - name: Deploy to cloud.gov weathergov-staging space
-          uses: cloud-gov/cg-cli-tools@main
-          env:
-            DEPLOY_NOW: thanks
-          with:
-            cf_username: ${{ secrets.CF_STAGING_USERNAME }}
-            cf_password: ${{ secrets.CF_STAGING_PASSWORD }}
-            cf_org: nws-weathergov
-            cf_space: staging
-            cf_command: "push -f manifests/manifest-staging.yaml --var newrelic-license=${{ secrets.NEWRELIC_LICENSE }} --strategy rolling"
-        - name: Run post deploy steps
-          uses: cloud-gov/cg-cli-tools@main
-          with:
-            cf_username: ${{ secrets.CF_STAGING_USERNAME }}
-            cf_password: ${{ secrets.CF_STAGING_PASSWORD }}
-            cf_org: nws-weathergov
-            cf_space: staging
-            cf_command: "run-task weathergov-staging --command './scripts/post-deploy.sh' --name 'weathergov-staging-deploy' -k '2G' -m '256M'"
+      - uses: actions/checkout@v4
+      - name: bundle javascript
+        uses: ./.github/actions/javascript-bundle
+
+      - name: Deploy api interop layer to cloud.gov weathergov-staging space
+        uses: cloud-gov/cg-cli-tools@main
+        env:
+          DEPLOY_NOW: thanks
+        with:
+          cf_username: ${{ secrets.CF_STAGING_USERNAME }}
+          cf_password: ${{ secrets.CF_STAGING_PASSWORD }}
+          cf_org: nws-weathergov
+          cf_space: staging
+          cf_command: "push api-weathergov-staging -f manifests/manifest-staging.yaml --var newrelic-license=${{ secrets.NEWRELIC_LICENSE }} --strategy rolling"
+
+      - name: Deploy application to cloud.gov weathergov-staging space
+        uses: cloud-gov/cg-cli-tools@main
+        env:
+          DEPLOY_NOW: thanks
+        with:
+          cf_username: ${{ secrets.CF_STAGING_USERNAME }}
+          cf_password: ${{ secrets.CF_STAGING_PASSWORD }}
+          cf_org: nws-weathergov
+          cf_space: staging
+          cf_command: "push weathergov-staging -f manifests/manifest-staging.yaml --var newrelic-license=${{ secrets.NEWRELIC_LICENSE }} --strategy rolling"
+
+      - name: Run post deploy steps
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_STAGING_USERNAME }}
+          cf_password: ${{ secrets.CF_STAGING_PASSWORD }}
+          cf_org: nws-weathergov
+          cf_space: staging
+          cf_command: "run-task weathergov-staging --command './scripts/post-deploy.sh' --name 'weathergov-staging-deploy' -k '2G' -m '256M'"
 
   new-relic-record:
     name: Record deployment to New Relic

--- a/manifests/manifest-design.yaml
+++ b/manifests/manifest-design.yaml
@@ -16,11 +16,28 @@ default_config: &defaults
     - secrets
 
 applications:
-- name: weathergov-design
-  <<: *defaults
-  memory: 256M
-  instances: 1
-  random-route: false
+  - name: weathergov-design
+    <<: *defaults
+    memory: 256M
+    instances: 1
+    random-route: false
+
+  - name: api-weathergov-design
+    stack: cflinuxfs4
+    memory: 256M
+    instances: 1
+    buildpacks:
+      - nodejs_buildpack
+    env:
+      NEWRELIC_LICENSE: ((newrelic-license))
+      API_INTEROP_PRODUCTION: true
+      API_INTEROP_NAME: design
+      API_URL: https://weathergov-api-proxy.app.cloud.gov
+    health-check-type: process
+    path: ../api-interop-layer
+    random-route: false
+    services:
+      - database
 # - name: cronish
 #   <<: *defaults
 #   no-route: true

--- a/manifests/manifest-eric.yaml
+++ b/manifests/manifest-eric.yaml
@@ -15,11 +15,27 @@ default_config: &defaults
     - secrets
 
 applications:
-- name: weathergov-eric
-  <<: *defaults
-  memory: 256M
-  instances: 1
-  random-route: false
+  - name: weathergov-eric
+    <<: *defaults
+    memory: 256M
+    instances: 1
+    random-route: false
+
+  - name: api-weathergov-eric
+    stack: cflinuxfs4
+    memory: 256M
+    instances: 1
+    buildpacks:
+      - nodejs_buildpack
+    env:
+      NEWRELIC_LICENSE: ((newrelic-license))
+      API_INTEROP_PRODUCTION: true
+      API_INTEROP_NAME: eric
+    health-check-type: process
+    path: ../api-interop-layer
+    random-route: false
+    services:
+      - database
 # - name: cronish
 #   <<: *defaults
 #   no-route: true

--- a/manifests/manifest-greg.yaml
+++ b/manifests/manifest-greg.yaml
@@ -15,11 +15,27 @@ default_config: &defaults
     - secrets
 
 applications:
-- name: weathergov-greg
-  <<: *defaults
-  memory: 256M
-  instances: 1
-  random-route: false
+  - name: weathergov-greg
+    <<: *defaults
+    memory: 256M
+    instances: 1
+    random-route: false
+
+  - name: api-weathergov-greg
+    stack: cflinuxfs4
+    memory: 256M
+    instances: 1
+    buildpacks:
+      - nodejs_buildpack
+    env:
+      NEWRELIC_LICENSE: ((newrelic-license))
+      API_INTEROP_PRODUCTION: true
+      API_INTEROP_NAME: greg
+    health-check-type: process
+    path: ../api-interop-layer
+    random-route: false
+    services:
+      - database
 # - name: cronish
 #   <<: *defaults
 #   no-route: true

--- a/manifests/manifest-staging.yaml
+++ b/manifests/manifest-staging.yaml
@@ -15,11 +15,27 @@ default_config: &defaults
     - secrets
 
 applications:
-- name: weathergov-staging
-  <<: *defaults
-  memory: 256M
-  instances: 1
-  random-route: false
+  - name: weathergov-staging
+    <<: *defaults
+    memory: 256M
+    instances: 1
+    random-route: false
+
+  - name: api-weathergov-staging
+    stack: cflinuxfs4
+    memory: 256M
+    instances: 1
+    buildpacks:
+      - nodejs_buildpack
+    env:
+      NEWRELIC_LICENSE: ((newrelic-license))
+      API_INTEROP_PRODUCTION: true
+      API_INTEROP_NAME: staging
+    health-check-type: process
+    path: ../api-interop-layer
+    random-route: false
+    services:
+      - database
 # - name: cronish
 #   <<: *defaults
 #   no-route: true


### PR DESCRIPTION
## What does this PR do? 🛠️

Sets up deploy for all environments except beta. Addresses https://github.com/weather-gov/weather.gov/issues/1731

## What does the reviewer need to know? 🤔

It is not possible to have a rolling strategy for multiple apps defined in a manifest (see cloud.gov [documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html#deployment-process)). So here we are doing an app deploy one by one. Right now a "rolling" strategy doesn't matter that much because we only have one instance at any given time but it will matter when we add more instances down the line. 