### PR TITLE
gitlab ci: build and push utility image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,25 @@ stages:
   - test
   - deploy
 
+build-utility-image:
+  image: docker:27
+  stage: build
+  services:
+    - name: docker:27-dind
+      command: [ "--tls=false" ]
+      variables:
+        HEALTHCHECK_TCP_PORT: "2375"
+  when: manual
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ""
+    PROJECT_REGISTRY: "$CI_REGISTRY/nws/systems/dis/weather.gov-2.0"
+  script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - docker compose build utility-node
+    - docker image tag weathergov-utility-node:latest $PROJECT_REGISTRY/weathergov-utility:latest
+    - docker push $PROJECT_REGISTRY/weathergov-utility:latest
+
 # NB: GitLab clones into CI_BUILDS_DIR which defaults to
 # /builds/gitlab-licensed/NWS/Systems/DIS/Weather.gov-2.0/ whereas in our Docker
 # images our WORKDIR is /app. so we symlink the various /app/node_modules to
@@ -52,7 +71,7 @@ js-component-tests:
     reports:
       junit: test-results.xml # mocha-junit-reporter writes to this file by default
 
-interop-layer-tests:
+js-interop-layer-tests:
   stage: test
   image: $CI_REGISTRY_IMAGE/weathergov-utility:latest
   script:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: weathergov
+
 services:
   database:
     image: mysql:8.0 # 8.0.35 in prod


### PR DESCRIPTION
## What does this PR do? 🛠️

Docker-in-docker example for building our own images and pushing to the Gitlab repository. [Example run](https://vlab.noaa.gov/gitlab-licensed/NWS/Systems/DIS/Weather.gov-2.0/-/jobs/2787).

Note that we can attach rules, e.g. build when these files have changed:

```yaml
  rules:
    - changes:
      compare_to: 'refs/heads/main'
      paths:
        - Dockerfile.utility-node
        - ./package-lock.json
        - ./api-interop-layer/package-lock.json
        - ./tests/api/package-lock.json
```

But for now I've made this an optional manual step until we have some form of versioning in place. 

## What does the reviewer need to know? 🤔

- I added a project name to our `docker-compose.yml` -- this is needed, otherwise the default project name will be derived from the directory and hence will be `weathergov-20` in our CI setup.
- This docker-in-docker setup was given to us by the vlab support team. They currently disable TLS for some reason and will likely change in future releases. 