### PR TITLE
config split: enable s3fs for uploads on cloud.gov

### DIFF
--- a/web/config/cloudgov/config_split.patch.field.storage.node.field_fullimage.yml
+++ b/web/config/cloudgov/config_split.patch.field.storage.node.field_fullimage.yml
@@ -1,0 +1,6 @@
+adding:
+  settings:
+    uri_scheme: private
+removing:
+  settings:
+    uri_scheme: public

--- a/web/config/cloudgov/config_split.patch.field.storage.node.field_smallimage.yml
+++ b/web/config/cloudgov/config_split.patch.field.storage.node.field_smallimage.yml
@@ -1,0 +1,6 @@
+adding:
+  settings:
+    uri_scheme: private
+removing:
+  settings:
+    uri_scheme: public

--- a/web/config/cloudgov/config_split.patch.field.storage.node.field_wfo_sitrep.yml
+++ b/web/config/cloudgov/config_split.patch.field.storage.node.field_wfo_sitrep.yml
@@ -1,0 +1,6 @@
+adding:
+  settings:
+    uri_scheme: private
+removing:
+  settings:
+    uri_scheme: public


### PR DESCRIPTION
## What does this PR do? 🛠️

Enables `s3fs` for newer upload content types on cloud.gov. The config is copied from the pre-existing `config_split.patch.field.storage.node.field_image.yml` and _should_ be all we need here.

## What does the reviewer need to know? 🤔

To test, `docker compose exec drupal drush config-split:activate cloudgov` (don't forget to deactivate afterwards!)

We will need to test uploads again on staging to make sure uploaded s3 files are persisted. Uploading the newer uploads to s3 is untested. 