### PR TITLE
For unknown alerts with "evacuation" in the title, make them equivalent to the NWS-defined "Evacuation Immediate" event

### DIFF
--- a/api-interop-layer/data/alerts/backgroundUpdateTask.js
+++ b/api-interop-layer/data/alerts/backgroundUpdateTask.js
@@ -122,6 +122,12 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
         kind: "land",
         priority: Number.MAX_SAFE_INTEGER,
       };
+
+      if (/\bevacuation\b/i.test(rawAlert.properties.event)) {
+        // For any alert with the word "evacuation", pin it to the same metadata
+        // as the NWS-defined evacuation alert.
+        alert.metadata = alertKinds.get("evacuation immediate");
+      }
     }
 
     // For now, we're only ingesting land alerts. Once we get into marine

--- a/api-interop-layer/data/alerts/backgroundUpdateTask.test.js
+++ b/api-interop-layer/data/alerts/backgroundUpdateTask.test.js
@@ -297,6 +297,44 @@ describe("alert background processing module", () => {
     });
   });
 
+  it("prioritizes unknown 'evacuation' alerts correctly", async () => {
+    response.json.resolves({
+      features: [
+        {
+          geometry: "geo",
+          properties: {
+            id: "one",
+            event: "Pasta Sauce Evacuation Emergency",
+            sent: dayjs().subtract(1, "minute").toISOString(),
+            effective: dayjs().subtract(1, "minute").toISOString(),
+            onset: dayjs().subtract(1, "minute").toISOString(),
+            expires: dayjs().add(1, "minute").toISOString(),
+            ends: dayjs().add(1, "minute").toISOString(),
+          },
+        },
+      ],
+    });
+
+    await updateAlerts({ parent });
+
+    const newAlerts = getNewAlertsMessages();
+    const [
+      {
+        alert: { event, metadata },
+      },
+    ] = newAlerts[0];
+
+    expect(event).to.equal("Pasta Sauce Evacuation Emergency");
+    expect(metadata).to.eql({
+      level: {
+        priority: 2048,
+        text: "other",
+      },
+      kind: "land",
+      priority: 8192,
+    });
+  });
+
   it("posts an error if it encounters a problem", async () => {
     fetch.rejects();
 


### PR DESCRIPTION
Just what it says on the tin, plus tests.

- closes #1841
