### PR TITLE
Alerts cache table

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,14 @@ module.exports = {
 
         // chai provides "empty" expressions, such as `to.be.true`
         "no-unused-expressions": "off",
+
+        // Sometimes we destructure arrays and in certain cases
+        // we don't care about the first variable, so we use an
+        // underscore
+        "no-unused-vars": ["error", {
+          "varsIgnorePattern": "^_",
+          "argsIgnorePattern": "^_"
+        }],
       },
       env: { mocha: true },
     },

--- a/api-interop-layer/data/alerts/backgroundUpdateTask.js
+++ b/api-interop-layer/data/alerts/backgroundUpdateTask.js
@@ -62,9 +62,7 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
   alertsCache.db = db;
   await alertsCache.createTable();
   
-  const incomingHashes = rawAlerts.map(alert => {
-    return alert.properties.hash;
-  });
+  const incomingHashes = rawAlerts.map(alert => alert.properties.hash);
 
   const currentHashes = await alertsCache.getHashes();
   const newHashes = await alertsCache.determineNewHashesFrom(currentHashes, incomingHashes);
@@ -72,9 +70,7 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
 
   // Filter the actual alerts that need to be updated, based
   // on the computed hash
-  const alertsToUpdate = rawAlerts.filter(alert => {
-    return newHashes.includes(alert.properties.hash);
-  });
+  const alertsToUpdate = rawAlerts.filter(alert => newHashes.includes(alert.properties.hash));
   parent.postMessage({
     action: "log",
     level: "verbose",
@@ -227,7 +223,7 @@ export const start = () => {
 };
 
 if (parentPort) {
-  parentPort.on("message", ({ action, data }) => {
+  parentPort.on("message", ({ action }) => {
     switch (action.toLowerCase()) {
       case "start":
         start();

--- a/api-interop-layer/data/alerts/backgroundUpdateTask.js
+++ b/api-interop-layer/data/alerts/backgroundUpdateTask.js
@@ -130,6 +130,11 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
         message: `Ignoring "${rawAlert.properties.event}" - not a land alert`,
       });
 
+      // For caching purposes, we store these alerts with the alertKind and no
+      // valid geometry. This prevents us from reprocessing them the next round, but
+      // also prevents them from being retrieved from the cache for any given point.
+      alertsCache.add(rawAlert.properties.hash, alert, null, alert.metadata.kind);
+      
       continue; // eslint-disable-line no-continue
     }
 
@@ -188,7 +193,7 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
 
     // Add the alert to the cache
     if(geometry){
-      await alertsCache.add(rawAlert.properties.hash, alert, geometry);
+      alertsCache.add(rawAlert.properties.hash, alert, geometry, alert.metadata.kind);
 
       parent.postMessage({
         action: "log",

--- a/api-interop-layer/data/alerts/backgroundUpdateTask.js
+++ b/api-interop-layer/data/alerts/backgroundUpdateTask.js
@@ -12,7 +12,6 @@ import { AlertsCache } from "./cache.js";
 
 // The hashes of all the active alerts we know about. Anything in this list will
 // not be processed in future updates, since we've already captured it.
-const KNOWN_ALERTS = new Set();
 const alertsCache = new AlertsCache();
 
 
@@ -21,12 +20,8 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
   parent.postMessage({
     action: "log",
     level: "verbose",
-    message: `updating alerts with ${KNOWN_ALERTS.size} known alerts`,
+    message: `updating alerts`,
   });
-
-  // The list of alert hashes in the current results from the API. We'll use
-  // this to figure out which alerts to remove from KNOWN_ALERTS.
-  const theseAlertHashes = new Set();
 
   const rawAlerts = await fetchAPIJson("/alerts/active?status=actual").then(
     ({ error, features }) => {
@@ -40,8 +35,6 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
         const hash = createHash("sha256");
         hash.update(JSON.stringify(feature.properties));
         feature.properties.hash = hash.digest("base64");
-
-        theseAlertHashes.add(feature.properties.hash);
 
         modifyTimestampsForAlert(feature);
 
@@ -63,40 +56,42 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
     message: `got ${rawAlerts.length} alerts from the API`,
   });
 
-  for (const hash of KNOWN_ALERTS) {
-    if (!theseAlertHashes.has(hash)) {
-      // A previously-known alert is no longer in this update. We should
-      // remove it now.
-      parent.postMessage({
-        action: "log",
-        level: "verbose",
-        message: `removing alert with hash ${hash}`,
-      });
-      KNOWN_ALERTS.delete(hash);
-      parent.postMessage({ action: "remove", hash });
-    }
-  }
-
-  const alertsToUpdate = rawAlerts.filter(
-    ({ properties: { hash } }) => !KNOWN_ALERTS.has(hash),
-  );
-
+  // Determine which alerts to both update and drop
+  // based on the incoming hashes and the current cache.
   const db = await openDatabase();
   alertsCache.db = db;
   await alertsCache.createTable();
+  
+  const incomingHashes = rawAlerts.map(alert => {
+    return alert.properties.hash;
+  });
 
-  // NEW
-  // Remove any invalid alerts from the cache table
-  // (ie alerts in the table that are not present in the current batch)
-  const incomingHashes = alertsToUpdate.map(alert => alert.properties.hash);
-  await alertsCache.removeInvalidBasedOn(incomingHashes);
+  const currentHashes = await alertsCache.getHashes();
+  const newHashes = await alertsCache.determineNewHashesFrom(currentHashes, incomingHashes);
+  const invalidHashes = await alertsCache.determineOldHashesFrom(currentHashes, incomingHashes);
 
+  // Filter the actual alerts that need to be updated, based
+  // on the computed hash
+  const alertsToUpdate = rawAlerts.filter(alert => {
+    return newHashes.includes(alert.properties.hash);
+  });
   parent.postMessage({
     action: "log",
     level: "verbose",
     message: `got ${alertsToUpdate.length} alerts to update`,
   });
 
+  // Remove the invalid hashes from the cache
+  await alertsCache.removeByHashes(invalidHashes);
+  parent.postMessage({
+    action: "log",
+    level: "verbose",
+    message: `Removed ${invalidHashes.length} alerts from the cache that were no longer valid`
+  });
+
+
+  // Now update each of the alerts in the list of alerts
+  // to update, then store them into the cache.
   for await (const rawAlert of alertsToUpdate) {
     const alert = {
       metadata: alertKinds.get(rawAlert.properties.event.toLowerCase()),
@@ -135,7 +130,6 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
         message: `Ignoring "${rawAlert.properties.event}" - not a land alert`,
       });
 
-      KNOWN_ALERTS.add(rawAlert.properties.hash);
       continue; // eslint-disable-line no-continue
     }
 
@@ -187,14 +181,12 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
     }
 
     if (alert.finish && alert.finish.isBefore(now)) {
-      KNOWN_ALERTS.add(rawAlert.properties.hash);
       continue; // eslint-disable-line no-continue
     }
 
     const geometry = await generateAlertGeometry(db, rawAlert);
 
-    // NEW
-    // Add the alert to the cache table
+    // Add the alert to the cache
     if(geometry){
       await alertsCache.add(rawAlert.properties.hash, alert, geometry);
 
@@ -203,14 +195,6 @@ export const updateAlerts = async ({ parent = parentPort } = {}) => {
         level: "verbose",
         message: `adding alert with hash ${rawAlert.properties.hash}`,
       });
-
-      parent.postMessage({
-        action: "add",
-        hash: rawAlert.properties.hash,
-        alert,
-      });
-
-      KNOWN_ALERTS.add(rawAlert.properties.hash);
     } else {
       parent.postMessage({
         action: "log",
@@ -241,9 +225,6 @@ if (parentPort) {
   parentPort.on("message", ({ action, data }) => {
     switch (action.toLowerCase()) {
       case "start":
-        data.forEach((hash) => {
-          KNOWN_ALERTS.add(hash);
-        });
         start();
         break;
       default:

--- a/api-interop-layer/data/alerts/backgroundUpdateTask.test.js
+++ b/api-interop-layer/data/alerts/backgroundUpdateTask.test.js
@@ -22,16 +22,14 @@ describe("alert background processing module", () => {
     storedHashes = [];
     storedAlerts = {};
     getHashesStub = sandbox.stub(AlertsCache.prototype, "getHashes");
-    getHashesStub.callsFake(function(){
-      return storedHashes;
-    });
+    getHashesStub.callsFake(() =>storedHashes);
     addAlertStub = sandbox.stub(AlertsCache.prototype, "add");
-    addAlertStub.callsFake(function(hash, alert, geometry, alertKind){
+    addAlertStub.callsFake((hash, alert, geometry, alertKind) =>{
       storedHashes.push(hash);
       storedAlerts[hash] = [hash, alert, geometry, alertKind];
     });
     removeAlertsStub = sandbox.stub(AlertsCache.prototype, "removeByHashes");
-    removeAlertsStub.callsFake(function(hashes){
+    removeAlertsStub.callsFake((hashes) =>{
       hashes.forEach(hash => {
         const idx = storedHashes.indexOf(hash);
         if(idx >= 0){
@@ -236,9 +234,7 @@ describe("alert background processing module", () => {
     expect(storedHashes).to.have.length(4);
     expect(Object.values(storedAlerts)).to.have.length(4);
 
-    const geometries = Object.values(storedAlerts).map(alertInfo => {
-      return alertInfo[2];
-    });
+    const geometries = Object.values(storedAlerts).map(alertInfo => alertInfo[2]);
 
     expect(geometries).to.eql(["geo", null, "geo", "geo"]);
   });

--- a/api-interop-layer/data/alerts/cache.js
+++ b/api-interop-layer/data/alerts/cache.js
@@ -1,0 +1,114 @@
+/**
+ * AlertsCache
+ * -----------------------------------
+ * Serves as the interface into the alerts cache database table,
+ * where active alerts and their geometries are stored.
+ * To avoid potential memory conflicts in the threaded environment,
+ * actual alert data is not stored on this object and methods are
+ * mostly immufable.
+ * Consumers can use multiple instances of this object to read vs write
+ * to the cache table.
+ */
+export class AlertsCache {
+  constructor(tableName="weathergov_geo_alerts_cache", dbConnection){
+    this.db = dbConnection;
+    this.tableName = tableName;
+
+    // Bound methods
+    this.getHashes = this.getHashes.bind(this);
+    this.determineOldHashesFrom = this.determineOldHashesFrom.bind(this);
+    this.removeByHashes = this.removeByHashes.bind(this);
+    this.removeInvalidBasedOn = this.removeInvalidBasedOn.bind(this);
+  }
+
+  async createTable(){
+    const sql = `CREATE TABLE IF NOT EXISTS ${this.tableName} (
+id INT AUTO_INCREMENT,
+hash TEXT NOT NULL,
+alertJson JSON NOT NULL,
+shape GEOMETRY NOT NULL,
+PRIMARY KEY(id)
+) DEFAULT CHARSET=utf8mb4`;
+    return await this.db.query(sql);
+  }
+
+  async getHashes(){
+    const sql = `SELECT hash FROM ${this.tableName};`;
+    const [ result, _ ] = await this.db.query(sql);
+    return result;
+  }
+
+  /**
+   * Given an array of current hashes and an array of incoming
+   * hashes, return a list of hashes from the current set that are
+   * not in the incoming set.
+   * This is how we determine old/invalid hashes during an
+   * all active alerts request.
+   * NOTE: node does not yet have standardized Set methods
+   * for determining difference, so we can't do the "normal"
+   * thing here and use Sets
+   * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference
+   */
+  determineOldHashesFrom(currentHashes, incomingHashes){
+    return currentHashes.filter(currentHash => {
+      return !incomingHashes.includes(currentHash);
+    });
+  }
+
+  /**
+   * Given an array of current hashes and an array of incoming
+   * hashes, return a list of hashes from the incoming set that
+   * are not in the current set.
+   * This is how we determine new hashes during an all active
+   * alerts request, and how we know which alerts are new.
+   * NOTE: node does not yet have standardized Set methods
+   * for determining difference, so we can't do the "normal"
+   * thing here and use Sets
+   * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference
+   */
+  determineNewHashesFrom(currentHashes, incomingHashes){
+    return incomingHashes.filter(incomingHash => {
+      return !currentHashes.includes(incomingHash);
+    });
+  }
+
+  /**
+   * Remove rows from the cache table by hash.
+   * If the argument is a list, we assume a list of hashes.
+   */
+  async removeByHashes(aHashList){
+    if(!aHashList.length){
+      return [];
+    }
+    let whereClause = `hash='${aHashList[0]}';`;
+    if(aHashList.length > 1){
+      const marks = aHashList.map(() => "?").join(", ");
+      whereClause = `hash IN (${marks});`;
+    }
+    const sql = `DELETE FROM ${this.tableName} WHERE ${whereClause}`;
+    return await this.db.query(sql, aHashList);
+  }
+
+  /**
+   * Given an array of incoming hashes, determine which
+   * from the current cache table are no longer valid and remove
+   * them from the table.
+   */
+  async removeInvalidBasedOn(incomingHashes){
+    const currentHashes = await this.getHashes();
+    const invalidHashes = this.determineOldHashesFrom(currentHashes, incomingHashes);
+    return await this.removeByHashes(invalidHashes);
+  }
+
+  /**
+   * Add the provided hash, geometry, and alert data to the
+   * cache table.
+   */
+  async add(hash, alert, geometry){
+    const alertAsString = JSON.stringify(alert);
+    const geometryAsString = JSON.stringify(geometry);
+    const sql = `INSERT INTO ${this.tableName} (hash, alertJson, shape) VALUES(?, ?, ST_GeomFromGeoJson(?));`;
+    return await this.db.query(sql, [hash, alertAsString, geometryAsString]);
+  }
+}
+

--- a/api-interop-layer/data/alerts/cache.js
+++ b/api-interop-layer/data/alerts/cache.js
@@ -37,7 +37,7 @@ PRIMARY KEY(id)
   async getHashes(){
     const sql = `SELECT hash FROM ${this.tableName};`;
     const [ result, _ ] = await this.db.query(sql);
-    return result;
+    return result.map(r => r.hash);
   }
 
   /**
@@ -130,7 +130,7 @@ PRIMARY KEY(id)
    * Drop the cache table from the database entirely.
    */
   async dropCacheTable(){
-    const sql = `DROP TABLE ${this.tableName}`;
+    const sql = `DROP TABLE IF EXISTS ${this.tableName}`;
     return await this.db.query(sql);
   }
 }

--- a/api-interop-layer/data/alerts/cache.js
+++ b/api-interop-layer/data/alerts/cache.js
@@ -13,12 +13,6 @@
 export class AlertsCache {
   constructor(tableName="weathergov_geo_alerts_cache"){
     this.tableName = tableName;
-
-    // Bound methods
-    this.getHashes = this.getHashes.bind(this);
-    this.removeByHashes = this.removeByHashes.bind(this);
-    this.getInsersectingAlerts = this.getIntersectingAlerts.bind(this);
-    this.dropCacheTable = this.dropCacheTable.bind(this);
   }
 
   async createTable(){

--- a/api-interop-layer/data/alerts/cache.js
+++ b/api-interop-layer/data/alerts/cache.js
@@ -17,7 +17,6 @@ export class AlertsCache {
     // Bound methods
     this.getHashes = this.getHashes.bind(this);
     this.removeByHashes = this.removeByHashes.bind(this);
-    this.removeInvalidBasedOn = this.removeInvalidBasedOn.bind(this);
     this.getInsersectingAlerts = this.getIntersectingAlerts.bind(this);
     this.dropCacheTable = this.dropCacheTable.bind(this);
   }
@@ -85,17 +84,6 @@ PRIMARY KEY(id)
     }
     const sql = `DELETE FROM ${this.tableName} WHERE ${whereClause}`;
     return this.db.query(sql, aHashList);
-  }
-
-  /**
-   * Given an array of incoming hashes, determine which
-   * from the current cache table are no longer valid and remove
-   * them from the table.
-   */
-  async removeInvalidBasedOn(incomingHashes){
-    const currentHashes = await this.getHashes();
-    const invalidHashes = this.determineOldHashesFrom(currentHashes, incomingHashes);
-    return this.removeByHashes(invalidHashes);
   }
 
   /**

--- a/api-interop-layer/data/alerts/cache.js
+++ b/api-interop-layer/data/alerts/cache.js
@@ -28,7 +28,8 @@ export class AlertsCache {
 id INT AUTO_INCREMENT,
 hash TEXT NOT NULL,
 alertJson JSON NOT NULL,
-shape GEOMETRY NOT NULL,
+shape GEOMETRY DEFAULT NULL,
+alertKind TEXT DEFAULT NULL,
 PRIMARY KEY(id)
 ) DEFAULT CHARSET=utf8mb4`;
     return await this.db.query(sql);
@@ -106,13 +107,13 @@ PRIMARY KEY(id)
    * Add the provided hash, geometry, and alert data to the
    * cache table.
    */
-  async add(hash, alert, geometry){
+  async add(hash, alert, geometry, alertKind=null){
     const alertAsString = JSON.stringify(alert);
     const geometryAsString = JSON.stringify(geometry);
-    const sql = `INSERT INTO ${this.tableName} (hash, alertJson, shape) VALUES(?, ?, ST_GeomFromGeoJson(?));`;
-    return await this.db.query(sql, [hash, alertAsString, geometryAsString]);
+    const sql = `INSERT INTO ${this.tableName} (hash, alertJson, shape, alertKind) VALUES(?, ?, ST_GeomFromGeoJson(?), ?);`;
+    return await this.db.query(sql, [hash, alertAsString, geometryAsString, alertKind]);
   }
-
+  
   /**
    * Given an incoming GeoJSON geometry,
    * retrieve all alerts that intersect with that geometry.

--- a/api-interop-layer/data/alerts/cache.test.js
+++ b/api-interop-layer/data/alerts/cache.test.js
@@ -1,0 +1,142 @@
+import sinon from "sinon";
+import { expect } from "chai";
+import { AlertsCache } from "./cache.js";
+
+const CURRENT_TEST_HASHES = [
+  "one",
+  "two",
+  "three",
+  "five",
+  "seven"
+];
+
+describe("AlertsCache tests", () => {
+  let alertsCache;
+  beforeEach(() => {
+    alertsCache = new AlertsCache();
+    alertsCache.db = global.test.database;
+  });
+  it("#createTable", async () => {
+    const partOfQuery = "CREATE TABLE IF NOT EXISTS weathergov_geo_alerts_cache";
+    global.test.database.query
+      .withArgs(sinon.match(partOfQuery))
+      .resolves(true);
+
+    const result = await alertsCache.createTable();
+
+    expect(result).to.equal(true);
+  });
+
+  it("#getHashes", async () => {
+    const query = `SELECT hash FROM ${alertsCache.tableName}`;
+    global.test.database.query
+      .withArgs(sinon.match(query))
+      .resolves([
+        CURRENT_TEST_HASHES.map(hash => {
+          return { hash };
+        })
+      ]);
+
+    const result = await alertsCache.getHashes();
+
+    expect(result).to.eql(CURRENT_TEST_HASHES);
+  });
+
+  it("#determineOldHashesFrom", () => {
+    const current = CURRENT_TEST_HASHES;
+    const incoming = ["two", "three", "four", "five"];
+    const expected = ["one", "seven"];
+
+    const actual = alertsCache.determineOldHashesFrom(
+      current,
+      incoming
+    );
+
+    expect(actual).to.eql(expected);
+  });
+
+  it("#determineNewHashesFrom", () => {
+    const current = CURRENT_TEST_HASHES;
+    const incoming = ["two", "three", "four", "five", "zero"];
+    const expected = ["four", "zero"];
+
+    const actual = alertsCache.determineNewHashesFrom(
+      current,
+      incoming
+    );
+
+    expect(actual).to.eql(expected);
+  });
+
+  it("#removeByHashes", async () => {
+    const toRemove = ["two", "three", "five"];
+    const query = `DELETE FROM ${alertsCache.tableName} WHERE hash IN (?, ?, ?);`;
+    global.test.database.query
+      .withArgs(query, toRemove)
+      .resolves(true);
+
+    const result = await alertsCache.removeByHashes(toRemove);
+
+    expect(result).to.be.true;
+  });
+
+  it("#add (with land alert kind)", async () => {
+    const hash = "ten";
+    const alert = { some: "json-object"};
+    const geometry = { some: "geojson-object"};
+    const kind = "land";
+
+    const query = `INSERT INTO ${alertsCache.tableName} (hash, alertJson, shape, alertKind) VALUES(?, ?, ST_GeomFromGeoJson(?), ?);`;
+    
+    global.test.database.query
+      .withArgs(query, [hash, JSON.stringify(alert), JSON.stringify(geometry), kind])
+      .resolves("INSERT WORKED");
+
+    const actual = await alertsCache.add(hash, alert, geometry, "land");
+
+    expect(actual).to.equal("INSERT WORKED");
+  });
+
+  it("#getIntersectingAlerts", async () => {
+    const query = `SELECT alertJson, ST_AsGeoJson(shape) as geometry FROM ${alertsCache.tableName} WHERE ST_INTERSECTS(ST_GeomFromGeoJson(?), shape);`;
+    const geoJson = { "this-is": "some-geojson" };
+    const output = [
+      {
+        alertJson: {name: "alert1"},
+        "geometry": "geometry1"
+      },
+      {
+        alertJson:{name: "alert2"},
+        "geometry": "geometry2"
+      }
+    ];
+    const expected = [
+      {
+        name: "alert1",
+        geometry: "geometry1"
+      },
+      {
+        name: "alert2",
+        geometry: "geometry2"
+      }
+    ];
+    global.test.database.query
+      .withArgs(query, [geoJson])
+      .resolves([output]);
+
+    const result = await alertsCache.getIntersectingAlerts(geoJson);
+
+    expect(result).to.eql(expected);
+  });
+
+  it("#dropCacheTable", async () => {
+    const query = `DROP TABLE IF EXISTS ${alertsCache.tableName}`;
+    global.test.database.query
+      .withArgs(query)
+      .resolves("TABLE DROPPED");
+
+    const result = await alertsCache.dropCacheTable();
+
+    expect(result).to.equal("TABLE DROPPED");
+  });
+});

--- a/api-interop-layer/data/alerts/cache.test.js
+++ b/api-interop-layer/data/alerts/cache.test.js
@@ -32,9 +32,7 @@ describe("AlertsCache tests", () => {
     global.test.database.query
       .withArgs(sinon.match(query))
       .resolves([
-        CURRENT_TEST_HASHES.map(hash => {
-          return { hash };
-        })
+        CURRENT_TEST_HASHES.map(hash => ({ hash }))
       ]);
 
     const result = await alertsCache.getHashes();

--- a/api-interop-layer/data/alerts/geometry.js
+++ b/api-interop-layer/data/alerts/geometry.js
@@ -180,7 +180,7 @@ export const generateAlertGeometry = async (db, rawAlert) => {
     }
   }
 
-  // we cannot generate a geometry.;
+  // we cannot generate a geometry
   return null;
 };
 

--- a/api-interop-layer/data/alerts/geometry.js
+++ b/api-interop-layer/data/alerts/geometry.js
@@ -180,7 +180,7 @@ export const generateAlertGeometry = async (db, rawAlert) => {
     }
   }
 
-  // we cannot generate a geometry.
+  // we cannot generate a geometry.;
   return null;
 };
 

--- a/api-interop-layer/data/alerts/index.js
+++ b/api-interop-layer/data/alerts/index.js
@@ -8,6 +8,7 @@ import { parseDuration } from "./parse/index.js";
 import sort from "./sort.js";
 import { AlertsCache } from "./cache.js";
 import openDatabase from "../db.js";
+import dayjs from "../../util/day.js";
 
 const logger = createLogger("alerts");
 const backgroundLogger = createLogger("alerts (background)");
@@ -28,20 +29,22 @@ export const updateFromBackground = ({
   message,
 }) => {
   switch (action) {
-    case "error":
-      metadata.error = true;
-      break;
+  case "error":
+    metadata.error = true;
+    break;
 
-    case "log":
-      backgroundLogger[level]?.(message);
-      if (!backgroundLogger[level]) {
-        logger.error(`Attempted to write to invalid log level: '${level}'`);
-        logger.error("Received message:");
-        logger.error(message);
-      }
-      break;
-    default:
-      break;
+  case "log":
+    backgroundLogger[level]?.(message);
+    if (!backgroundLogger[level]) {
+      logger.error(`Attempted to write to invalid log level: '${level}'`);
+      logger.error("Received message:");
+      logger.error(message);
+    }
+    break;
+  default:
+    metadata.updated = dayjs();
+    metadata.error = false;
+    break;
   }
 };
 

--- a/api-interop-layer/data/alerts/index.js
+++ b/api-interop-layer/data/alerts/index.js
@@ -1,19 +1,18 @@
 import { Worker, isMainThread } from "node:worker_threads";
 import path from "node:path";
 
-import { booleanIntersects, buffer, point } from "@turf/turf";
-import dayjs from "../../util/day.js";
+import { buffer, point } from "@turf/turf";
 import { modifyTimestampsForAlert } from "./utils.js";
 import { createLogger } from "../../util/monitoring/index.js";
 import { parseDuration } from "./parse/index.js";
 import sort from "./sort.js";
 import { AlertsCache } from "./cache.js";
+import openDatabase from "../db.js";
 
 const logger = createLogger("alerts");
 const backgroundLogger = createLogger("alerts (background)");
 const cachedAlerts = new Map();
 const alertsCache = new AlertsCache();
-import openDatabase from "../db.js";
 
 const metadata = {
   error: false,
@@ -25,8 +24,6 @@ const metadata = {
 // database cache table, and removing stale alerts from the cache table.
 export const updateFromBackground = ({
   action,
-  hash,
-  alert,
   level,
   message,
 }) => {

--- a/api-interop-layer/data/alerts/index.test.js
+++ b/api-interop-layer/data/alerts/index.test.js
@@ -4,6 +4,7 @@ import dayjs from "../../util/day.js";
 import { alignAlertsToDaily } from "./utils.js";
 import alertHandler, { updateFromBackground } from "./index.js";
 import alertKinds from "./kinds.js";
+import { AlertsCache } from "./cache.js";
 
 /**
  * Test helper for creating arrays of mock
@@ -29,13 +30,19 @@ describe("alert data module", () => {
   const sandbox = sinon.createSandbox();
 
   const response = { status: 200, json: sandbox.stub() };
+  let getIntersection;
 
   beforeEach(() => {
     response.status = 200;
     sandbox.resetBehavior();
     sandbox.resetHistory();
+    getIntersection = sandbox.stub(AlertsCache.prototype, "getIntersectingAlerts");
 
     fetch.resolves(response);
+  });
+
+  afterEach(() => {
+    getIntersection.restore();
   });
 
   describe("after initial setup", () => {
@@ -43,6 +50,10 @@ describe("alert data module", () => {
       beforeEach(async () => {
         response.json.resetBehavior();
         response.json.resetHistory();
+        getIntersection.callsFake(function(geometry){
+          console.log("get intersecting alerts called!");
+          return Promise.resolve([]);
+        });
       });
 
       afterEach(() => {
@@ -119,11 +130,14 @@ describe("alert data module", () => {
             },
           };
 
-          updateFromBackground({ action: "add", hash: "test", alert });
+          getIntersection.callsFake(function(){
+            return Promise.resolve([alert]);
+          });
         });
 
         afterEach(() => {
-          updateFromBackground({ action: "remove", hash: "test" });
+          getIntersection.resetBehavior();
+          getIntersection.resetHistory();
         });
 
         it("formats the start time", async () => {
@@ -184,21 +198,23 @@ describe("alert data module", () => {
             };
 
             updateFromBackground({ action: "add", hash, alert });
-            return hash;
+            return alert;
           });
 
-        const removeAll = (hashes) =>
-          hashes.forEach((hash) =>
-            updateFromBackground({ action: "remove", hash }),
-          );
+        afterEach(() => {
+          getIntersection.resetBehavior();
+          getIntersection.resetHistory();
+        });
 
         it("when one of them is a warning", async () => {
-          const hashes = addAlerts(
+          const alerts = addAlerts(
             "Severe Thunderstorm Warning",
             "Severe Thunderstorm Watch",
             "severe weather statement",
             "avalanche advisory",
           );
+
+          getIntersection.resolves(alerts);
 
           const { highestLevel: actual } = await alertHandler({
             point: { latitude: 1, longitude: 1 },
@@ -206,16 +222,16 @@ describe("alert data module", () => {
           });
 
           expect(actual).to.equal("warning");
-
-          removeAll(hashes);
         });
 
         it("when there are no warnings, but at least one watch", async () => {
-          const hashes = addAlerts(
+          const alerts = addAlerts(
             "Severe Thunderstorm Watch",
             "severe weather statement",
             "avalanche advisory",
           );
+
+          getIntersection.resolves(alerts);
 
           const { highestLevel: actual } = await alertHandler({
             point: { latitude: 1, longitude: 1 },
@@ -223,15 +239,15 @@ describe("alert data module", () => {
           });
 
           expect(actual).to.equal("watch");
-
-          removeAll(hashes);
         });
 
         it("when there are no warnings or watches", async () => {
-          const hashes = addAlerts(
+          const alerts = addAlerts(
             "severe weather statement",
             "avalanche advisory",
           );
+
+          getIntersection.resolves(alerts);
 
           const { highestLevel: actual } = await alertHandler({
             point: { latitude: 1, longitude: 1 },
@@ -239,8 +255,6 @@ describe("alert data module", () => {
           });
 
           expect(actual).to.equal("other");
-
-          removeAll(hashes);
         });
       });
     });

--- a/api-interop-layer/data/alerts/index.test.js
+++ b/api-interop-layer/data/alerts/index.test.js
@@ -50,10 +50,7 @@ describe("alert data module", () => {
       beforeEach(async () => {
         response.json.resetBehavior();
         response.json.resetHistory();
-        getIntersection.callsFake(function(geometry){
-          console.log("get intersecting alerts called!");
-          return Promise.resolve([]);
-        });
+        getIntersection.callsFake(() =>Promise.resolve([]));
       });
 
       afterEach(() => {
@@ -130,9 +127,7 @@ describe("alert data module", () => {
             },
           };
 
-          getIntersection.callsFake(function(){
-            return Promise.resolve([alert]);
-          });
+          getIntersection.callsFake(() =>Promise.resolve([alert]));
         });
 
         afterEach(() => {


### PR DESCRIPTION
## What does this PR do? 🛠️
This PR attempts to partially address interop layer refactoring. It implements the alert cache table strategy outlined in the [interop alert refactoring doc](https://docs.google.com/document/d/1xhjscbNdmVywgZgvMksBKP-cJEpfomSMHAIvS7Zyw30/edit?usp=sharing).

## What does the reviewer need to know? 🤔
### A new spatial table
Alerts are now cached -- with their geometries, if present -- in a new spatial table called `weathergov_geo_alerts_cache`. This table will be dropped and recreated whenever the interop process (re)starts. It's schema is defined in code (see inline comments).
  
### `AlertsCache`
The interface into the alerts cache table is a helper object called `AlertsCache`. Instances of this object contain immutable functions for interacting with the cache table. The advantage is that you can make several instances of this object and they will not interfere with each other -- a necessity in our case since we have a main thread (pulls out alerts by point) and a worker thread (updates/invalidates cached alerts).
  
### How it works
Previously, we were storing relevant/processed alerts in memory, including any complex geometries for larger alert areas. With these changes, _no alert data is stored long term in memory_, and everything is handled by the database table.
  
The background worker's job is now to:
* Hit the alerts endpoint, generating a unique hash for each alert
* If a hash is already in the db table, skip
* If there are hashes in the db table that are _not_ in the new alerts, then we remove those from the table (they are now invalid)
* New hashes are processed, including mapping for kind and computing geometries from zones/counties if needed
* Land alerts are fully processed and stored in the db with their geometries
* All other alert types are stored in the db _without_ geometries. This ensures that we don't loop through these "seen" alerts again on the next run, but also that we don't return those alerts as valid when requesting all alerts for a lat/lon pair
  
Then in the main thread, we perform an `AlertsCache` call that takes a given geo point and queries for all alerts that intersect that point. This geographic computation is done within the database, so it's one query.
