### PR TITLE
[Interop layer] Use a database connection pool

### DIFF
--- a/api-interop-layer/data/alerts/index.js
+++ b/api-interop-layer/data/alerts/index.js
@@ -2,7 +2,7 @@ import dayjs from "../../util/day.js";
 import { fetchAPIJson } from "../../util/fetch.js";
 import { createLogger } from "../../util/monitoring/index.js";
 import paragraphSquash from "../../util/paragraphSquash.js";
-import { openDatabase } from "../db.js";
+import openDatabase from "../db.js";
 import alertKinds from "./kinds.js";
 import {
   parseDescription,
@@ -144,8 +144,6 @@ export const updateAlerts = async () => {
   metadata.updated = dayjs();
   metadata.error = false;
 
-  await db.end();
-
   logger.verbose(`storing ${cachedAlerts.length} alerts`);
   return cachedAlerts;
 };
@@ -214,7 +212,6 @@ export default async ({ grid, point, place: { timezone } }) => {
     })
     .pop();
 
-  await db.end();
   logger.verbose(`got ${alerts.length} alerts; highest is ${highest?.text}`);
 
   // Clone the cached stuff so external entities can't overwrite it. Also so

--- a/api-interop-layer/data/alerts/index.test.js
+++ b/api-interop-layer/data/alerts/index.test.js
@@ -1,6 +1,5 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import * as mariadb from "mariadb";
 import dayjs from "../../util/day.js";
 import { alignAlertsToDaily } from "./utils.js";
 
@@ -26,19 +25,8 @@ const makeDayWithHours = (
 
 describe("alert data module", () => {
   const sandbox = sinon.createSandbox();
-  const db = {
-    query: sandbox.stub(),
-    end: () => Promise.resolve(),
-  };
 
   const response = { status: 200, json: sandbox.stub() };
-
-  // Do this before everything, so it'll happen before any describe blocks run,
-  // otherwise the connection creation won't be stubbed when the script is first
-  // imported below.
-  before(() => {
-    mariadb.default.createConnection.resolves(db);
-  });
 
   beforeEach(() => {
     response.status = 200;
@@ -46,7 +34,7 @@ describe("alert data module", () => {
     sandbox.resetHistory();
 
     fetch.resolves(response);
-    db.query.resolves([{ yes: 1 }]);
+    global.test.database.query.resolves([{ yes: 1 }]);
   });
 
   it("fetches alerts when the module is loaded", async () => {

--- a/api-interop-layer/data/db.js
+++ b/api-interop-layer/data/db.js
@@ -28,7 +28,7 @@ const getDatabaseConnection = () => {
   };
 };
 
-let pool = false;
+let pool;
 
 export default async () => {
   if (pool) {

--- a/api-interop-layer/data/obs/index.js
+++ b/api-interop-layer/data/obs/index.js
@@ -1,5 +1,5 @@
 import dayjs from "../../util/day.js";
-import { openDatabase } from "../db.js";
+import openDatabase from "../db.js";
 import isObservationValid from "./valid.js";
 import { convertProperties } from "../../util/convert.js";
 import { fetchAPIJson } from "../../util/fetch.js";
@@ -133,7 +133,6 @@ export default async ({
         ST_SRID(ST_GEOMFROMTEXT('POINT(${longitude} ${latitude})'), 4326)
       ) as distance
     `);
-    await db.end();
 
     sendNewRelicMetric({
       name: "wx.observation",

--- a/api-interop-layer/data/obs/index.test.js
+++ b/api-interop-layer/data/obs/index.test.js
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import * as mariadb from "mariadb";
 import dayjs from "dayjs";
 import sinon, { createSandbox } from "sinon";
 
@@ -15,16 +14,9 @@ describe("observations module", () => {
     json: sandbox.stub(),
   };
 
-  const db = {
-    query: sandbox.stub(),
-    end: () => Promise.resolve(),
-  };
-
   let getObservations;
 
   before(async () => {
-    mariadb.default.createConnection.resolves(db);
-
     // Import the module now. Its dependency on the database will cause a hang
     // if we load it before the mocking is all setup. The reason is that the
     // database utility itself blocks until it can establish a connection.
@@ -75,7 +67,7 @@ describe("observations module", () => {
       )
       .resolves(response);
 
-    db.query.resolves([{ distance: 100 }]);
+    global.test.database.query.resolves([{ distance: 100 }]);
   });
 
   describe("properly handles feels-like temperature", () => {

--- a/api-interop-layer/data/points.js
+++ b/api-interop-layer/data/points.js
@@ -1,4 +1,4 @@
-import { openDatabase } from "./db.js";
+import openDatabase from "./db.js";
 import { fetchAPIJson } from "../util/fetch.js";
 import { createLogger } from "../util/monitoring/index.js";
 

--- a/api-interop-layer/mocha.js
+++ b/api-interop-layer/mocha.js
@@ -1,19 +1,27 @@
 import sinon from "sinon"; // eslint-disable-line import/no-extraneous-dependencies
 import * as mariadb from "mariadb";
 
+const sandbox = sinon.createSandbox();
+
 export async function mochaGlobalSetup() {
-  sinon.stub(global, "fetch");
+  sandbox.stub(global, "fetch");
   sinon.stub(mariadb.default, "createConnection");
+  sinon.stub(mariadb.default, "createPool");
+  global.test = { database: { query: sandbox.stub(), end: sandbox.stub() } };
+
+  mariadb.default.createConnection.resolves(global.test.database);
+  mariadb.default.createPool.resolves(global.test.database);
 }
 
 export async function mochaGlobalTeardown() {
   global.fetch.restore();
   mariadb.default.createConnection.restore();
+  mariadb.default.createPool.restore();
 }
 
 export const mochaHooks = {
   beforeEach() {
-    fetch.resetHistory();
-    fetch.resetBehavior();
+    sandbox.resetHistory();
+    sandbox.resetBehavior();
   },
 };

--- a/web/themes/new_weather_theme/templates/partials/daily-summary-list-item.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/daily-summary-list-item.html.twig
@@ -34,9 +34,9 @@ day
 
         {% set alertCount = alerts.metadata.count %}
         {% if alertCount > 0 %}
-          {% set alertID = alerts.item[0].id %}
-          {% set alertType = alerts.item[0].event %}
-          {% set alertLevel = alerts.item[0].level %}
+          {% set alertID = alerts.items[0].id %}
+          {% set alertType = alerts.items[0].event %}
+          {% set alertLevel = alerts.items[0].level %}
 
           {% if alertCount > 1 %}
             {% set alertID = null %}


### PR DESCRIPTION
## What does this PR do? 🛠️

The MariaDB library that we're using (because there's not a first-party MySQL library, surprisingly) exposes alias methods on the pool object where it automatically fetches an available connection, executes the query, then releases the connection back to the pool. This way the various parts of the app the query the database don't also need to worry about freeing up the connection. At least one module was *not* releasing its connection, which is possibly why running browser tests more than 5-6 times in a few minutes would result in database crashes.

Anyway... this should handle that.

closes #1756 
