### PR TITLE
[HOTFIX] Mismatch in exported config for new derived field

### DIFF
--- a/web/config/sync/jsonapi_extras.jsonapi_resource_config.node--wfo_weather_story_upload.yml
+++ b/web/config/sync/jsonapi_extras.jsonapi_resource_config.node--wfo_weather_story_upload.yml
@@ -170,6 +170,12 @@ resourceFields:
     publicName: field_cwa_center_lon
     enhancer:
       id: ''
+  field_derived_wfo:
+    disabled: false
+    fieldName: field_derived_wfo
+    publicName: field_derived_wfo
+    enhancer:
+      id: ''
   field_description:
     disabled: false
     fieldName: field_description
@@ -228,12 +234,6 @@ resourceFields:
     disabled: false
     fieldName: field_starttime
     publicName: field_starttime
-    enhancer:
-      id: ''
-  field_title:
-    disabled: false
-    fieldName: field_title
-    publicName: field_title
     enhancer:
       id: ''
   field_weburl:


### PR DESCRIPTION
## What does this PR do? 🛠️
We encountered a problem in the staging environment, where the newest updates from `main` were crashing the site.
  

## What does the reviewer need to know? 🤔
<!--- Include any local deployment instructions, navigation instructions, etc -->  

The issue appears to be the config failing to import properly. Logging into the instance, we found that running `drush config:import` gave the following error output:
<details>
<summary>Click to see the shell output</summary>

```shell
WARN[0000] The "NEWRELIC_LICENSE" variable is not set. Defaulting to a blank string. 
+------------+----------------------------------------------------------------+-----------+
| Collection | Config                                                         | Operation |
+------------+----------------------------------------------------------------+-----------+
|            | field.storage.node.field_derived_wfo                           | Create    |
|            | field.field.node.wfo_weather_story_upload.field_derived_wfo    | Create    |
|            | core.extension                                                 | Update    |
|            | core.entity_form_display.node.wfo_weather_story_upload.default | Update    |
|            | core.entity_view_display.node.wfo_weather_story_upload.teaser  | Update    |
|            | core.entity_view_display.node.wfo_weather_story_upload.default | Update    |
|            | user.role.authenticated                                        | Update    |
|            | workbench_access.access_scheme.wfo                             | Update    |
|            | workflows.workflow.weather_gov_content_moderation              | Update    |
|            | user.role.user_admin                                           | Update    |
|            | user.role.content_editor                                       | Update    |
|            | user.role.content_admin                                        | Update    |
|            | core.entity_form_display.node.weather_story.default            | Delete    |
|            | core.entity_view_display.node.weather_story.default            | Delete    |
|            | core.entity_view_display.node.weather_story.full               | Delete    |
|            | core.entity_view_display.node.weather_story.teaser             | Delete    |
|            | field.field.node.weather_story.body                            | Delete    |
|            | field.field.node.weather_story.field_wfo                       | Delete    |
|            | core.base_field_override.node.weather_story.promote            | Delete    |
|            | field.field.node.weather_story.field_image                     | Delete    |
|            | node.type.weather_story                                        | Delete    |
|            | field.storage.node.field_image                                 | Delete    |
+------------+----------------------------------------------------------------+-----------+

 // Import the listed configuration changes?: yes.                                                                      

[ERROR] [config_import] [2024-11-21T22:11:35] Drupal\Core\Config\ConfigImporterException: There were errors validating the config synchronization.
Integrity check failed for the JSON:API Extras configuration. There is no configuration set for the field "field_derived_wfo" on the resource "node--wfo_weather_story_upload". To fix this, disable the configuration integrity check (in the JSON:API Extras settings page), so you can import these fields locally. After that configure and re-save this resource type in the JSON:API Extras configuration page (http://default/admin/config/services/jsonapi/resource_types/node--wfo_weather_story_upload/edit). Finally, re-enable the configuration integrity checks and export the configuration again. in Drupal\Core\Config\ConfigImporter->validate() (line 823 of /opt/drupal/web/core/lib/Drupal/Core/Config/ConfigImporter.php). | uid: 0 | request-uri: http://default/
 [error]  Drupal\Core\Config\ConfigImporterException: There were errors validating the config synchronization.
Integrity check failed for the JSON:API Extras configuration. There is no configuration set for the field "field_derived_wfo" on the resource "node--wfo_weather_story_upload". To fix this, disable the configuration integrity check (in the JSON:API Extras settings page), so you can import these fields locally. After that configure and re-save this resource type in the JSON:API Extras configuration page (http://default/admin/config/services/jsonapi/resource_types/node--wfo_weather_story_upload/edit). Finally, re-enable the configuration integrity checks and export the configuration again. in Drupal\Core\Config\ConfigImporter->validate() (line 823 of /opt/drupal/web/core/lib/Drupal/Core/Config/ConfigImporter.php). 

In ConfigImportCommands.php line 290:
                                                                                                                                                                                                                                                         
  The import failed due to the following reasons:                                                                                                                                                                                                        
  Integrity check failed for the JSON:API Extras configuration. There is no configuration set for the field "field_derived_wfo" on the resource "node--wfo_weather_story_upload". To fix this, disable the configuration integrity check (in the JSON:A  
  PI Extras settings page), so you can import these fields locally. After that configure and re-save this resource type in the JSON:API Extras configuration page (http://default/admin/config/services/jsonapi/resource_types/node--wfo_weather_story_  
  upload/edit). Finally, re-enable the configuration integrity checks and export the configuration again.                                                                                                                                                
                                                                                                                                                                                                                                                         

In ConfigImporter.php line 823:
                                                                                                                                                                                                                                                         
  There were errors validating the config synchronization.                                                                                                                                                                                               
  Integrity check failed for the JSON:API Extras configuration. There is no configuration set for the field "field_derived_wfo" on the resource "node--wfo_weather_story_upload". To fix this, disable the configuration integrity check (in the JSON:A  
  PI Extras settings page), so you can import these fields locally. After that configure and re-save this resource type in the JSON:API Extras configuration page (http://default/admin/config/services/jsonapi/resource_types/node--wfo_weather_story_  
  upload/edit). Finally, re-enable the configuration integrity checks and export the configuration again.                                                                                                                                                                                                                                                                                                                                                                         
```

</details>
  
We decided to follow these steps in our local environment, simulating the experience of putting main atop the previous beta tagged commit. Steps were as follows:
1. Checkout the tag `beta-v1.10.0` locally and re-initialize all the docker setup based on it
2. Checkout main
3. Confirm the forecast page is erroring out (it was -- white screen of death 💀 ) ✅ 
4. Confirm `make import-config` gives the same error message as above ✅ 
5. Log into the admin panel and disable validity checking in JSON:API settings, as advised in error message
6. Confirm the new field is listed for weather story upload types in JSON:API settings ✅ 
7. Save the configuration for JSON:API
8. Export the config with `make export-config`

  
Those steps produced the extra config file present in this PR.
  
To test that it works with this config file present, we did the following steps all over again, cleanly:
1. Stash this new config file
1. Checkout the tag `beta-v1.10.0` locally and re-initialize all the docker setup based on it
2. Checkout main
3. Confirm the forecast page is erroring out (it was -- white screen of death 💀 ) ✅ 
4. Confirm `make import-config` gives the same error message as above ✅ 
5. Apply the stashed changes (the file in this PR, in addition to all the others)
6. Run `make import-config`
7. Confirm there were _no errors this time_ (there weren't)
8. Load the page without error ✅ 

