### PR TITLE
Set a manual node ID on the "today" tab forecast summary

### DIFF
--- a/web/themes/new_weather_theme/templates/partials/daily-summary-list-item.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/daily-summary-list-item.html.twig
@@ -10,7 +10,9 @@ intended for use within the "Today" tab, and should only
 display some of the forecast information for the current
 day
 #}
-{% set itemId =  periods[0].monthAndDay | lower | replace({" ":"-"}) %}
+{% if itemId is null %}
+  {% set itemId =  periods[0].monthAndDay | lower | replace({" ":"-"}) %}
+{% endif %}
 
 <li class="display-block bg-white padding-y-205 padding-x-205 shadow-1 grid-col-12 height-full" {% if itemId %}id="{{itemId}}{% endif %}">    
     <div class="grid-container padding-0 margin-bottom-2 tablet:margin-bottom-2">

--- a/web/themes/new_weather_theme/templates/partials/today-summary-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/today-summary-forecast.html.twig
@@ -12,6 +12,7 @@
         {% set precipHours = today.qpf[0] %}
         {% include '@new_weather_theme/partials/daily-summary-list-item.html.twig' with
         {
+            itemId: "quick-forecast-summary",
             'periods': today.periods,
             'dayHours': today.hours,
             'alerts': today.alerts,


### PR DESCRIPTION
## What does this PR do? 🛠️

The today tab forecast summary uses the same component as the daily forecast tab. This component automatically applies an ID to the container based on the forecast date. As a result, we end up with two nodes with the same node ID - one on the "today" tab and one on the "forecast" tab, which causes the quick forecast link to try to go to the wrong place.

This PR modifies the component so that it can accept a node ID as an argument and it will use the date if an ID is not provided, and modifies the today tab to provide an ID. This clears up the ID collision and fixes the link.