### PR TITLE
Automatically set versions in Drupal library files at deploy-time

### DIFF
--- a/.github/actions/set-library-versions/action.yml
+++ b/.github/actions/set-library-versions/action.yml
@@ -1,0 +1,44 @@
+runs:
+  using: composite
+  steps:
+    - name: install dependencies
+      shell: bash
+      run: |
+        cd web/themes/new_weather_theme
+        npm ci
+    
+    - name: set library versions
+      uses: actions/github-script@v7
+      with: |
+        const { chdir } = require("node:process");
+        chdir("web/themes/new_weather_theme");
+
+        const fs = require("node:fs/promises");
+        const yaml = require("js-yaml");
+
+        const paths = [
+          "new_weather_theme.libraries.yml",
+          "../weathergov_admin/weathergov_admin.libraries.yml",
+        ];
+
+        const timestamp = Date.now();
+
+        await Promise.all(
+          paths.map(async (path) => {
+            const lib = yaml.load(await fs.readFile(path));
+            Object.entries(lib).forEach(([key, library]) => {
+              if (library.js) {
+                Object.keys(library.js).forEach((jsPath) => {
+                  // If any of the paths to the components of this library are not URLs,
+                  // then at least some of it must be local, in which case we should
+                  // increment the version.
+                  if (!URL.canParse(jsPath)) {
+                    library.version = timestamp;
+                  }
+                });
+              }
+            });
+
+            await fs.writeFile(path, yaml.dump(lib));
+          }),
+        );

--- a/.github/workflows/deploy-beta.yaml
+++ b/.github/workflows/deploy-beta.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: set library versions
+        uses: ./.github/actions/set-library-versions
       - name: bundle javascript
         uses: ./.github/actions/javascript-bundle
       - name: Deploy to cloud.gov sandbox

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -24,6 +24,8 @@ jobs:
       CF_PASSWORD: CF_${{ github.event.inputs.environment }}_PASSWORD
     steps:
       - uses: actions/checkout@v4
+      - name: set library versions
+        uses: ./.github/actions/set-library-versions
       - name: bundle javascript
         uses: ./.github/actions/javascript-bundle
       - name: Deploy application in ${{ github.event.inputs.environment }} space

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
+        - name: set library versions
+          uses: ./.github/actions/set-library-versions
         - name: bundle javascript
           uses: ./.github/actions/javascript-bundle
         - name: Deploy to cloud.gov weathergov-staging space


### PR DESCRIPTION
## What does this PR do? 🛠️

This code looks at our two themes' library files and looks for any entries that have Javascript components that are not hosted at URLs. Those entries have their `version` set to the current Unix timestamp, so they're guaranteed to always be unique and incrementing.

I tested the code in the action by pulling it into a separate JS file and just running it, and it correctly identified the right libraries and set the version on them. But of course, we won't know if this really works until we've put it in main. :sigh:

closes #1878