### PR TITLE
increase dss builder upload limits to 3mb

### DIFF
--- a/.bp-config/php/php.ini.d/upload_max_filesize.ini
+++ b/.bp-config/php/php.ini.d/upload_max_filesize.ini
@@ -1,0 +1,3 @@
+; Increase upload limit to 3M for DSS builder integration
+; https://php.net/upload-max-filesize
+upload_max_filesize = 3M

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -96,6 +96,9 @@ RUN { \
   # messages about the debugger not being able to connect when we don't have a
   # listener running yet.
   echo 'xdebug.log_level=0'; \
+  # Mirror cloud.gov php settings
+  echo 'memory_limit = 512M'; \
+  echo 'upload_max_filesize = 3M'; \
   } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 ENV PATH=${PATH}:/opt/drupal/vendor/bin

--- a/web/config/sync/field.field.node.wfo_pdf_upload.field_wfo_sitrep.yml
+++ b/web/config/sync/field.field.node.wfo_pdf_upload.field_wfo_sitrep.yml
@@ -22,6 +22,6 @@ settings:
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: pdf
-  max_filesize: '2 MB'
+  max_filesize: '3 MB'
   description_field: false
 field_type: file

--- a/web/config/sync/field.field.node.wfo_weather_story_upload.field_fullimage.yml
+++ b/web/config/sync/field.field.node.wfo_weather_story_upload.field_fullimage.yml
@@ -41,7 +41,7 @@ settings:
   handler_settings: {  }
   file_directory: 'tmp/[random:number]'
   file_extensions: 'png gif jpg jpeg webp'
-  max_filesize: '2 MB'
+  max_filesize: '3 MB'
   max_resolution: ''
   min_resolution: ''
   alt_field: false

--- a/web/config/sync/field.field.node.wfo_weather_story_upload.field_smallimage.yml
+++ b/web/config/sync/field.field.node.wfo_weather_story_upload.field_smallimage.yml
@@ -41,7 +41,7 @@ settings:
   handler_settings: {  }
   file_directory: 'tmp/[random:number]'
   file_extensions: 'png gif jpg jpeg webp'
-  max_filesize: '2 MB'
+  max_filesize: '3 MB'
   max_resolution: ''
   min_resolution: ''
   alt_field: false


### PR DESCRIPTION
## What does this PR do? 🛠️

As per one of my weather story proposals, bump up the upload limit to 3M. 

Before:

```
error: could not upload file: [{'title': 'Unprocessable Content', 'status': '422', 'detail': 'Unprocessable Entity: file validation failed.\nThe file is 2.76 MB exceeding the maximum file size of 2 MB.', 'links': {'via': {'href': 'http://localhost:8080/jsonapi/node/wfo_weather_story_upload/field_smallimage'}}}]
```

after:
```
error: could not upload file: [{'title': 'Unprocessable Content', 'status': '422', 'detail': 'Unprocessable Entity: file validation failed.\nThe file is 3.29 MB exceeding the maximum file size of 3 MB.', 'links': {'via': {'href': 'http://localhost:8080/jsonapi/node/wfo_weather_story_upload/field_smallimage'}}}]
```

## What does the reviewer need to know? 🤔

Nada