### PR TITLE
Enable debugging for the interop layer in local dev

### DIFF
--- a/api-interop-layer/package.json
+++ b/api-interop-layer/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node --expose-gc --experimental-loader newrelic/esm-loader.mjs -r newrelic main.js",
-    "start-dev": "nodemon -e js --experimental-loader newrelic/esm-loader.mjs -r newrelic main.js",
+    "start-dev": "nodemon -e js --experimental-loader newrelic/esm-loader.mjs -r newrelic --inspect=0.0.0.0:9229 main.js",
     "test": "LOG_LEVEL=silent c8 --reporter html --reporter clover mocha '**/*.test.js' --exclude 'node_modules/**' --require mocha.js"
   },
   "author": "",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - api-proxy
     ports:
       - 8082:8082
+      - 9229:9229
     volumes:
       - ./api-interop-layer:/app
       - /app/node_modules

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -4,6 +4,9 @@ Our Drupal container runs with xdebug installed and configured for debugging and
 coverage reporting. It should already be fully configured, so the only things
 you'll need to configure are your local IDE.
 
+This is also true for our API interop layer container. It enables the Node.js
+inspector and forwards its port to the docker host.
+
 If you're using Visual Studio, you can use the official
 [xdebug plugin](https://github.com/xdebug/vscode-php-debug) and follow the
 instructions there. The only things you should _need_ to change are the path
@@ -15,14 +18,25 @@ complete `launch.json`:
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Listen for Xdebug",
+      "type": "node",
+      "request": "attach",
+      "name": "Interop layer",
+      "address": "localhost",
+      "port": 9229,
+      "restart": true,
+      "remoteRoot": "/app",
+      "localRoot": "${workspaceFolder}/api-interop-layer"
+    },
+    {
+      "name": "Drupal",
       "type": "php",
       "request": "launch",
       "port": 9003,
       "pathMappings": {
         "/opt/drupal/web/sites": "${workspaceFolder}/web/sites",
         "/opt/drupal/web/modules": "${workspaceFolder}/web/modules",
-        "/opt/drupal/web/themes": "${workspaceFolder}/web/themes"
+        "/opt/drupal/web/themes": "${workspaceFolder}/web/themes",
+        "/opt/drupal/web/core": "/Users/michaelgwalker/src/drupal/core"
       }
     }
   ]


### PR DESCRIPTION
## What does this PR do? 🛠️

This PR turns on the Node.js inspector within nodemon and forwards the inspector ports back to the host machine. Documentation is also updated.

## What does the reviewer need to know? 🤔

It took several tries starting and restarting the VS Code debugger for it to attach properly, but then suddenly, it did. It's been reliable ever since.