### PR TITLE
pm2 configuration tweaks

### DIFF
--- a/api-interop-layer/ecosystem.config.cjs
+++ b/api-interop-layer/ecosystem.config.cjs
@@ -2,9 +2,9 @@ module.exports = {
   apps: [{
     name: "api-interop-layer",
     script: "main.js",
-    ignore_watch: ["newrelic_agent.log"],
+    ignore_watch: ["newrelic_agent.log", "node_modules", ".pm2"],
     args: "--update-env",
     interpreter_args: "--experimental-loader newrelic/esm-loader.mjs -r newrelic",
-    watch: true
+    watch: ["*.js"]
   }]
 }


### PR DESCRIPTION
## What does this PR do? 🛠️

PM2 was crashing because it was watching its own pid file. Configure it to watch only javascript files instead.