### PR TITLE
Browser test tweaks

### DIFF
--- a/tests/playwright/e2e/afd-page.spec.js
+++ b/tests/playwright/e2e/afd-page.spec.js
@@ -33,6 +33,7 @@ describe("AFD Page Tests", () => {
     }) => {
       const response = await page.goto(
         "http://localhost:8080/afd/OKX/invalid-afd-id.json",
+        { waitUntil: "load" }
       );
 
       expect(response.status()).toBe(404);
@@ -41,7 +42,7 @@ describe("AFD Page Tests", () => {
     test("Displays a 404 page for a listing of AFDs at an invalid WFO", async ({
       page,
     }) => {
-      const response = await page.goto("http://localhost:8080/afd/WWW");
+      const response = await page.goto("http://localhost:8080/afd/WWW", { waitUntil: "load" });
 
       expect(response.status()).toBe(404);
     });
@@ -51,8 +52,8 @@ describe("AFD Page Tests", () => {
     test("Can retrieve <option> elements html partial for version listing", async ({
       page,
     }) => {
-      await page.goto("http://localhost:8081/proxy/play/testing");
-      await page.goto("http://localhost:8080/wx/afd/locations/OKX");
+      await page.goto("http://localhost:8081/proxy/play/testing", { waitUntil: "load"});
+      await page.goto("http://localhost:8080/wx/afd/locations/OKX", { waitUntil: "load"});
 
       const options = await page.locator("option:first-child");
       await expect(options).toHaveCount(1);
@@ -65,7 +66,7 @@ describe("AFD Page Tests", () => {
     });
 
     test("Can retreive html partial for AFD content", async ({ page }) => {
-      await page.goto("http://localhost:8081/proxy/play/testing");
+      await page.goto("http://localhost:8081/proxy/play/testing", { waitUntil: "load"});
       // See tests/api/data/products/
       // This is our OKX first AFD testing example data
       await page.goto(`http://localhost:8080/wx/afd/${firstId}`);
@@ -80,14 +81,14 @@ describe("AFD Page Tests", () => {
 
   describe("Querystrings and Redirects", () => {
     beforeEach(async ({ page }) => {
-      await page.goto("http://localhost:8081/proxy/play/testing");
+      await page.goto("http://localhost:8081/proxy/play/testing", { waitUntil: "load"});
     });
 
     test("Hitting /afd without any querystrings will redirect to the most recent anywhere", async ({
       page,
     }) => {
       const expectedId = OVERALL_REFERENCES["@graph"][0].id;
-      await page.goto(`http://localhost:8080/afd`);
+      await page.goto("http://localhost:8080/afd", { waitUntil: "load" });
       await page.waitForURL(`http://localhost:8080/afd/TAE/${expectedId}`);
 
       const article = await page.locator("article");
@@ -100,7 +101,7 @@ describe("AFD Page Tests", () => {
       page,
     }) => {
       const expectedId = OKX_REFERENCES["@graph"][0].id;
-      await page.goto("http://localhost:8080/afd?wfo=OKX");
+      await page.goto("http://localhost:8080/afd?wfo=OKX", { waitUntil: "load"});
       await page.waitForURL(`http://localhost:8080/afd/OKX/${expectedId}`);
 
       const article = await page.locator("article");
@@ -135,8 +136,8 @@ describe("AFD Page Tests", () => {
    */
   describe("Changing selections tests", () => {
     beforeEach(async ({ page }) => {
-      await page.goto("http://localhost:8081/proxy/play/testing");
-      await page.goto("http://localhost:8080/afd/OKX");
+      await page.goto("http://localhost:8081/proxy/play/testing", { waitUntil: "load"});
+      await page.goto("http://localhost:8080/afd/OKX", { waitUntil: "load"});
     });
 
     describe("WFO selector correctly populates based on path", () => {
@@ -146,7 +147,7 @@ describe("AFD Page Tests", () => {
       });
 
       test("with lowercase WFO code", async ({ page }) => {
-        await page.goto("http://localhost:8080/afd/okx");
+        await page.goto("http://localhost:8080/afd/okx", { waitUntil: "load"});
         const selected = page.locator(`wx-combo-box input[name="wfo"]`);
         await expect(selected).toHaveValue("OKX");
       });

--- a/tests/playwright/e2e/alerts.spec.js
+++ b/tests/playwright/e2e/alerts.spec.js
@@ -5,8 +5,8 @@ const { describe, beforeEach } = test;
 
 describe("Alerts e2e tests", () => {
   beforeEach(async ({ page }) => {
-    await page.goto("http://localhost:8081/proxy/play/testing");
-    await page.goto("/point/34.749/-92.275");
+    await page.goto("http://localhost:8081/proxy/play/testing", { waitUntil: "load"});
+    await page.goto("/point/34.749/-92.275", { waitUntil: "load"});
   });
 
   test("The correct number of alerts show on the page", async ({ page }) => {

--- a/tests/playwright/e2e/combo-box-location.spec.js
+++ b/tests/playwright/e2e/combo-box-location.spec.js
@@ -29,7 +29,7 @@ describe("wx-combo-box-location tests", () => {
       },
     );
 
-    await page.goto("http://localhost:8080");
+    await page.goto("http://localhost:8080", { waitUntil: "load"});
   });
 
   test("Can find the combo-box element", async ({ page }) => {

--- a/tests/playwright/e2e/daily-forecast-alerts.spec.js
+++ b/tests/playwright/e2e/daily-forecast-alerts.spec.js
@@ -5,7 +5,7 @@ const { describe, beforeEach } = test;
 describe("alerts in the daily tab", () => {
   beforeEach(async ({ page }) => {
     await page.goto("http://localhost:8081/proxy/play/testing");
-    await page.goto("/point/34.749/-92.275");
+    await page.goto("/point/34.749/-92.275", { waitUntil: "load"});
     await page.locator("#daily-tab-button").first().click();
   });
 

--- a/tests/playwright/e2e/daily-forecast.spec.js
+++ b/tests/playwright/e2e/daily-forecast.spec.js
@@ -8,7 +8,7 @@ describe("daily forecast", () => {
   });
 
   test("does not display missing day periods", async ({ page }) => {
-    await page.goto("/point/21.305/-157.858");
+    await page.goto("/point/21.305/-157.858", { waitUntil: "load"});
     const lastDay = page
       .locator(".wx-daily-forecast-block .wx-daily-forecast-list-item")
       .last();

--- a/tests/playwright/e2e/dates-are-localized.spec.js
+++ b/tests/playwright/e2e/dates-are-localized.spec.js
@@ -13,7 +13,7 @@ describe("main script", () => {
     describe("formats the timestamp according to the browser's locale settings", () => {
       test.use({ locale });
       test(`for the ${locale} locale`, async ({ page }) => {
-        await page.goto("/point/33.521/-86.812");
+        await page.goto("/point/33.521/-86.812", { waitUntil: "load"});
 
         const timestamps = await page.locator("time[data-wx-local-time]").all();
         expect(timestamps.length).toBeGreaterThan(0);

--- a/tests/playwright/e2e/hourly-forecast.spec.js
+++ b/tests/playwright/e2e/hourly-forecast.spec.js
@@ -7,7 +7,7 @@ describe("Hourly forecast table tests", () => {
   describe("Alert row spanning tests", () => {
     beforeEach(async ({ page }) => {
       await page.goto("http://localhost:8081/proxy/play/testing");
-      await page.goto("/point/34.749/-92.275#daily");
+      await page.goto("/point/34.749/-92.275#daily", { waitUntil: "load"});
     });
 
     test("Should have 2 alert rows on the hourly forecast", async ({
@@ -56,13 +56,13 @@ describe("Hourly forecast table tests", () => {
 
   describe("Alert span clicking behavior", () => {
     beforeEach(async ({ page }) =>
-      page.goto("http://localhost:8081/proxy/play/testing"),
+      page.goto("http://localhost:8081/proxy/play/testing", { waitUntil: "load"}),
     );
 
     test("works when clicking an alert in one of the daily tab's hourly tables", async ({
       page,
     }) => {
-      await page.goto("/point/34.749/-92.275#daily");
+      await page.goto("/point/34.749/-92.275#daily", { waitUntil: "load"});
 
       // Click the alert
       await page
@@ -85,7 +85,7 @@ describe("Hourly forecast table tests", () => {
 
   describe("Hourly precipitation tables", () => {
     test("Renders tables for every day", async ({ page }) => {
-      await page.goto("/point/34.749/-92.275#daily");
+      await page.goto("/point/34.749/-92.275#daily", { waitUntil: "load"});
 
       const count = await page
         .locator("#daily ol li table.wx-precip-table")

--- a/tests/playwright/e2e/invalid-icons.spec.js
+++ b/tests/playwright/e2e/invalid-icons.spec.js
@@ -5,7 +5,7 @@ const { describe, beforeEach } = test;
 describe("Invalid icon URL tests", () => {
   beforeEach(async ({ page }) => {
     await page.goto("http://localhost:8081/proxy/play/testing");
-    await page.goto("/point/38.886/-77.094");
+    await page.goto("/point/38.886/-77.094", { waitUntil: "load"});
   });
 
   test("Doesn't render icon for unknown icon name (current conditions)", async ({
@@ -63,7 +63,7 @@ describe("Invalid icon URL tests", () => {
 describe("Valid icon rendering double-checks", () => {
   beforeEach(async ({ page }) => {
     await page.goto("http://localhost:8081/proxy/play/testing");
-    await page.goto("/point/34.749/-92.275");
+    await page.goto("/point/34.749/-92.275", { waitUntil: "load"});
   });
 
   test("Should render an icon in the current conditions", async ({ page }) => {

--- a/tests/playwright/e2e/invalid-locations-are-not-found.spec.js
+++ b/tests/playwright/e2e/invalid-locations-are-not-found.spec.js
@@ -13,7 +13,7 @@ describe("invalid location-based routes return 404", () => {
       ["with non-numeric longitude", "123", "abc"],
     ].forEach(([name, lat, lon]) => {
       test(name, async ({ page }) => {
-        const response = await page.goto(`/point/${lat}/${lon}`);
+        const response = await page.goto(`/point/${lat}/${lon}`, { waitUnfil: "load"});
         await expect(response.status()).toEqual(404);
       });
     });
@@ -26,7 +26,7 @@ describe("invalid location-based routes return 404", () => {
       ["with WFO with numbers", "a1b"],
     ].forEach(([name, wfo]) => {
       test(name, async ({ page }) => {
-        const response = await page.goto(`/local/${wfo}/1/1`);
+        const response = await page.goto(`/local/${wfo}/1/1`, { waitUnfil: "load"});
         await expect(response.status()).toEqual(404);
       });
     });
@@ -38,7 +38,7 @@ describe("invalid location-based routes return 404", () => {
       ["with non-numeric Y", "1", "a"],
     ].forEach(([name, x, y]) => {
       test(name, async ({ page }) => {
-        const response = await page.goto(`/local/TST/${x}/${y}`);
+        const response = await page.goto(`/local/TST/${x}/${y}`, { waitUnfil: "load"});
         await expect(response.status()).toEqual(404);
       });
     });

--- a/tests/playwright/e2e/location-page.spec.js
+++ b/tests/playwright/e2e/location-page.spec.js
@@ -9,7 +9,7 @@ describe("the location page", () => {
   });
 
   test("does not display marine alerts", async ({ page }) => {
-    await page.goto("/point/33.521/-86.812");
+    await page.goto("/point/33.521/-86.812", { waitUntil: "load"});
     const alertEl = page.locator("weathergov-alert-list > div");
 
     await expect(alertEl).toHaveCount(1);
@@ -18,7 +18,7 @@ describe("the location page", () => {
   });
 
   test("does include alerts based on fire zone", async ({ page }) => {
-    await page.goto("/point/34.749/-92.275");
+    await page.goto("/point/34.749/-92.275", { waitUntil: "load"});
     const alertEl = page.locator("weathergov-alert-list > div");
 
     await expect(alertEl).toContainText("Red Flag Warning");
@@ -26,7 +26,7 @@ describe("the location page", () => {
 
   describe("shows n/a for unavailable data", () => {
     test("wind is null", async ({ page }) => {
-      await page.goto("/point/33.211/-87.566");
+      await page.goto("/point/33.211/-87.566", { waitUntil: "load"});
       const windEl = page.locator(".wx-current-conditions .wx-wind-speed > td");
 
       await expect(windEl).toContainText("N/A");
@@ -37,7 +37,7 @@ describe("the location page", () => {
     test("does not kload if the today tab is not displaying", async ({
       page,
     }) => {
-      await page.goto("/point/33.521/-86.812");
+      await page.goto("/point/33.521/-86.812", { waitUntil: "load"});
       const radarContainer = page.locator("#wx_radar_container");
 
       await expect(radarContainer).toBeEmpty();
@@ -46,7 +46,7 @@ describe("the location page", () => {
     test("loads correctly after switching to the today tab", async ({
       page,
     }) => {
-      await page.goto("/point/33.521/-86.812");
+      await page.goto("/point/33.521/-86.812", { waitUntil: "load"});
       const currentTab = page.locator('[data-tab-name="today"]');
       const radarContainer = page.locator("#wx_radar_container");
 
@@ -61,7 +61,7 @@ describe("the location page", () => {
     test("should load the default tabbed view without any error messages", async ({
       page,
     }) => {
-      await page.goto("/point/34.749/-92.275");
+      await page.goto("/point/34.749/-92.275", { waitUntil: "load"});
       const errorEl = page.locator(".usa-alert--error");
 
       await expect(errorEl).toHaveCount(0);
@@ -70,7 +70,7 @@ describe("the location page", () => {
     test("should load without any error messages in the today tab", async ({
       page,
     }) => {
-      await page.goto("/point/34.749/-92.275#today");
+      await page.goto("/point/34.749/-92.275#today", { waitUntil: "load"});
       const errorEl = page.locator(".usa-alert--error");
 
       await expect(errorEl).toHaveCount(0);
@@ -79,7 +79,7 @@ describe("the location page", () => {
     test("should load without any error messages in the daily (7-day) tab", async ({
       page,
     }) => {
-      await page.goto("/point/34.749/-92.275#daily");
+      await page.goto("/point/34.749/-92.275#daily", { waitUntil: "load"});
       const errorEl = page.locator(".usa-alert--error");
 
       await expect(errorEl).toHaveCount(0);
@@ -88,7 +88,7 @@ describe("the location page", () => {
     test("should load without any error messages in the current conditions tab", async ({
       page,
     }) => {
-      await page.goto("/point/34.749/-92.275#today");
+      await page.goto("/point/34.749/-92.275#today", { waitUntil: "load"});
       const errorEl = page.locator(".usa-alert--error");
 
       await expect(errorEl).toHaveCount(0);

--- a/tests/playwright/e2e/location-pages-preserve-browser-history.spec.js
+++ b/tests/playwright/e2e/location-pages-preserve-browser-history.spec.js
@@ -7,7 +7,7 @@ describe("location search", () => {
     const start = "/point/36.168/-86.778";
 
     await page.goto("http://localhost:8081/stop");
-    await page.goto(start);
+    await page.goto(start, { waitUntil: "load"});
 
     // Clear out saved results for simplicity's sake
     await page.evaluate(() => {

--- a/tests/playwright/e2e/qpf-table.spec.js
+++ b/tests/playwright/e2e/qpf-table.spec.js
@@ -6,7 +6,7 @@ const { describe, beforeEach } = test;
 describe("quantitative precipitation forecast table", () => {
   beforeEach(async ({ page }) => {
     await page.goto("http://localhost:8081/proxy/play/testing");
-    await page.goto("http://localhost:8080/point/34.749/-92.275#daily");
+    await page.goto("http://localhost:8080/point/34.749/-92.275#daily", { waitUntil: "load"});
   });
 
   test("shows snow, ice, and water when all are present", async ({ page }) => {

--- a/tests/playwright/e2e/quick-forecast.spec.js
+++ b/tests/playwright/e2e/quick-forecast.spec.js
@@ -4,7 +4,7 @@ const { describe, beforeEach } = test;
 
 beforeEach(async ({page}) => {
   await page.goto("http://localhost:8081/proxy/play/testing");
-  await page.goto("/point/34.749/-92.275");
+  await page.goto("/point/34.749/-92.275", { waitUntil: "load"});
   await page.locator("#daily-tab-button").click();
   await page.locator('.wx-quick-forecast[role="tablist"]').waitFor();
 });

--- a/tests/playwright/e2e/quick-toggle.spec.js
+++ b/tests/playwright/e2e/quick-toggle.spec.js
@@ -4,7 +4,7 @@ const { describe, beforeEach } = test;
 
 beforeEach(async ({page}) => {
   await page.goto("http://localhost:8081/proxy/play/testing");
-  await page.goto("/point/34.749/-92.275");
+  await page.goto("/point/34.749/-92.275", { waitUntil: "load"});
   await page.locator("#daily-tab-button").click();
   await page.locator('.wx-quick-forecast[role="tablist"]').waitFor();
   const currentHeight = page.viewportSize().height;

--- a/tests/playwright/e2e/radar.spec.js
+++ b/tests/playwright/e2e/radar.spec.js
@@ -6,7 +6,7 @@ const { describe, beforeEach } = test;
 describe("radar component", () => {
   beforeEach(async ({ page }) => {
     await page.goto("http://localhost:8081/proxy/play/testing");
-    await page.goto("/point/35.198/-111.651");
+    await page.goto("/point/35.198/-111.651", { waitUntil: "load"});
   });
 
   describe("radar container", () => {

--- a/tests/playwright/e2e/tabbed-nav.spec.js
+++ b/tests/playwright/e2e/tabbed-nav.spec.js
@@ -13,7 +13,7 @@ describe("<wx-tabbed-nav> component tests", () => {
   describe("Alert link interaction", () => {
     beforeEach(async ({ page }) => {
       await page.goto("http://localhost:8081/proxy/play/testing");
-      await page.goto("/point/34.749/-92.275");
+      await page.goto("/point/34.749/-92.275", { waitUntil: "load"});
     });
 
     describe("Basic tabbed nav tests", () => {
@@ -153,7 +153,7 @@ describe("<wx-tabbed-nav> component tests", () => {
       page,
     }) => {
       const alertID = "alert_aa84ba418dfe6f3e1eb046cf9e4086aaaaddeb65_001_1";
-      await page.goto(`/point/34.749/-92.275#${alertID}`);
+      await page.goto(`/point/34.749/-92.275#${alertID}`, { waitUnfil: "load"});
 
       const alert = await page.locator(`#${alertID}`).first();
       const alertContent = await alert
@@ -175,7 +175,7 @@ describe("<wx-tabbed-nav> component tests", () => {
       test(`Activates the ${tabName} tab if the hash is present`, async ({
         page,
       }) => {
-        await page.goto(`/point/34.749/-92.275#${tabName}`);
+        await page.goto(`/point/34.749/-92.275#${tabName}`, { waitUnfil: "load"});
         const tabButton = await page
           .locator(`.tab-button[data-tab-name="${tabName}"]`)
           .first();
@@ -197,7 +197,7 @@ describe("<wx-tabbed-nav> component tests", () => {
       });
 
       const badHash = "urn:hello.there.everyone";
-      await page.goto(`/point/34.749/-92.275#${badHash}`);
+      await page.goto(`/point/34.749/-92.275#${badHash}`, { waitUnfil: "load"});
 
       expect(gotError).toBe(false);
     });
@@ -207,7 +207,7 @@ describe("<wx-tabbed-nav> component tests", () => {
     test("Should not display an alerts tab or area if there are no alerts", async ({
       page,
     }) => {
-      await page.goto("/point/35.198/-111.651");
+      await page.goto("/point/35.198/-111.651", { waitUntil: "load"});
       const tabButton = await page.locator(
         '.tab-button[data-tab-name="alerts"]',
       );
@@ -220,7 +220,7 @@ describe("<wx-tabbed-nav> component tests", () => {
 
   describe("a11y tablist/tabpanel guidelines tests", () => {
     beforeEach(async ({ page }) => {
-      await page.goto("/point/34.749/-92.275");
+      await page.goto("/point/34.749/-92.275", { waitUntil: "load"});
     });
 
     test("puts focus on the corresponding tabpanel when tab is pushed from a focused tab button", async ({

--- a/tests/playwright/e2e/territories.spec.js
+++ b/tests/playwright/e2e/territories.spec.js
@@ -21,7 +21,7 @@ describe("territory places are supported", () => {
     // ["", "US Minor Outlying Islands (UM)", ""],
   ].forEach(([url, territory, place]) => {
     test(`supports ${territory}`, async ({ page }) => {
-      await page.goto(url);
+      await page.goto(url, { waitUntil: "load"});
       await expect(page.locator("main h1")).toContainText(place);
 
       // These validate that there is forecast data for the territories. But

--- a/tests/playwright/e2e/touchpoints.spec.js
+++ b/tests/playwright/e2e/touchpoints.spec.js
@@ -6,7 +6,7 @@ describe("Touchpoints button tests", () => {
   describe("Basic layout", () => {
 
     test("Touchpoints button is visible", async ({ page }) => {
-      await page.goto("http://localhost:8080/");
+      await page.goto("http://localhost:8080/", { waitUntil: "load" });
       const button = await page.locator("a.touchpoints-button");
 
       await expect(button).toBeVisible();

--- a/web/themes/new_weather_theme/assets/js/point.page.components.js
+++ b/web/themes/new_weather_theme/assets/js/point.page.components.js
@@ -1,0 +1,17 @@
+/**
+ * This module bundles all components that are
+ * custom elements.
+ * The libraries.yml file will then ensure they are not
+ * deferred, and are loaded into the head tag so that
+ * processing of the custom elements happens earlier in
+ * the page load.
+ * This should help with the browser test flakiness
+ * when combined with a good `waitUntil` value on
+ * page loads
+ */
+import("./components/TabbedNavigator.js");
+import("./components/HourlyTable.js");
+import("./components/Tabs.js");
+import("./components/DailyForecast.js");
+import("./components/combo-box.js");
+import("./components/combo-box-location.js");

--- a/web/themes/new_weather_theme/assets/js/point.page.js
+++ b/web/themes/new_weather_theme/assets/js/point.page.js
@@ -1,11 +1,6 @@
-import("./components/TabbedNavigator.js");
-import("./components/afd-selector.js");
-import("./components/HourlyTable.js");
 import("./localizeTimestamps.js");
 import("./locationSearch.js");
 import("./radar.js");
-import("./components/combo-box.js");
-import("./components/combo-box-location.js");
 import("./components/alertMap.js");
 import("./charts/hourly-temperature.js");
 import("./charts/hourly-pops.js");
@@ -14,5 +9,3 @@ import("./charts/hourly-wind.js");
 import("./charts/hourly-dewpoint.js");
 import("./charts/qpf.js");
 import("./components/quick-forecast-toggle.js");
-import("./components/DailyForecast.js");
-import("./components/Tabs.js");

--- a/web/themes/new_weather_theme/new_weather_theme.libraries.yml
+++ b/web/themes/new_weather_theme/new_weather_theme.libraries.yml
@@ -32,6 +32,15 @@ point-page:
         type: module
         defer: true
 
+point-page-components:
+  version: 2024-12-11
+  header: true
+  js:
+    assets/js/point.page.components.js:
+      attributes:
+        type: module
+        defer: false
+
 afd-page:
   version: 2024-09-03
   js:

--- a/web/themes/new_weather_theme/templates/layout/afd-page.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/afd-page.html.twig
@@ -1,4 +1,5 @@
 {{ attach_library("new_weather_theme/afd-page") }}
+
 {% set wfo = wfo | upper %}
 
 <div class="layout-container grid-row height-full flex-column flex-no-wrap">

--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -6,6 +6,7 @@
   {{ attach_library('new_weather_theme/chartjs') }}
   {% endif %}
   {{ attach_library('new_weather_theme/point-page') }}
+  {{ attach_library('new_weather_theme/point-page-components') }}
 
   <header role="banner">
     <div class="grid-container">

--- a/web/themes/new_weather_theme/templates/layout/page-metadata-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page-metadata-alerts.html.twig
@@ -1,4 +1,5 @@
 {{ attach_library("new_weather_theme/point-page") }}
+{{ attach_library('new_weather_theme/point-page-components') }}
 
 <div class="layout-container grid-row height-full flex-column flex-no-wrap">
   <header role="banner">


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR addresses the ongoing ticket #1675, and appears to ameliorate _some_ of our browser test flakiness.

## What does the reviewer need to know? 🤔
Here's the rub: currently, any custom element components are all bundled up with the functional (non-custom element) components on the point page. These are loaded into a single script tag in the body that is given the "defer" attribute. For custom elements, this means that the functionality of the components might not be fully loaded at page "load" time. That means we are testing for functionality that in a lot of cases hasn't loaded yet (and so the tests fail). It's a matter of timing.
  
To get around this, we have separated actual custom elements into a separate library bundle for the point page called `point.page.components.js`. This is now loaded without the "defer" attribute, and is also present in the head of the page to ensure priority loading.
  
Additionally, we have annotated most of the `page.goto` calls in our tests to explicitly wait for the `load` event. Note that this is actually the default behavior for `goto` anyway. We simply wanted to be explicit, so that later on if we need to tweak these tests further for performance reasons, we know where we can change things.
  
Testing this locally, all of the e2e tests seem to pass with pretty good regularity (where they weren't necessarily before).

