### PR TITLE
derive WFO for weather story uploads

### DIFF
--- a/tests/playwright/outside/api.spec.js
+++ b/tests/playwright/outside/api.spec.js
@@ -157,6 +157,11 @@ describe("API tests", () => {
     const secondJson = await secondResponse.json();
     expect(secondJson).not.toHaveProperty("errors");
     expect(secondJson).toHaveProperty("data");
+    // verify that `weather_cms_entity_presave` could not derive the WFO due to
+    // insufficient information.
+    expect(secondJson.data).toHaveProperty('attributes');
+    expect(secondJson.data.attributes).toHaveProperty('field_derived_wfo');
+    expect(secondJson.data.attributes.field_derived_wfo).toEqual('unknown');
   });
 
   test("uploader cannot upload wfo weather story images with missing attributes", async ({ request }) => {
@@ -224,7 +229,7 @@ describe("API tests", () => {
           title: pngFilename,
           field_office: "WFO test office",
           field_description: "a blank uploaded image",
-          field_weburl: "/test/wxstory.php?wfo=test",
+          field_weburl: "/FXC/wxstory.php?wfo=test",
           field_frontpage: true,
           field_graphicnumber: 1,
           field_order: 1,
@@ -256,5 +261,11 @@ describe("API tests", () => {
     const secondJson = await secondResponse.json();
     expect(secondJson).not.toHaveProperty("errors");
     expect(secondJson).toHaveProperty("data");
+    // verify that `weather_cms_entity_presave` derived the WFO properly.
+    expect(secondJson.data).toHaveProperty('attributes');
+    expect(secondJson.data.attributes).toHaveProperty('field_derived_wfo');
+    expect(secondJson.data.attributes.field_derived_wfo).toEqual('TEST');
   });
 });
+
+    // TODO test: five regexp matches with example

--- a/tests/playwright/outside/api.spec.js
+++ b/tests/playwright/outside/api.spec.js
@@ -198,7 +198,7 @@ describe("API tests", () => {
     expect(secondResponse.status()).toEqual(422);
   });
 
-  test("uploader can upload wfo weather story images with all attributes", async ({ request }) => {
+  const uploadWeatherStoryWithAttributes = async (request, attributes) => {
     // step one: upload the first image
     const pngFilename = "test-upload.png";
     const uploadFullLocation = `${API_ENDPOINT}/node/wfo_weather_story_upload/field_fullimage`;
@@ -229,7 +229,7 @@ describe("API tests", () => {
           title: pngFilename,
           field_office: "WFO test office",
           field_description: "a blank uploaded image",
-          field_weburl: "/FXC/wxstory.php?wfo=test",
+          field_weburl: "",
           field_frontpage: true,
           field_graphicnumber: 1,
           field_order: 1,
@@ -239,6 +239,7 @@ describe("API tests", () => {
           field_cwa_center_lon: 119.6456844,
           field_starttime: 1726572420,
           field_endtime: 1726572420,
+          ...attributes,
         },
         relationships: {
           field_fullimage: {
@@ -261,11 +262,56 @@ describe("API tests", () => {
     const secondJson = await secondResponse.json();
     expect(secondJson).not.toHaveProperty("errors");
     expect(secondJson).toHaveProperty("data");
+    return secondJson;
+  };
+
+  test("uploader can upload wfo weather story images with all attributes", async ({ request }) => {
+    const json = await uploadWeatherStoryWithAttributes(request, {
+      field_weburl: "/FXC/wxstory.php?wfo=afc",
+    });
     // verify that `weather_cms_entity_presave` derived the WFO properly.
-    expect(secondJson.data).toHaveProperty('attributes');
-    expect(secondJson.data.attributes).toHaveProperty('field_derived_wfo');
-    expect(secondJson.data.attributes.field_derived_wfo).toEqual('TEST');
+    expect(json.data).toHaveProperty('attributes');
+    expect(json.data.attributes).toHaveProperty('field_derived_wfo');
+    expect(json.data.attributes.field_derived_wfo).toEqual('AFC');
+  });
+
+  test("drupal can derive wfo weather.gov url", async ({ request }) => {
+    const json = await uploadWeatherStoryWithAttributes(request, {
+      field_weburl: "https://www.weather.gov/SJT/",
+    });
+    // verify that `weather_cms_entity_presave` derived the WFO properly.
+    expect(json.data).toHaveProperty('attributes');
+    expect(json.data.attributes).toHaveProperty('field_derived_wfo');
+    expect(json.data.attributes.field_derived_wfo).toEqual('SJT');
+  });
+
+  test("drupal can derive wfo from relative WFO url", async ({ request }) => {
+    const json = await uploadWeatherStoryWithAttributes(request, {
+      field_weburl: "/grr/",
+    });
+    // verify that `weather_cms_entity_presave` derived the WFO properly.
+    expect(json.data).toHaveProperty('attributes');
+    expect(json.data.attributes).toHaveProperty('field_derived_wfo');
+    expect(json.data.attributes.field_derived_wfo).toEqual('GRR');
+  });
+
+  test("drupal can derive wfo from radar url", async ({ request }) => {
+    const json = await uploadWeatherStoryWithAttributes(request, {
+      field_weburl: "http://radar.weather.gov/lzk/",
+    });
+    // verify that `weather_cms_entity_presave` derived the WFO properly.
+    expect(json.data).toHaveProperty('attributes');
+    expect(json.data.attributes).toHaveProperty('field_derived_wfo');
+    expect(json.data.attributes.field_derived_wfo).toEqual('LZK');
+  });
+
+  test("drupal can derive wfo from srh.noaa.gov url", async ({ request }) => {
+    const json = await uploadWeatherStoryWithAttributes(request, {
+      field_weburl: "http://www.srh.noaa.gov/graphicast.php?site=jan&gc=8",
+    });
+    // verify that `weather_cms_entity_presave` derived the WFO properly.
+    expect(json.data).toHaveProperty('attributes');
+    expect(json.data.attributes).toHaveProperty('field_derived_wfo');
+    expect(json.data.attributes.field_derived_wfo).toEqual('JAN');
   });
 });
-
-    // TODO test: five regexp matches with example

--- a/web/config/sync/core.entity_form_display.node.wfo_weather_story_upload.default.yml
+++ b/web/config/sync/core.entity_form_display.node.wfo_weather_story_upload.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.wfo_weather_story_upload.field_cwa_center_lat
     - field.field.node.wfo_weather_story_upload.field_cwa_center_lon
+    - field.field.node.wfo_weather_story_upload.field_derived_wfo
     - field.field.node.wfo_weather_story_upload.field_description
     - field.field.node.wfo_weather_story_upload.field_endtime
     - field.field.node.wfo_weather_story_upload.field_frontpage
@@ -30,13 +31,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   field_cwa_center_lat:
     type: string_textfield
-    weight: 122
+    weight: 9
     region: content
     settings:
       size: 60
@@ -44,7 +45,15 @@ content:
     third_party_settings: {  }
   field_cwa_center_lon:
     type: string_textfield
-    weight: 123
+    weight: 10
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_derived_wfo:
+    type: string_textfield
+    weight: 22
     region: content
     settings:
       size: 60
@@ -52,7 +61,7 @@ content:
     third_party_settings: {  }
   field_description:
     type: text_textarea
-    weight: 132
+    weight: 18
     region: content
     settings:
       rows: 5
@@ -60,20 +69,20 @@ content:
     third_party_settings: {  }
   field_endtime:
     type: datetime_timestamp
-    weight: 126
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   field_frontpage:
     type: boolean_checkbox
-    weight: 130
+    weight: 17
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_fullimage:
     type: image_image
-    weight: 136
+    weight: 20
     region: content
     settings:
       progress_indicator: throbber
@@ -81,14 +90,14 @@ content:
     third_party_settings: {  }
   field_graphicnumber:
     type: number
-    weight: 127
+    weight: 14
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_office:
     type: string_textfield
-    weight: 124
+    weight: 11
     region: content
     settings:
       size: 60
@@ -96,21 +105,21 @@ content:
     third_party_settings: {  }
   field_order:
     type: number
-    weight: 128
+    weight: 15
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_radar:
     type: number
-    weight: 129
+    weight: 16
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_smallimage:
     type: image_image
-    weight: 137
+    weight: 21
     region: content
     settings:
       progress_indicator: throbber
@@ -118,13 +127,13 @@ content:
     third_party_settings: {  }
   field_starttime:
     type: datetime_timestamp
-    weight: 125
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   field_weburl:
     type: string_textfield
-    weight: 133
+    weight: 19
     region: content
     settings:
       size: 60
@@ -132,47 +141,47 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 2
+    weight: 1
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 15
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 120
+    weight: 8
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 16
+    weight: 5
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -180,7 +189,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 2
     region: content
     settings:
       match_operator: CONTAINS

--- a/web/config/sync/core.entity_view_display.node.wfo_weather_story_upload.default.yml
+++ b/web/config/sync/core.entity_view_display.node.wfo_weather_story_upload.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.wfo_weather_story_upload.field_cwa_center_lat
     - field.field.node.wfo_weather_story_upload.field_cwa_center_lon
+    - field.field.node.wfo_weather_story_upload.field_derived_wfo
     - field.field.node.wfo_weather_story_upload.field_description
     - field.field.node.wfo_weather_story_upload.field_endtime
     - field.field.node.wfo_weather_story_upload.field_frontpage
@@ -41,6 +42,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_derived_wfo:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 11
     region: content
   field_description:
     type: text_default

--- a/web/config/sync/core.entity_view_display.node.wfo_weather_story_upload.teaser.yml
+++ b/web/config/sync/core.entity_view_display.node.wfo_weather_story_upload.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.wfo_weather_story_upload.field_cwa_center_lat
     - field.field.node.wfo_weather_story_upload.field_cwa_center_lon
+    - field.field.node.wfo_weather_story_upload.field_derived_wfo
     - field.field.node.wfo_weather_story_upload.field_description
     - field.field.node.wfo_weather_story_upload.field_endtime
     - field.field.node.wfo_weather_story_upload.field_frontpage
@@ -33,6 +34,7 @@ content:
 hidden:
   field_cwa_center_lat: true
   field_cwa_center_lon: true
+  field_derived_wfo: true
   field_description: true
   field_endtime: true
   field_frontpage: true

--- a/web/config/sync/field.field.node.wfo_weather_story_upload.field_derived_wfo.yml
+++ b/web/config/sync/field.field.node.wfo_weather_story_upload.field_derived_wfo.yml
@@ -1,0 +1,25 @@
+uuid: 4f960333-68a8-4bed-a809-08e423dd8e48
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_derived_wfo
+    - node.type.wfo_weather_story_upload
+  module:
+    - unique_content_field_validation
+third_party_settings:
+  unique_content_field_validation:
+    unique: false
+    unique_text: ''
+id: node.wfo_weather_story_upload.field_derived_wfo
+field_name: field_derived_wfo
+entity_type: node
+bundle: wfo_weather_story_upload
+label: 'derived WFO'
+description: 'This derived WFO is automatically calculated or retrieved from the rest of the weather story data.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/config/sync/field.storage.node.field_derived_wfo.yml
+++ b/web/config/sync/field.storage.node.field_derived_wfo.yml
@@ -1,0 +1,21 @@
+uuid: 9a0681f5-9676-4faa-b2c2-e36c6f57aecf
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_derived_wfo
+field_name: field_derived_wfo
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/weather_cms/weather_cms.module
+++ b/web/modules/weather_cms/weather_cms.module
@@ -60,11 +60,6 @@ function weather_cms_form_adjust_timezones($form, &$form_state)
  */
 function weather_cms_entity_presave(Drupal\Core\Entity\EntityInterface $entity) {
 
-    // TODO test: if weburl is empty, derived field should be unknown
-    // TODO test: if derived field is already present, it is not changed even if weburl is changed
-    // TODO test: derived field is set through uploading
-    // TODO test: five regexp matches with example
-
     if ($entity->bundle() === 'wfo_weather_story_upload') {
 
         // field_derived_wfo can be manually overridden because it is not always

--- a/web/modules/weather_cms/weather_cms.module
+++ b/web/modules/weather_cms/weather_cms.module
@@ -78,7 +78,7 @@ function weather_cms_entity_presave(Drupal\Core\Entity\EntityInterface $entity) 
 
         // attempt to match against weather.gov.
         // example: http://www.weather.gov/mfl
-        $weathergov = "/^http:\/\/www.weather.gov\/([a-zA-Z]+)\/?$/i";
+        $weathergov = "/^https?:\/\/www.weather.gov\/([a-zA-Z]+)\/?$/i";
         if (preg_match($weathergov, $url, $matches)) {
             $derived_wfo = strtoupper($matches[1]);
             $entity->set('field_derived_wfo', $derived_wfo);
@@ -105,8 +105,8 @@ function weather_cms_entity_presave(Drupal\Core\Entity\EntityInterface $entity) 
 
         // attempt to match against radar.weather.gov.
         // example: http://radar.weather.gov/lzk/
-        $radar = "/^https?:\/\/radar.weather.gov\/([a-zA-Z]+)/i";
-        if (preg_match($fxc, $url, $matches)) {
+        $radar = "/^https?:\/\/radar.weather.gov\/([a-zA-Z]+)\/?/i";
+        if (preg_match($radar, $url, $matches)) {
             $derived_wfo = strtoupper($matches[1]);
             $entity->set('field_derived_wfo', $derived_wfo);
             return;

--- a/web/modules/weather_cms/weather_cms.module
+++ b/web/modules/weather_cms/weather_cms.module
@@ -54,3 +54,79 @@ function weather_cms_form_adjust_timezones($form, &$form_state)
     $form["timezone"]["timezone"]["#options"] = $timezone_ids_to_labels;
     return $form;
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function weather_cms_entity_presave(Drupal\Core\Entity\EntityInterface $entity) {
+
+    // TODO test: if weburl is empty, derived field should be unknown
+    // TODO test: if derived field is already present, it is not changed even if weburl is changed
+    // TODO test: derived field is set through uploading
+    // TODO test: five regexp matches with example
+
+    if ($entity->bundle() === 'wfo_weather_story_upload') {
+
+        // field_derived_wfo can be manually overridden because it is not always
+        // accurate. so if it is set, bail out.
+        if (!empty($entity->get('field_derived_wfo')->getValue())) {
+            return;
+        }
+
+        // WebURL is used to derive the WFO, so if it is not set, also bail out.
+        $url = $entity->get('field_weburl')->value;
+        if (empty($url)) {
+            // we can't map the WFO so mark as unknown.
+            $entity->set('field_derived_wfo', 'unknown');
+            return;
+        }
+
+        // attempt to match against weather.gov.
+        // example: http://www.weather.gov/mfl
+        $weathergov = "/^http:\/\/www.weather.gov\/([a-zA-Z]+)\/?$/i";
+        if (preg_match($weathergov, $url, $matches)) {
+            $derived_wfo = strtoupper($matches[1]);
+            $entity->set('field_derived_wfo', $derived_wfo);
+            return;
+        }
+
+        // attempt to match against a relative WFO url.
+        // example: /eax/
+        $relative = "/^\/([a-zA-Z]+)\/$/i";
+        if (preg_match($relative, $url, $matches)) {
+            $derived_wfo = strtoupper($matches[1]);
+            $entity->set('field_derived_wfo', $derived_wfo);
+            return;
+        }
+
+        // attempt to match against FXC.
+        // example: /FXC/wxstory.php?wfo=pqr
+        $fxc = "/^\/FXC\/wxstory.php\\?wfo=([a-zA-Z]+)$/i";
+        if (preg_match($fxc, $url, $matches)) {
+            $derived_wfo = strtoupper($matches[1]);
+            $entity->set('field_derived_wfo', $derived_wfo);
+            return;
+        }
+
+        // attempt to match against radar.weather.gov.
+        // example: http://radar.weather.gov/lzk/
+        $radar = "/^https?:\/\/radar.weather.gov\/([a-zA-Z]+)/i";
+        if (preg_match($fxc, $url, $matches)) {
+            $derived_wfo = strtoupper($matches[1]);
+            $entity->set('field_derived_wfo', $derived_wfo);
+            return;
+        }
+
+        // attempt to match against srh.noaa.gov. this is rare.
+        // example: http://www.srh.noaa.gov/graphicast.php?site=jan&gc=9
+        $srh = "/^https?:\/\/www.srh.noaa.gov\/graphicast.php\\?site=([a-zA-Z]+)/i";
+        if (preg_match($srh, $url, $matches)) {
+            $derived_wfo = strtoupper($matches[1]);
+            $entity->set('field_derived_wfo', $derived_wfo);
+            return;
+        }
+
+        // we can't map the WFO so mark as unknown.
+        $entity->set('field_derived_wfo', 'unknown');
+    }
+}


### PR DESCRIPTION
## What does this PR do? 🛠️

For weather story uploads, we attempt to derive the WFO based on, primarily, the `WebURL` XML attribute -- this gives us a ~92% success rate. **This is not a permanent solution.** The proper fix/approach needs to come from the DSS builder team, and this is a stopgap measure until we figure out the proper way to correlate weather story uploads and WFOs.

Note: I tried doing a computed property in Drupal but found it overly complicated and brittle with a lot of boilerplate code besides. So, I ended up going with a `presave` hook approach.

- Adds a new `field_derived_wfo` that can be overridden manually (that is, if the derived WFO is incorrect or unknown)
- `presave` hook will examine the weather story upload and attempt to derive the WFO
  - if the derived field is already set, we bail out. 
  - if the web url field is not set, we bail out. 
  - there are roughly five regexp matches we can attempt to derive the wfo from (all are covered with outside tests)
  - if we cannot determine the WFO then we set it to `unknown`

Closes https://github.com/weather-gov/weather.gov/issues/2060

## What does the reviewer need to know? 🤔

Please run outside tests manually with this PR -- they do not run as part of the CI (yet).