### PR TITLE
When browsing to a place URL, don't redirect to a point URL

### DIFF
--- a/web/modules/weather_data/weather_data.module
+++ b/web/modules/weather_data/weather_data.module
@@ -1,15 +1,55 @@
 <?php
 
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
 function weather_data_template_preprocess_default_variables_alter(&$variables)
 {
     // First, get our route information.
     $container = \Drupal::getContainer();
     $route = $container->get("current_route_match");
 
-    // We only need to populate globals if we're on a point route.
-    if ($route->getRouteName() == "weather_routes.point") {
+    // By default, assume we are not on a page with lat/lon information.
+    $lat = null;
+    $lon = null;
+
+    $routeName = $route->getRouteName();
+
+    // If we're on a place route, we'll need to query to get the lat/lon. We
+    // are assured that a lat/lon will exist because the route controller will
+    // throw a 404 if there's not. It's a duplicate query, but I couldn't figure
+    // out how to pass the lat/lon from the route controller down to here.
+    if ($routeName == "weather_routes.place") {
+        $state = $route->getParameter("state");
+        $place = $route->getParameter("place");
+
+        $db = $container->get("database");
+        $location = $db
+            ->query(
+                "SELECT
+                ST_X(point) AS lon,
+                ST_Y(point) AS lat
+            FROM weathergov_geo_places
+            WHERE
+                state LIKE :state
+                AND
+                name LIKE :place",
+                [":state" => $state, ":place" => $place],
+            )
+            ->fetch();
+
+        $lat = $location->lat;
+        $lon = $location->lon;
+    }
+
+    // If we're on a point route, we can take lat/lon directly from the URL.
+    if ($routeName == "weather_routes.point") {
         $lat = $route->getParameter("lat");
         $lon = $route->getParameter("lon");
+    }
+
+    // If we have lat and lon, then we can fetch data from the interop layer and
+    // make it available to Twig.
+    if ($lat && $lon) {
         $weatherMetadata["point"] = ["lat" => $lat, "lon" => $lon];
 
         // this is required since we no longer can interpret api.weather.gov lat/lon directly

--- a/web/modules/weather_data/weather_data.module
+++ b/web/modules/weather_data/weather_data.module
@@ -22,6 +22,10 @@ function weather_data_template_preprocess_default_variables_alter(&$variables)
         $state = $route->getParameter("state");
         $place = $route->getParameter("place");
 
+        // We need to unescape spaces and slashes from the URL parameter.
+        $place = str_replace("_", " ", $place);
+        $place = str_replace(",", "/", $place);
+
         $db = $container->get("database");
         $location = $db
             ->query(
@@ -58,9 +62,7 @@ function weather_data_template_preprocess_default_variables_alter(&$variables)
 
         $fetch = $container->get("http_client");
         try {
-            $data = $fetch
-                ->get("$baseUrl/point/$lat/$lon")
-                ->getBody();
+            $data = $fetch->get("$baseUrl/point/$lat/$lon")->getBody();
         } catch (Throwable $e) {
             $data = '{"error":true}';
         }

--- a/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
+++ b/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
@@ -129,11 +129,11 @@ final class LocationAndGridRouteController extends ControllerBase
             );
 
             if ($location !== false) {
-                $url = Url::fromRoute("weather_routes.point", [
-                    "lat" => $location->lat,
-                    "lon" => $location->lon,
-                ]);
-                return new RedirectResponse($url->toString());
+                // If we get a location, continue with the rendering process.
+                // If anyone figures out how to pass the lat/lon from here on
+                // through the process, that'd be dandy – then the template
+                // variable preprocessor thingy wouldn't have to redo this query
+                return [];
             }
         } catch (\Throwable $e) {
             throw new NotFoundHttpException();

--- a/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
+++ b/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
@@ -113,28 +113,80 @@ final class LocationAndGridRouteController extends ControllerBase
         }
     }
 
-    public function redirectFromPlace($state, $place)
+    private function getKnownPlace($state, $place)
+    {
+        // We escape spaces with underscores and slashes with commas. We need
+        // to unescape them before querying. (None of the place names in our
+        // database have underscores or commas at the time of this writing.)
+        $place = str_replace("_", " ", $place);
+        $place = str_replace(",", "/", $place);
+
+        return $this->dataLayer->databaseFetch(
+            "SELECT
+                ST_X(point) AS lon,
+                ST_Y(point) AS lat,
+                state,
+                name
+            FROM weathergov_geo_places
+            WHERE
+                state LIKE :state
+                AND
+                name LIKE :place",
+            [":state" => $state, ":place" => $place],
+        );
+    }
+
+    public function servePlacePage($state, $place)
     {
         try {
-            $location = $this->dataLayer->databaseFetch(
-                "SELECT
-                    ST_X(point) AS lon,
-                    ST_Y(point) AS lat
-                FROM weathergov_geo_places
-                WHERE
-                    state LIKE :state
-                    AND
-                    name LIKE :place",
-                [":state" => $state, ":place" => $place],
-            );
+            $known = $this->getKnownPlace($state, $place);
 
-            if ($location !== false) {
-                // If we get a location, continue with the rendering process.
-                // If anyone figures out how to pass the lat/lon from here on
-                // through the process, that'd be dandy – then the template
-                // variable preprocessor thingy wouldn't have to redo this query
-                return [];
+            // If we don't know this place, immediately return a 404. There's no
+            // point doing any further processing.
+            if ($known == false) {
+                throw new NotFoundHttpException();
             }
+
+            // If the place name has a space in it, we'll need to redirect the
+            // user to the canonical URL.
+            $redirectForSpaces = str_contains($place, " ");
+
+            // Unescape the place name so we can compare it to the place name
+            // we got from the database.
+            $place = str_replace("_", " ", $place);
+            $place = str_replace(",", "/", $place);
+
+            // If the place name we got has a space in it, or if the state or
+            // place do not strictly match what's in our database, we'll send
+            // the user a redirect to our canonical place URL.
+            if (
+                $redirectForSpaces ||
+                $state != $known->state ||
+                $place != $known->name
+            ) {
+                // We'll send them back to this same route, but we'll use
+                // the state and place names from our database, with the
+                // place name escaped to handle spaces and slashes.
+                // (There are two places in American Samoa with slashes in
+                // their names, but slashes are URL path characters so we
+                // don't want to persist them!)
+                $url = Url::fromRoute("weather_routes.place", [
+                    "state" => $known->state,
+                    "place" => str_replace(
+                        "/",
+                        ",",
+                        str_replace(" ", "_", $known->name),
+                    ),
+                ]);
+                return new RedirectResponse($url->toString());
+            }
+
+            // If we're here, we know the location and the requested URL is
+            // already canonical, so continue with the rendering process.
+            // If anyone figures out how to pass the lat/lon from here on
+            // through the process, that'd be dandy – then the template
+            // variable preprocessor thingy wouldn't have to redo this query
+            return [];
         } catch (\Throwable $e) {
             throw new NotFoundHttpException();
         }

--- a/web/modules/weather_routes/weather_routes.routing.yml
+++ b/web/modules/weather_routes/weather_routes.routing.yml
@@ -32,7 +32,7 @@ weather_routes.grid:
 weather_routes.place:
   path: '/place/{state}/{place}'
   defaults:
-    _controller: \Drupal\weather_routes\Controller\LocationAndGridRouteController::redirectFromPlace
+    _controller: \Drupal\weather_routes\Controller\LocationAndGridRouteController::servePlacePage
   requirements:
     _access: 'TRUE'
     state: '^[a-zA-Z]{2}$'

--- a/web/themes/new_weather_theme/new_weather_theme.theme
+++ b/web/themes/new_weather_theme/new_weather_theme.theme
@@ -180,6 +180,8 @@ function new_weather_theme_theme_suggestions_page_alter(&$suggestions)
                 ->attributes->get("exception"),
         )
     ) {
+        // If there is an error and we have a page to handle that kind of error,
+        // update the suggested page. In every case, bail out here.
         $status_code = Drupal::requestStack()
             ->getCurrentRequest()
             ->attributes->get("exception")
@@ -187,9 +189,15 @@ function new_weather_theme_theme_suggestions_page_alter(&$suggestions)
         switch ($status_code) {
             case 404:
                 $suggestions[] = "page__" . (string) $status_code;
-                break;
+                return;
             default:
-                break;
+                return;
         }
+    }
+
+    // If we're on a place page, render the point page. The variable preprocess
+    // hook will ensure the appropriate data is available.
+    if (in_array("page__place", $suggestions)) {
+        $suggestions[] = "page__point";
     }
 }


### PR DESCRIPTION
## What does this PR do? 🛠️

Currently when you browse to a place page, such as https://beta.weather.gov/place/ca/oxnard, we find an appropriate lat/lon and redirect you to a point page: https://beta.weather.gov/point/34.1975/-119.17705

This is not ideal either for SEO or usability. This PR modifies that behavior.

1. If the place name has a space in it, we redirect to the same URL but with the space replaced with an underscore
2. If the state or place name are not capitalized the same as our database, we redirect to the same URL but with the capitalization normalized
3. If the state and place name match our database, we simply render the page instead of redirecting.

The result is that we should end up with mostly canonical URLs for all the places we know about. For example:

```
https://beta.weather.gov/places/ca/los angeles
```
would become
```
https://beta.weather.gov/places/CA/Los_Angeles
```

A natural successor and completion of #1514.

## Screenshots (if appropriate): 📸

***NOTE*** that this screenshot is a little outdated because the PR was updated to redirect from the "ca/los angeles" place to "CA/Los_Angeles". But it still shows the gist of what's going on.

![image](https://github.com/user-attachments/assets/6fda40c0-1296-477f-969e-f824a0253b23)

