### PR TITLE
weather story uploads: overwrite upload

### DIFF
--- a/tests/playwright/outside/api.spec.js
+++ b/tests/playwright/outside/api.spec.js
@@ -139,7 +139,7 @@ describe("API tests", () => {
         type: "node--wfo_weather_story_upload",
         attributes: {
           title: pngFilename,
-          field_office: "WFO test office",
+          field_office: "test-WFO-office",
           field_description: "a blank uploaded image",
         },
         relationships: {
@@ -227,7 +227,7 @@ describe("API tests", () => {
         type: "node--wfo_weather_story_upload",
         attributes: {
           title: pngFilename,
-          field_office: "WFO test office",
+          field_office: "test-WFO-office",
           field_description: "a blank uploaded image",
           field_weburl: "",
           field_frontpage: true,

--- a/web/config/sync/field.field.node.wfo_weather_story_upload.field_fullimage.yml
+++ b/web/config/sync/field.field.node.wfo_weather_story_upload.field_fullimage.yml
@@ -12,7 +12,7 @@ third_party_settings:
   filefield_paths:
     enabled: true
     file_path:
-      value: '[node:field_office]/[node:content-type:machine-name]/field_fullimage'
+      value: '[node:field_derived_wfo]/[node:content-type:machine-name]/field_fullimage'
       options:
         slashes: true
         pathauto: false

--- a/web/config/sync/field.field.node.wfo_weather_story_upload.field_smallimage.yml
+++ b/web/config/sync/field.field.node.wfo_weather_story_upload.field_smallimage.yml
@@ -12,7 +12,7 @@ third_party_settings:
   filefield_paths:
     enabled: true
     file_path:
-      value: '[node:field_office]/[node:content-type:machine-name]/field_smallimage'
+      value: '[node:field_derived_wfo]/[node:content-type:machine-name]/field_smallimage'
       options:
         slashes: true
         pathauto: false

--- a/web/modules/weather_cms/weather_cms.module
+++ b/web/modules/weather_cms/weather_cms.module
@@ -128,8 +128,11 @@ function weather_cms_entity_presave(Drupal\Core\Entity\EntityInterface $entity)
 /**
  * Hook after `filefield_paths_filefield_paths_process_file` runs.
  */
-function weather_cms_filefield_paths_process_file(ContentEntityInterface $entity, FieldItemListInterface $field, array $settings)
-{
+function weather_cms_filefield_paths_process_file(
+    ContentEntityInterface $entity,
+    FieldItemListInterface $field,
+    array $settings
+) {
     // if we have a weather story upload, replace the file in-place if applicable.
     if ($entity->bundle() === 'wfo_weather_story_upload') {
         $file_system = \Drupal::service('file_system');
@@ -139,7 +142,7 @@ function weather_cms_filefield_paths_process_file(ContentEntityInterface $entity
             $dirname = $file_system->dirname($location);
             $new_location = "${dirname}/${origname}";
 
-            if ($location != $new_location) {
+            if ($location !== $new_location) {
                 $message = "weather story upload: moving ${location} to ${new_location}";
                 \Drupal::logger("weather_cms")->notice($message);
                 // NB `$file_system->moveUploadedFile` does not work here, so do

--- a/web/modules/weather_cms/weather_cms.module
+++ b/web/modules/weather_cms/weather_cms.module
@@ -147,10 +147,7 @@ function weather_cms_filefield_paths_process_file(
             if ($location !== $new_location) {
                 $message = "weather story upload: moving {$location} to {$new_location}";
                 \Drupal::logger("weather_cms")->notice($message);
-                // NB `$file_system->moveUploadedFile` does not work here, so do
-                // the renaming manually.
-                $file_system->delete($new_location);
-                $file_system->move($location, $new_location);
+                $file_system->move($location, $new_location, \Drupal\Core\File\FileExists::Replace);
             }
         }
     }

--- a/web/modules/weather_cms/weather_cms.module
+++ b/web/modules/weather_cms/weather_cms.module
@@ -1,6 +1,8 @@
 <?php
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\weather_cms\Timezones;
 
 // This hook allows us to alter single elements of a widget, which we want to do for alt text on uploaded images
@@ -122,5 +124,29 @@ function weather_cms_entity_presave(Drupal\Core\Entity\EntityInterface $entity)
 
         // we can't map the WFO so mark as unknown.
         $entity->set('field_derived_wfo', 'unknown');
+
+/**
+ * Hook after `filefield_paths_filefield_paths_process_file` runs.
+ */
+function weather_cms_filefield_paths_process_file(ContentEntityInterface $entity, FieldItemListInterface $field, array $settings)
+{
+    // if we have a weather story upload, replace the file in-place if applicable.
+    if ($entity->bundle() === 'wfo_weather_story_upload') {
+        $file_system = \Drupal::service('file_system');
+        foreach ($field->referencedEntities() as $file) {
+            $origname = $file->get('origname')->value;
+            $location = $file->get('uri')->value;
+            $dirname = $file_system->dirname($location);
+            $new_location = "${dirname}/${origname}";
+
+            if ($location != $new_location) {
+                $message = "weather story upload: moving ${location} to ${new_location}";
+                \Drupal::logger("weather_cms")->notice($message);
+                // NB `$file_system->moveUploadedFile` does not work here, so do
+                // the renaming manually.
+                $file_system->delete($new_location);
+                $file_system->move($location, $new_location);
+            }
+        }
     }
 }

--- a/web/modules/weather_cms/weather_cms.module
+++ b/web/modules/weather_cms/weather_cms.module
@@ -140,10 +140,10 @@ function weather_cms_filefield_paths_process_file(
             $origname = $file->get('origname')->value;
             $location = $file->get('uri')->value;
             $dirname = $file_system->dirname($location);
-            $new_location = "${dirname}/${origname}";
+            $new_location = "{$dirname}/{$origname}";
 
             if ($location !== $new_location) {
-                $message = "weather story upload: moving ${location} to ${new_location}";
+                $message = "weather story upload: moving {$location} to {$new_location}";
                 \Drupal::logger("weather_cms")->notice($message);
                 // NB `$file_system->moveUploadedFile` does not work here, so do
                 // the renaming manually.

--- a/web/modules/weather_cms/weather_cms.module
+++ b/web/modules/weather_cms/weather_cms.module
@@ -124,6 +124,8 @@ function weather_cms_entity_presave(Drupal\Core\Entity\EntityInterface $entity)
 
         // we can't map the WFO so mark as unknown.
         $entity->set('field_derived_wfo', 'unknown');
+    }
+}
 
 /**
  * Hook after `filefield_paths_filefield_paths_process_file` runs.


### PR DESCRIPTION
## What does this PR do? 🛠️

**NB** https://github.com/weather-gov/weather.gov/pull/2082 should be reviewed/merged first

Partially addresses https://github.com/weather-gov/weather.gov/issues/2033 -- specifically, by overwriting weather story images as they come in. I've also changed it so that uploads use the derived wfo for clarity. 

## What does the reviewer need to know? 🤔

I've added a logging message for this specific path. Example:

```
drupal-1             | [NOTICE] [weather_cms] [2024-11-18T22:06:32] weather story upload: moving public://National Weather Service/wfo_weather_story_upload/field_fullimage/fullimage1_43.png to public://National Weather Service/wfo_weather_story_upload/field_fullimage/fullimage1.png | uid: 2 | request-uri: http://localhost:8080/jsonapi/node/wfo_weather_story_upload
drupal-1             | [NOTICE] [weather_cms] [2024-11-18T22:06:32] weather story upload: moving public://National Weather Service/wfo_weather_story_upload/field_smallimage/smallimage1_36.png to public://National Weather Service/wfo_weather_story_upload/field_smallimage/smallimage1.png | uid: 2 | request-uri: http://localhost:8080/jsonapi/node/wfo_weather_story_upload
```

To test, please run outside tests twice and observe that `/web/sites/default/files/unknown/wfo_weather_story_upload/field_fullimage/test-upload.png` is overwritten properly.