### PR TITLE
More text is marked for translation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,17 @@ services:
     ports:
       - 3306:3306
 
+  phpmyadmin:
+    image: phpmyadmin
+    networks:
+        - weather.gov
+    depends_on:
+        - database
+    ports:
+        - 8087:80
+    environment:
+        PMA_HOST: database
+
   api-proxy:
     build:
       context: ./tests/api

--- a/docs/code-review-templates/code-review-web.md
+++ b/docs/code-review-templates/code-review-web.md
@@ -52,6 +52,9 @@ This is an automated comment on every pull request requiring a review. A checked
     - [ ] Links are unique and contextual. All links can be understood taken alone, e.g., ‘Read more - about 508’
     - [ ] Page titles are descriptive
 
+## Translations
+- [ ] all new content is marked for translation and in `en.po`
+
 ## Device Matrix
 - [ ] firefox/gecko (renders correctly and user interactions work)
 - [ ] chrome/chromium/edge (renders correctly and user interactions work)

--- a/tests/playwright/e2e/radar.spec.js
+++ b/tests/playwright/e2e/radar.spec.js
@@ -24,19 +24,6 @@ describe("radar component", () => {
           .getAttribute("xlink:href");
         await expect(iconHref).toMatch(/uswds\/sprite\.svg#zoom_out_map$/);
       });
-
-      test("with 'expand' text description", async ({ page }) => {
-        const descriptions = await page.locator(
-          ".wx-radar-expand__description",
-        );
-        await expect(descriptions).toHaveCount(2);
-
-        const hidden = await page.locator(
-          ".wx-radar-expand__description.display-none",
-        );
-        await expect(hidden).toHaveCount(1);
-        await expect(hidden).toContainText("collapse");
-      });
     });
 
     describe("toggles expanded state...", () => {
@@ -60,20 +47,6 @@ describe("radar component", () => {
           await expect(iconHref).toMatch(
             /images\/spritesheet\.svg#wx_zoom-in-map$/,
           );
-        });
-
-        test("sets text description to 'collapse'", async ({ page }) => {
-          await click(page);
-          const descriptions = await page.locator(
-            ".wx-radar-expand__description",
-          );
-          await expect(descriptions).toHaveCount(2);
-
-          const hidden = await page.locator(
-            ".wx-radar-expand__description.display-none",
-          );
-          await expect(hidden).toHaveCount(1);
-          await expect(hidden).toContainText("expand");
         });
 
         test("triggers a window resize event", async ({ page }) => {
@@ -110,20 +83,6 @@ describe("radar component", () => {
             .locator(".wx-radar-container svg use")
             .getAttribute("xlink:href");
           await expect(iconHref).toMatch(/uswds\/sprite\.svg#zoom_out_map$/);
-        });
-
-        test("sets text description to 'expand'", async ({ page }) => {
-          await click(page);
-          const descriptions = await page.locator(
-            ".wx-radar-expand__description",
-          );
-          await expect(descriptions).toHaveCount(2);
-
-          const hidden = await page.locator(
-            ".wx-radar-expand__description.display-none",
-          );
-          await expect(hidden).toHaveCount(1);
-          await expect(hidden).toContainText("collapse");
         });
 
         test("triggers a window resize event", async ({ page }) => {

--- a/tests/playwright/e2e/radar.spec.js
+++ b/tests/playwright/e2e/radar.spec.js
@@ -103,17 +103,4 @@ describe("radar component", () => {
       });
     });
   });
-
-  describe("screenreader-only link", () => {
-    test("opens the daily tab", async ({ page }) => {
-      await page
-        .locator("[wx-outer-radar-container] .usa-sr-only a")
-        .evaluate((node) => node.click());
-
-      const dailyTab = await page.locator("#daily");
-
-      await expect(dailyTab).toBeVisible();
-      await expect(dailyTab).toHaveAttribute("data-selected");
-    });
-  });
 });

--- a/tests/translations/config.js
+++ b/tests/translations/config.js
@@ -26,6 +26,8 @@ module.exports = {
       "../../web/modules/weather_cms/**/*.module",
       "../../web/modules/weather_data/**/*.php",
       "../../web/modules/weather_data/**/*.module",
+      "../../web/modules/weather_login/**/*.php",
+      "../../web/modules/weather_login/**/*.module",
     ],
     exclude: [],
   },
@@ -37,7 +39,15 @@ module.exports = {
 
   suppress: {
     missing: {
-      en: [],
+      en: [
+        "Decision support is description tk tk",
+        "Briefing tk tk",
+        "County finder tk tk",
+        "State page tk tk",
+        "Resource 1 tk tk",
+        "Resource 2 tk tk",
+        "Resource 3 tk tk"
+      ],
       "zh-hans": [],
     },
     stale: {

--- a/tests/translations/main.js
+++ b/tests/translations/main.js
@@ -116,7 +116,7 @@ languages.forEach((langCode) => {
     console.error(
       `${RED_ERROR} ${missing.length} strings from en.po are not in ${langCode}.po`
     );
-    missing.forEach((key) => console.error(`\t"${key}"`));
+    missing.forEach((key) => console.error(`\t${key}\t${english[key].msgstr}`));
   } else {
     console.log(`${GREEN_SUCCESS} All strings from en.po are in ${langCode}.po.`);
   }
@@ -126,15 +126,15 @@ languages.forEach((langCode) => {
   const stale = comparisonKeys.filter((key) => !translationKeys.includes(key)).filter((key) => !ignored.has(key));
   if (stale.length) {
     console.warn(
-      `${YELLOW_WARNING} ${missing.length} strings from ${langCode}.po are not in en.po`
+      `${YELLOW_WARNING} ${stale.length} strings from ${langCode}.po are not in en.po`
     );
-    missing.forEach((key) => console.warn(`\t"${key}"`));
+    stale.forEach((key) => console.warn(`\t"${key}"`));
   } else {
     console.log(`${GREEN_SUCCESS} All strings from ${langCode}.po are in en.po.`);
   }
 });
 
 if (hasErrors) {
-  console.warn("Hint: You can add keys to config.suppress.missing or config.suppress.stale to suppress test failures.");
+  console.warn(`${YELLOW_WARNING} Exiting with errors.`);
   process.exit(-1);
 }

--- a/tests/translations/tests/fixtures/t.filter.html.twig
+++ b/tests/translations/tests/fixtures/t.filter.html.twig
@@ -1,6 +1,6 @@
             {% if period.probabilityOfPrecipitation and period.probabilityOfPrecipitation > 1 %}
             <p class="text-gray-50 font-body-xs margin-top-05 margin-bottom-0">
-            {{period.probabilityOfPrecipitation}}% {{ "daily-forecast.text.chance-precip.01" | t }}
+            {{ "daily-forecast.text.chance-precip.02" | t({ "@percent": period.probabilityOfPrecipitation }) }}
             </p>
             {% endif %}
 

--- a/tests/translations/translationExtraction.js
+++ b/tests/translations/translationExtraction.js
@@ -8,7 +8,7 @@ const TWIG_T_FILTER_SINGLE_RX =
 const TWIG_T_FILTER_DOUBLE_RX =
   /\{\{\s*["]([^"]+)["]\s*\|\s*t(\(\s*(\{[^}]+\})\s*\))?\s*\}\}/gs;
 const TWIG_T_VARIABLE_SET_RX =
-  /\{\%\s*set\s*[A-Za-z_0-9]+\s*\=\s*["]([^"]+)["]\s*\|\s*t\s*\%\}/gs;
+  /\{\%\s*set\s*[A-Za-z_0-9]+\s*\=\s*['"]([^'"]+)['"]\s*\|\s*t\s*\%\}/gs;
 const TWIG_T_DICT_SET_RX = /\:\s*['"]([^'"]+)['"]\s*\|\s*t/gs;
 const PHP_T_FUNCTION_RX = /-\>t\(['"]([^'"]+)['"]\)/gs;
 

--- a/web/modules/weather_i18n/translations/en.po
+++ b/web/modules/weather_i18n/translations/en.po
@@ -10,6 +10,14 @@
 #
 # Message IDs are versioned, to remind you of this rule. ⚠️
 #
+# The general message ID taxonomy is four parts,
+# separated by dots, but usage is not strictly enforced.
+#   `location.role.name.version`
+#    |        |    |    └─ eg: `02`
+#    |        |    └─ unique label, eg: `areas-impacted`
+#    |        └─ eg: `text`, `heading`, `label`, `label+aria`
+#    └─ feature or filename, eg: `daily-forecast`
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Weather.gov Utility\\n"
@@ -20,23 +28,89 @@ msgstr ""
 msgid "abbreviations.not-applicable.01"
 msgstr "N/A"
 
+msgid "afd.aria.letterhead.01"
+msgstr "Letterhead and timestamp"
+
+msgid "afd.button.update-selection.01"
+msgstr "Update selection"
+
+msgid "afd.heading.area-forecast-discussion.01"
+msgstr "Area Forecast Discussion"
+
+msgid "afd.heading.forecast-discussion.01"
+msgstr "Forecast Discussion"
+
+msgid "afd.label.forecast-office.01"
+msgstr "Forecast office:"
+
+msgid "afd.label.versions.01"
+msgstr "Versions for @wfo_name:"
+
+msgid "afd.table-header.chance-precip.01"
+msgstr "Chance of precipitation"
+
+msgid "afd.table-header.location.01"
+msgstr "Location"
+
+msgid "afd.table-header.next-day.01"
+msgstr "Next day"
+
+msgid "afd.table-header.temperatures.01"
+msgstr "Temperatures"
+
+msgid "afd.table-header.today.01"
+msgstr "Today"
+
+msgid "afd.table-header.tomorrow-night.01"
+msgstr "Tomorrow night"
+
+msgid "afd.table-header.tomorrow.01"
+msgstr "Tomorrow"
+
+msgid "afd.table-header.tonight.01"
+msgstr "Tonight"
+
+msgid "alerts.aria.multiple-alert.01"
+msgstr "Multiple weather alerts"
+
+msgid "alerts.aria.one-alert.01"
+msgstr "Weather alert"
+
+msgid "alerts.heading+aria.alerts.01"
+msgstr "Alerts"
+
 msgid "alerts.labels.areas-impacted.01"
 msgstr "Areas impacted"
 
 msgid "alerts.labels.what-to-do.01"
 msgstr "What to do"
 
+msgid "alerts.legend.impacted-area.01"
+msgstr "Impacted Area"
+
+msgid "alerts.table-header.alert-name.01"
+msgstr "Alert name"
+
+msgid "alerts.table-header.alert-type.01"
+msgstr "Type"
+
 msgid "alerts.text.counties-in.01"
 msgstr "Counties in @area"
 
 msgid "alerts.text.in-effect-from.01"
-msgstr "In effect from"
+msgstr "In effect from @start"
+
+msgid "alerts.text.in-effect-from-until.01"
+msgstr "In effect from @start – @end"
 
 msgid "alerts.text.including-cities.01"
 msgstr "Including these cities"
 
 msgid "alerts.text.issued-by.01"
 msgstr "Issued by @sender"
+
+msgid "backend.banner.under-development.01"
+msgstr "Under development"
 
 msgid "backend.login.cancel-text.01"
 msgstr "Cancel Text"
@@ -49,6 +123,21 @@ msgstr "SSO Cancel Path"
 
 msgid "backend.login.sso-login-path.01"
 msgstr "SSO Login Path"
+
+msgid "daily-forecast.aria.condition.01"
+msgstr "Condition: @description"
+
+msgid "daily-forecast.aria.high-not-applicable.01"
+msgstr "High temperature not applicable"
+
+msgid "daily-forecast.aria.high-of.01"
+msgstr "High of @degrees℉"
+
+msgid "daily-forecast.aria.low-of.01"
+msgstr "Low of @degrees℉"
+
+msgid "daily-forecast.heading.hourly-forecast.01"
+msgstr "Hourly forecast"
 
 msgid "daily-forecast.labels.alert.01"
 msgstr "Alert"
@@ -74,19 +163,25 @@ msgstr "Overnight"
 msgid "daily-forecast.labels.today.01"
 msgstr "Today"
 
-msgid "daily-forecast.text.chance-precip.01"
-msgstr "chance of precipitation"
+msgid "daily-forecast.table-header.date.01"
+msgstr "Date"
 
-msgid "daily-forecast.text.hide-details.01"
-msgstr "Hide hourly details"
+msgid "daily-forecast.table-header.condition.01"
+msgstr "Condition"
 
-msgid "daily-forecast.text.show-details.01"
-msgstr "Show hourly details"
+msgid "daily-forecast.table-header.high.01"
+msgstr "High"
 
-msgid "daily-forecast.label.details-toggle-charts.01"
+msgid "daily-forecast.table-header.low.01"
+msgstr "Low"
+
+msgid "daily-forecast.text.chance-precip.02"
+msgstr "@percent% chance of precipitation"
+
+msgid "daily-forecast.button.details-toggle-charts.01"
 msgstr "Charts"
 
-msgid "daily-forecast.bale.details-toggle-table.01"
+msgid "daily-forecast.button.details-toggle-table.01"
 msgstr "Table"
 
 msgid "daily-forecast.text.usa-gov-site.01"
@@ -98,11 +193,17 @@ msgstr "National Oceanic and Atmospheric Administration logo"
 msgid "footer.noaa-motto.01"
 msgstr "Science. Service. Stewardship"
 
+msgid "footer.link.touchpoints.01"
+msgstr "Help improve this site"
+
 msgid "footer.text.usa-gov-site-alt.01"
 msgstr "An official website of the United States government"
 
-msgid "forecast.current.aria.feels-like.01"
-msgstr "It feels like @feelsLike ℉."
+msgid "forecast.aria.current-conditions-feels-like.01"
+msgstr "It feels like @temperature ℉."
+
+msgid "forecast.aria.current-conditions-narrative.01"
+msgstr "Weather as of @time. The weather in @place is @conditions. Temperature is @temperature ℉."
 
 msgid "forecast.current.feels-like.01"
 msgstr "Feels like"
@@ -119,17 +220,26 @@ msgstr "Distance to location"
 msgid "forecast.current.obs-station-elevation.01"
 msgstr "Elevation"
 
-msgid "forecast.current.weather-as-of.01"
-msgstr "Weather as of"
+msgid "forecast.heading.current-conditions.01"
+msgstr "Current conditions"
 
-msgid "forecast.current.weather-temp-description.01"
-msgstr "The weather in @place, is @conditions.\n            Temperature is @temperature ℉."
+msgid "forecast.heading.daily-forecast.01"
+msgstr "Daily forecast"
+
+msgid "forecast.heading.today-forecast.01"
+msgstr "Today's forecast"
 
 msgid "forecast.errors.current-conditions.01"
 msgstr "There was an error loading the current conditions."
 
 msgid "forecast.errors.daily.01"
 msgstr "There was an error loading the daily forecast."
+
+msgid "forecast.errors.loading.01"
+msgstr "There was an error loading the forecast."
+
+msgid "forecast.errors.point.01"
+msgstr "Something went wrong loading this page. Please try again in a few minutes."
 
 msgid "forecast.labels.alerts.01"
 msgstr "Alerts"
@@ -139,6 +249,93 @@ msgstr "7 Days"
 
 msgid "forecast.labels.weather-info.01"
 msgstr "Weather information sections"
+
+msgid "forecast.link.area-forecast-discussion.01"
+msgstr "Area Forecast Discussion"
+
+msgid "frontpage.heading.find-your-forecast.01"
+msgstr "Find your forecast"
+
+msgid "frontpage.heading.in-mind.01"
+msgstr "A weather.gov built with you in&nbsp;mind"
+
+msgid "frontpage.heading.is-coming.01"
+msgstr "A new weather.gov is&nbsp;coming"
+
+msgid "frontpage.heading.touchpoints.01"
+msgstr "We want to hear from you!"
+
+msgid "frontpage.list-heading.in-mind-2-graf.01"
+msgstr "Over the next few years, we are working towards a site that will be:"
+
+msgid "frontpage.list.in-mind-1-item.01"
+msgstr "One cohesive experience"
+
+msgid "frontpage.list.in-mind-2-item.01"
+msgstr "Easy to navigate and understand from any device"
+
+msgid "frontpage.list.in-mind-3-item.01"
+msgstr "Accessible to all users, regardless of location, wealth, education, age, or&nbsp;ability"
+
+msgid "frontpage.list.in-mind-4-item.01"
+msgstr "Available in more languages"
+
+msgid "frontpage.list.in-mind-5-item.01"
+msgstr "A valuable resource for the public, as well as partners of the National Weather Service"
+
+msgid "frontpage.list.touchpoints-1-item.01"
+msgstr "Did you find the information you were looking for?"
+
+msgid "frontpage.list.touchpoints-2-item.01"
+msgstr "Did you have any challenges in understanding it?"
+
+msgid "frontpage.list.touchpoints-3-item.01"
+msgstr "In what ways have you been using this website?"
+
+msgid "frontpage.list.touchpoints-4-item.01"
+msgstr "What can we do to serve you better?"
+
+msgid "frontpage.text.in-mind-1-graf.01"
+msgstr "We are working towards a new weather.gov that quickly provides everyone with the critical information they need to protect themselves and their communities."
+
+msgid "frontpage.text.is-coming-1-graf.01"
+msgstr "This website is in development. We are creating a new, contemporary tool for anyone, anywhere in the U.S. to check their forecast and learn about hazardous weather on the way."
+
+msgid "frontpage.text.is-coming-2-graf.01"
+msgstr "As you explore, you may notice that we’re missing features you’re accustomed to seeing on weather.gov. This site is updated every two weeks with new features. Continue to check back to watch the site expand!"
+
+msgid "frontpage.text.is-coming-3-graf.01"
+msgstr "Because it’s a work in progress, this site has a long way to go before replacing weather.gov. In the meantime, you can still <a href='@url' class='usa-link'>access weather.gov</a> and all the tools it offers. You should continue to rely on weather.gov as the authoritative source for weather information."
+
+msgid "frontpage.text.touchpoints-1-graf.01"
+msgstr "<a href='@url' class='usa-link'>Tell us what you think</a> about how beta.weather.gov looks and functions."
+
+msgid "hourly-charts.heading.chance-precip.01"
+msgstr "Chance of precipitation"
+
+msgid "hourly-charts.heading.dewpoint.01"
+msgstr "Dewpoint"
+
+msgid "hourly-charts.heading.humidity.01"
+msgstr "Humidity"
+
+msgid "hourly-charts.heading.temperature.01"
+msgstr "Temperature"
+
+msgid "hourly-charts.heading.wind.01"
+msgstr "Wind"
+
+msgid "hourly-charts.legend.feels-like.01"
+msgstr "Feels like"
+
+msgid "hourly-charts.legend.gusts.01"
+msgstr "Gusts"
+
+msgid "hourly-charts.legend.temperature.01"
+msgstr "Temperature"
+
+msgid "hourly-charts.legend.wind-speed.01"
+msgstr "Wind speed"
 
 msgid "hourly-table.aria.scroll-left.01"
 msgstr "scroll left"
@@ -166,6 +363,9 @@ msgstr "Time"
 
 msgid "hourly-table.labels.wind-speed.01"
 msgstr "Wind speed"
+
+msgid "hourly-table.table-header.chance-precip.01"
+msgstr "Chance of precipitation"
 
 msgid "hourly-table.text.gusting.01"
 msgstr "with gusts up to @gustSpeed mph"
@@ -209,23 +409,26 @@ msgstr "Wind"
 msgid "precip-table.aria.amounts.01"
 msgstr "precipitation amounts for the coming hours"
 
-msgid "precip-table.labels.amounts.01"
+msgid "precip-table.heading.amounts.01"
 msgstr "Precipitation amounts"
 
-msgid "radar.aria.collapse-map.01"
-msgstr "collapse the radar map"
+msgid "precip-table.table-header.time-period.01"
+msgstr "Time Period"
 
-msgid "radar.aria.description.01"
-msgstr "Listed below is a visual representation of radar data for\n        @place. For more details on specific weather conditions,\n        view hourly data within the"
+msgid "precip-table.table-header+legend.rain.01"
+msgstr "Rain"
 
-msgid "radar.aria.expand-map.01"
-msgstr "expand the radar map"
+msgid "precip-table.table-header+legend.water.01"
+msgstr "Water"
 
-msgid "radar.aria.legend.01"
-msgstr "Legend which describes the intensity levels that correspond to color and dBz values"
+msgid "precip-table.table-header+legend.snow.01"
+msgstr "Snow"
 
-msgid "radar.labels.daily-tab.01"
-msgstr "daily tab"
+msgid "precip-table.table-header+legend.ice.01"
+msgstr "Ice"
+
+msgid "precip-table.text.water-explainer.01"
+msgstr "\"Water\" refers to the amount of water that is present in the precipitation. The precipitation may actually fall in solid form such as ice or snow, in liquid form as rain, or a mix of both."
 
 msgid "radar.labels.intensity.01"
 msgstr "Intensity"
@@ -239,11 +442,17 @@ msgstr "Radar"
 msgid "safety.labels.tips.01"
 msgstr "Tips to stay safe"
 
+msgid "satellite.heading.satellite.01"
+msgstr "Satellite"
+
 msgid "theme.text.submitted-by.01"
 msgstr "Submitted by @author_name on @month/@day"
 
 msgid "units.dbz.01"
 msgstr "dBz"
+
+msgid "units.inches.01"
+msgstr "@inches\""
 
 msgid "units.mercury-inches.01"
 msgstr "@mercury_inches in (@mbar&nbsp;mb)"
@@ -254,8 +463,8 @@ msgstr "miles"
 msgid "units.feet.01"
 msgstr "feet"
 
-msgid "units.mph.01"
-msgstr "mph"
+msgid "units.mph.02"
+msgstr "@speed mph"
 
 msgid "uswds-banner.gov.description_html.01"
 msgstr "A <strong>.gov</strong> website belongs to an official government organization in the United States."
@@ -284,23 +493,32 @@ msgstr "Lock"
 msgid "uswds-banner.skip-to-content.01"
 msgstr "Skip to main content"
 
+msgid "wfo-info.caption.coverage-area-map.01"
+msgstr "Coverage area for @wfo WFO"
+
+msgid "wfo-info.caption+aria.coverage-area-map.01"
+msgstr "This includes @counties"
+
+msgid "wfo-info.heading.contact-us.01"
+msgstr "Contact us"
+
+msgid "wfo-info.heading.forecast-discussion.01"
+msgstr "Forecaster's discussion"
+
+msgid "wfo-info.heading.local-expertise.01"
+msgstr "Local expertise"
+
 msgid "wfo-info.labels.about.01"
 msgstr "About"
 
-msgid "wfo-info.labels.contact-us.01"
-msgstr "Contact us"
-
-msgid "wfo-info.labels.coverage-area-map-caption.01"
-msgstr "Coverage area for @wfo WFO"
-
-msgid "wfo-info.labels.forecast-discussion.01"
-msgstr "Forecaster's discussion"
-
-msgid "wfo-info.labels.local-expertise.01"
-msgstr "Local expertise"
-
 msgid "wfo-info.labels.wfo.01"
 msgstr "@wfoName (@wfoCode) National Weather Service Office"
+
+msgid "wfo-info.link.area-forecast-discussion"
+msgstr "Current Area Forecast Discussion"
+
+msgid "wfo-info.text.forecast-discussion.01"
+msgstr "The purpose of the area forecast discussion is to provide the meteorological/scientific reasoning behind the forecast"
 
 msgid "wfo.labels.facebook.01"
 msgstr "Facebook"
@@ -316,6 +534,15 @@ msgstr "X (Twitter)"
 
 msgid "wfo.labels.youtube.01"
 msgstr "YouTube"
+
+msgid "weather-story.heading.from-forecaster.01"
+msgstr "From the forecaster"
+
+msgid "weather-story.link.area-forecast-discussion.01"
+msgstr "Area Forecast Discussion"
+
+msgid "weather-story.text.created-by.01"
+msgstr "<strong class='text-base-dark'>Created: @date</strong> by the <a class='usa-link' href='@wfo_url'>@wfo_name WFO</a>"
 
 msgid "wind.labels.calm.01"
 msgstr "calm"

--- a/web/modules/weather_i18n/translations/zh-hans.po
+++ b/web/modules/weather_i18n/translations/zh-hans.po
@@ -61,19 +61,7 @@ msgstr "整夜"
 msgid "daily-forecast.labels.today.01"
 msgstr "今天"
 
-msgid "daily-forecast.text.chance-precip.01"
-msgstr "降水概率"
-
-msgid "daily-forecast.text.hide-details.01"
-msgstr "不显示每小时详情"
-
-msgid "daily-forecast.text.show-details.01"
-msgstr "显示每小时详情"
-
 msgid "daily-forecast.label.details-toggle-charts.01"
-msgstr ""
-
-msgid "daily-forecast.bale.details-toggle-table.01"
 msgstr ""
 
 msgid "daily-forecast.text.usa-gov-site.01"
@@ -87,9 +75,6 @@ msgstr "科学。 服务。 管理"
 
 msgid "footer.text.usa-gov-site-alt.01"
 msgstr "美国政府官方网站"
-
-msgid "forecast.current.aria.feels-like.01"
-msgstr "感觉像77华氏度。"
 
 msgid "forecast.current.feels-like.01"
 msgstr "感觉像"
@@ -169,21 +154,6 @@ msgstr "风"
 msgid "precip-table.aria.amounts.01"
 msgstr "接下来几小时的降水量"
 
-msgid "precip-table.labels.amounts.01"
-msgstr "降水量"
-
-msgid "radar.aria.collapse-map.01"
-msgstr "关闭雷达图"
-
-msgid "radar.aria.expand-map.01"
-msgstr "展开雷达图"
-
-msgid "radar.aria.legend.01"
-msgstr "描述与颜色和 dBz 值相对应的强度等级的图例"
-
-msgid "radar.labels.daily-tab.01"
-msgstr "每日天气列表"
-
 msgid "radar.labels.intensity.01"
 msgstr "强度"
 
@@ -202,14 +172,8 @@ msgstr "@author_name于@month月@day日提交"
 msgid "units.dbz.01"
 msgstr "dBz"
 
-msgid "units.mercury-inches.01"
-msgstr "30.18 in (1022 mb)"
-
 msgid "units.miles.01"
 msgstr "英里"
-
-msgid "units.mph.01"
-msgstr "mph"
 
 msgid "uswds-banner.gov.description_html.01"
 msgstr ".gov网站属于美国的官方政府组织。"

--- a/web/themes/new_weather_theme/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--system-branding-block.html.twig
@@ -41,7 +41,7 @@
         xlink:href="/{{ directory }}/assets/images/uswds/sprite.svg#construction_worker"
       ></use>
     </svg>
-    Under development 
+    {{ "Under development" | t }}
   </span>
 </a>
 {% endblock %}

--- a/web/themes/new_weather_theme/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--system-branding-block.html.twig
@@ -41,7 +41,7 @@
         xlink:href="/{{ directory }}/assets/images/uswds/sprite.svg#construction_worker"
       ></use>
     </svg>
-    {{ "Under development" | t }}
+    {{ "backend.banner.under-development.01" | t }}
   </span>
 </a>
 {% endblock %}

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-weather-story-image.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-weather-story-image.html.twig
@@ -6,7 +6,7 @@
       <h3 class="wx-visual-h2 text-normal text-primary-darker margin-top-3 margin-bottom-2">{{ "From the forecaster" | t }}</h3>
       <h4 class="wx-visual-h3 text-primary-dark margin-0 margin-bottom-2">{{ content.title }}</h4>
       <p class="margin-0 margin-bottom-2">
-        <strong class="text-base-dark">Created: {{ content.updated.formatted }}</strong> by the <a class="usa-link" href="/offices/{{ content.wfo_code | normalize_wfo }}">{{ content.wfo_name }} WFO</a>
+        {{ "<strong class='text-base-dark'>Created: @updated</strong> by the <a class='usa-link' href='@wfo_url'>@wfo_name WFO</a>" | t({ "@updated": content.updated.formatted, "@wfo_url": '/offices/' . (content.wfo_code | normalize_wfo), "@wfo_name": content.wfo_name })}}
       </p>
       <p class="margin-0">{{ content.description }}</p>
     </div>
@@ -32,7 +32,7 @@
           <path d="M6 7H16V8H6V7Z" fill="#0085CA"/>
           <path fill-rule="evenodd" clip-rule="evenodd" d="M4 2H20V22H4V2ZM5 3H19V21H5V3Z" fill="#0085CA"/>
         </svg>
-        <a class="usa-link margin-left-1" href="/afd/{{ content.wfo_code }}">Area Forecast Discussion</a>
+        <a class="usa-link margin-left-1" href="/afd/{{ content.wfo_code }}">{{ "Area Forecast Discussion" | t }}</a>
       </div>
     </div>
   </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-weather-story-image.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-weather-story-image.html.twig
@@ -3,10 +3,14 @@
   <div class="wx-weather-story-wrapper">
     {# Top section with text #}
     <div class="margin-bottom-2">
-      <h3 class="wx-visual-h2 text-normal text-primary-darker margin-top-3 margin-bottom-2">{{ "From the forecaster" | t }}</h3>
+      <h3 class="wx-visual-h2 text-normal text-primary-darker margin-top-3 margin-bottom-2">{{ "weather-story.heading.from-forecaster.01" | t }}</h3>
       <h4 class="wx-visual-h3 text-primary-dark margin-0 margin-bottom-2">{{ content.title }}</h4>
       <p class="margin-0 margin-bottom-2">
-        {{ "<strong class='text-base-dark'>Created: @updated</strong> by the <a class='usa-link' href='@wfo_url'>@wfo_name WFO</a>" | t({ "@updated": content.updated.formatted, "@wfo_url": '/offices/' . (content.wfo_code | normalize_wfo), "@wfo_name": content.wfo_name })}}
+        {{ "weather-story.text.created-by.01" | t({
+          "@date": content.updated.formatted,
+          "@wfo_url": '/offices/' . (content.wfo_code | normalize_wfo),
+          "@wfo_name": content.wfo_name
+        })}}
       </p>
       <p class="margin-0">{{ content.description }}</p>
     </div>
@@ -32,7 +36,7 @@
           <path d="M6 7H16V8H6V7Z" fill="#0085CA"/>
           <path fill-rule="evenodd" clip-rule="evenodd" d="M4 2H20V22H4V2ZM5 3H19V21H5V3Z" fill="#0085CA"/>
         </svg>
-        <a class="usa-link margin-left-1" href="/afd/{{ content.wfo_code }}">{{ "Area Forecast Discussion" | t }}</a>
+        <a class="usa-link margin-left-1" href="/afd/{{ content.wfo_code }}">{{ "weather-story.link.area-forecast-discussion.01" | t }}</a>
       </div>
     </div>
   </div>

--- a/web/themes/new_weather_theme/templates/block/block--weathergov_area_forecast_discussion.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov_area_forecast_discussion.html.twig
@@ -1,6 +1,6 @@
 <div class="grid-container margin-top-2 padding-x-0 tablet:padding-x-2" wx-outer-radar-container>
   <div class="grid-row tablet-lg:grid-col-8 tablet-lg:grid-offset-2">
-    <h3 class="wx-visual-h2 text-normal text-primary-darker padding-x-2 tablet:padding-x-0 margin-top-3 margin-bottom-2">{{ "Forecast discussion" | t }}</h3>
+    <h3 class="wx-visual-h2 text-normal text-primary-darker padding-x-2 tablet:padding-x-0 margin-top-3 margin-bottom-2">{{ "afd.heading.forecast-discussion.01" | t }}</h3>
   </div>
 
   <div class="grid-container padding-1 bg-white shadow-1 grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">

--- a/web/themes/new_weather_theme/templates/layout/afd-page.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/afd-page.html.twig
@@ -24,7 +24,7 @@
     <div class="bg-primary-dark width-full">
         <div class="grid-container">
             <h1 class="text-white font-heading-xl text-normal tablet:flex-1 margin-y-1">
-                {{  "Area Forecast Discussion" | t }}
+                {{ "afd.heading.area-forecast-discussion.01" | t }}
             </h1>
         </div>
     </div>
@@ -34,7 +34,7 @@
 
                 <form id="afd-selection-form" name="afd-selection-form" class="bg-primary-lightest padding-x-2 padding-y-3 border-bottom-2px border-primary desktop__wx-position-sticky margin-x-neg-2" method="GET" action="/afd">
                     <label for="wfo-selector" class="usa-label margin-top-0">
-                        {{ "Forecast office:" | t }}
+                        {{ "afd.label.forecast-office.01" | t }}
                     </label>
 
                     <wx-combo-box
@@ -44,13 +44,13 @@
                     </wx-combo-box>
 
                     {% if version_list | length > 0 %}
-                        <label for="version-selector" class="usa-label">{{ "Versions for @wfo_name:" | t({ "@wfo_name": wfo | upper }) }}</label>
+                        <label for="version-selector" class="usa-label">{{ "afd.label.versions.01" | t({ "@wfo_name": wfo | upper }) }}</label>
                         <select id="version-selector" name="id" class="usa-select maxw-none tablet:maxw-mobile-lg">
                             {% include "@new_weather_theme/partials/afd-versions-select.html.twig" %}
                         </select>
                     {% endif %}
                     <input type="hidden" name="current-id" value="{{afd.id}}"/>
-                    <button class="usa-button margin-top-3" type="submit">{{ "Update selection" | t }}</button>
+                    <button class="usa-button margin-top-3" type="submit">{{ "afd.button.update-selection.01" | t }}</button>
 
                 </form>
             </div>

--- a/web/themes/new_weather_theme/templates/layout/afd-page.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/afd-page.html.twig
@@ -34,7 +34,7 @@
 
                 <form id="afd-selection-form" name="afd-selection-form" class="bg-primary-lightest padding-x-2 padding-y-3 border-bottom-2px border-primary desktop__wx-position-sticky margin-x-neg-2" method="GET" action="/afd">
                     <label for="wfo-selector" class="usa-label margin-top-0">
-                        Forecast office:
+                        {{ "Forecast office:" | t }}
                     </label>
 
                     <wx-combo-box
@@ -44,13 +44,13 @@
                     </wx-combo-box>
 
                     {% if version_list | length > 0 %}
-                        <label for="version-selector" class="usa-label">Versions for {{wfo | upper}}: </label>
+                        <label for="version-selector" class="usa-label">{{ "Versions for @wfo_name:" | t({ "@wfo_name": wfo | upper }) }}</label>
                         <select id="version-selector" name="id" class="usa-select maxw-none tablet:maxw-mobile-lg">
                             {% include "@new_weather_theme/partials/afd-versions-select.html.twig" %}
                         </select>
                     {% endif %}
                     <input type="hidden" name="current-id" value="{{afd.id}}"/>
-                    <button class="usa-button margin-top-3" type="submit">Update selection</button>
+                    <button class="usa-button margin-top-3" type="submit">{{ "Update selection" | t }}</button>
 
                 </form>
             </div>

--- a/web/themes/new_weather_theme/templates/layout/footer.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/footer.html.twig
@@ -19,7 +19,7 @@
 
     <a href="https://touchpoints.app.cloud.gov/touchpoints/22acf675/submit"
        class="touchpoints-button usa-button position-fixed bottom-0 z-top">
-      {{ "Help improve this site" | t }}
+      {{ "footer.link.touchpoints.01" | t }}
     </a>
 
   </footer>

--- a/web/themes/new_weather_theme/templates/layout/footer.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/footer.html.twig
@@ -19,7 +19,7 @@
 
     <a href="https://touchpoints.app.cloud.gov/touchpoints/22acf675/submit"
        class="touchpoints-button usa-button position-fixed bottom-0 z-top">
-      Help improve this site
+      {{ "Help improve this site" | t }}
     </a>
 
   </footer>

--- a/web/themes/new_weather_theme/templates/layout/frontpage.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/frontpage.html.twig
@@ -3,7 +3,7 @@
   <div class="grid-container">
     <div class="grid-row"> 
       <div class="grid-col tablet:grid-offset-2 tablet:grid-col-8">
-        <h1 class="text-normal text-white margin-y-0 font-sans-3xl text-ls-1"> Find your forecast </h1>
+        <h1 class="text-normal text-white margin-y-0 font-sans-3xl text-ls-1">{{ "Find your forecast" | t }}</h1>
       </div>
     </div>
 
@@ -52,18 +52,20 @@
             src="/{{ directory }}/assets/images/weather/spot_illos/wx_illo_announce.svg"
             alt=""
           />
-          <h2 class="text-normal text-primary-darker font-sans-2xl margin-y-0">A new weather.gov is&nbsp;coming</h2>
+          <h2 class="text-normal text-primary-darker font-sans-2xl margin-y-0">
+            {{ "A new weather.gov is&nbsp;coming" | t }}
+          </h2>
         </div>
       </div>
     </div>
     <div class="grid-row">
       <div class="grid-col tablet:grid-offset-2 tablet:grid-col-8">
 
-        <p class="font-sans-md">This website is in development. We are creating a new, contemporary tool for anyone, anywhere in the U.S. to check their forecast and learn about hazardous weather on the way. 
+        <p class="font-sans-md">{{ "This website is in development. We are creating a new, contemporary tool for anyone, anywhere in the U.S. to check their forecast and learn about hazardous weather on the way." | t }}
         </p>
-        <p>As you explore, you may notice that we’re missing features you’re accustomed to seeing on weather.gov. This site is updated every two weeks with new features. Continue to check back to watch the site expand!
+        <p>{{ "As you explore, you may notice that we’re missing features you’re accustomed to seeing on weather.gov. This site is updated every two weeks with new features. Continue to check back to watch the site expand!" | t }}
         </p>
-        <p class="margin-bottom-0">Because it’s a work in progress, this site has a long way to go before replacing weather.gov. In the meantime, you can still <a href="https://www.weather.gov" class="usa-link">access weather.gov</a> and all the tools it offers. You should continue to rely on weather.gov as the authoritative source for weather information.
+        <p class="margin-bottom-0">{{ "Because it’s a work in progress, this site has a long way to go before replacing weather.gov. In the meantime, you can still <a href='https://www.weather.gov' class='usa-link'>access weather.gov</a> and all the tools it offers. You should continue to rely on weather.gov as the authoritative source for weather information." | t({ "@url": 'https://www.weather.gov' }) }}
         </p>
       </div>
     </div>
@@ -81,23 +83,23 @@
           alt=""
         />
         <h2 class="font-sans-xl text-normal text-primary-darker margin-y-0">
-          A weather.gov built with you in&nbsp;mind
+          {{ "A weather.gov built with you in&nbsp;mind" | t}}
         </h2>
       </div>
     </div>
   </div>
   <div class="grid-row">
     <div class="grid-col tablet:grid-offset-2 tablet:grid-col-8">
-      <p>We are working towards a new weather.gov that quickly provides everyone with the critical information they need to protect themselves and their communities. </p>
+      <p>{{ "We are working towards a new weather.gov that quickly provides everyone with the critical information they need to protect themselves and their communities." | t }}</p>
       <p class="margin-bottom-1"> 
-      Over the next few years, we are working towards a site that will be: 
+      {{ "Over the next few years, we are working towards a site that will be:" | t}}
       </p>
       <ul class="usa-list margin-y-0"> 
-        <li> One cohesive experience </li>
-        <li> Easy to navigate and understand from any device </li>
-        <li> Accessible to all users, regardless of location, wealth, education, age, or&nbsp;ability </li>
-        <li> Available in more languages </li>
-        <li> A valuable resource for the public, as well as partners of the National Weather Service </li>
+        <li>{{ "One cohesive experience" | t }}</li>
+        <li>{{ "Easy to navigate and understand from any device" | t }}</li>
+        <li>{{ "Accessible to all users, regardless of location, wealth, education, age, or&nbsp;ability" | t }}</li>
+        <li>{{ "Available in more languages" | t }}</li>
+        <li>{{ "A valuable resource for the public, as well as partners of the National Weather Service" | t }}</li>
       </ul>
     </div>
   </div>
@@ -112,7 +114,7 @@
           alt=""
         />
         <h2 class="font-sans-xl text-normal text-primary-darker margin-y-0">
-           We want to hear from you!
+           {{ "We want to hear from you!" | t }}
         </h2>
       </div>
     </div>
@@ -120,13 +122,13 @@
   <div class="grid-row">
     <div class="grid-col tablet:grid-offset-2 tablet:grid-col-8">
       <p class="margin-bottom-1"> 
-      <a href="https://touchpoints.app.cloud.gov/touchpoints/22acf675/submit" class="usa-link"> Tell us what you think </a> about how beta.weather.gov looks and functions.
+      {{"<a href='https://touchpoints.app.cloud.gov/touchpoints/22acf675/submit' class='usa-link'>Tell us what you think</a> about how beta.weather.gov looks and functions." | t({ "@url": 'https://touchpoints.app.cloud.gov/touchpoints/22acf675/submit' }) }}
       </p>
       <ul class="usa-list margin-y-0"> 
-        <li> Did you find the information you were looking for? </li>
-        <li> Did you have any challenges in understanding it? </li>
-        <li> In what ways have you been using this website? </li>
-        <li> What can we do to serve you better? </li>
+        <li>{{ "Did you find the information you were looking for?" | t }}</li>
+        <li>{{ "Did you have any challenges in understanding it?" | t }}</li>
+        <li>{{ "In what ways have you been using this website?" | t }}</li>
+        <li>{{ "What can we do to serve you better?" | t }}</li>
       </ul>
     </div>
   </div>

--- a/web/themes/new_weather_theme/templates/layout/frontpage.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/frontpage.html.twig
@@ -3,7 +3,7 @@
   <div class="grid-container">
     <div class="grid-row"> 
       <div class="grid-col tablet:grid-offset-2 tablet:grid-col-8">
-        <h1 class="text-normal text-white margin-y-0 font-sans-3xl text-ls-1">{{ "Find your forecast" | t }}</h1>
+        <h1 class="text-normal text-white margin-y-0 font-sans-3xl text-ls-1">{{ "frontpage.heading.find-your-forecast.01" | t }}</h1>
       </div>
     </div>
 
@@ -53,20 +53,16 @@
             alt=""
           />
           <h2 class="text-normal text-primary-darker font-sans-2xl margin-y-0">
-            {{ "A new weather.gov is&nbsp;coming" | t }}
+            {{ "frontpage.heading.is-coming.01" | t }}
           </h2>
         </div>
       </div>
     </div>
     <div class="grid-row">
       <div class="grid-col tablet:grid-offset-2 tablet:grid-col-8">
-
-        <p class="font-sans-md">{{ "This website is in development. We are creating a new, contemporary tool for anyone, anywhere in the U.S. to check their forecast and learn about hazardous weather on the way." | t }}
-        </p>
-        <p>{{ "As you explore, you may notice that we’re missing features you’re accustomed to seeing on weather.gov. This site is updated every two weeks with new features. Continue to check back to watch the site expand!" | t }}
-        </p>
-        <p class="margin-bottom-0">{{ "Because it’s a work in progress, this site has a long way to go before replacing weather.gov. In the meantime, you can still <a href='https://www.weather.gov' class='usa-link'>access weather.gov</a> and all the tools it offers. You should continue to rely on weather.gov as the authoritative source for weather information." | t({ "@url": 'https://www.weather.gov' }) }}
-        </p>
+        <p class="font-sans-md">{{ "frontpage.text.is-coming-1-graf.01" | t }}</p>
+        <p>{{ "frontpage.text.is-coming-2-graf.01" | t }}</p>
+        <p class="margin-bottom-0">{{ "frontpage.text.is-coming-3-graf.01" | t({ "@url": 'https://www.weather.gov' }) }}</p>
       </div>
     </div>
   </div>
@@ -83,23 +79,21 @@
           alt=""
         />
         <h2 class="font-sans-xl text-normal text-primary-darker margin-y-0">
-          {{ "A weather.gov built with you in&nbsp;mind" | t}}
+          {{ "frontpage.heading.in-mind.01" | t}}
         </h2>
       </div>
     </div>
   </div>
   <div class="grid-row">
     <div class="grid-col tablet:grid-offset-2 tablet:grid-col-8">
-      <p>{{ "We are working towards a new weather.gov that quickly provides everyone with the critical information they need to protect themselves and their communities." | t }}</p>
-      <p class="margin-bottom-1"> 
-      {{ "Over the next few years, we are working towards a site that will be:" | t}}
-      </p>
-      <ul class="usa-list margin-y-0"> 
-        <li>{{ "One cohesive experience" | t }}</li>
-        <li>{{ "Easy to navigate and understand from any device" | t }}</li>
-        <li>{{ "Accessible to all users, regardless of location, wealth, education, age, or&nbsp;ability" | t }}</li>
-        <li>{{ "Available in more languages" | t }}</li>
-        <li>{{ "A valuable resource for the public, as well as partners of the National Weather Service" | t }}</li>
+      <p>{{ "frontpage.text.in-mind-1-graf.01" | t }}</p>
+      <p class="margin-bottom-1">{{ "frontpage.list-heading.in-mind-2-graf.01" | t}}</p>
+      <ul class="usa-list margin-y-0">
+        <li>{{ "frontpage.list.in-mind-1-item.01" | t }}</li>
+        <li>{{ "frontpage.list.in-mind-2-item.01" | t }}</li>
+        <li>{{ "frontpage.list.in-mind-3-item.01" | t }}</li>
+        <li>{{ "frontpage.list.in-mind-4-item.01" | t }}</li>
+        <li>{{ "frontpage.list.in-mind-5-item.01" | t }}</li>
       </ul>
     </div>
   </div>
@@ -114,7 +108,7 @@
           alt=""
         />
         <h2 class="font-sans-xl text-normal text-primary-darker margin-y-0">
-           {{ "We want to hear from you!" | t }}
+           {{ "frontpage.heading.touchpoints.01" | t }}
         </h2>
       </div>
     </div>
@@ -122,13 +116,13 @@
   <div class="grid-row">
     <div class="grid-col tablet:grid-offset-2 tablet:grid-col-8">
       <p class="margin-bottom-1"> 
-      {{"<a href='https://touchpoints.app.cloud.gov/touchpoints/22acf675/submit' class='usa-link'>Tell us what you think</a> about how beta.weather.gov looks and functions." | t({ "@url": 'https://touchpoints.app.cloud.gov/touchpoints/22acf675/submit' }) }}
+      {{ "frontpage.text.touchpoints-1-graf.01" | t({ "@url": 'https://touchpoints.app.cloud.gov/touchpoints/22acf675/submit' }) }}
       </p>
       <ul class="usa-list margin-y-0"> 
-        <li>{{ "Did you find the information you were looking for?" | t }}</li>
-        <li>{{ "Did you have any challenges in understanding it?" | t }}</li>
-        <li>{{ "In what ways have you been using this website?" | t }}</li>
-        <li>{{ "What can we do to serve you better?" | t }}</li>
+        <li>{{ "frontpage.list.touchpoints-1-item.01" | t }}</li>
+        <li>{{ "frontpage.list.touchpoints-2-item.01" | t }}</li>
+        <li>{{ "frontpage.list.touchpoints-3-item.01" | t }}</li>
+        <li>{{ "frontpage.list.touchpoints-4-item.01" | t }}</li>
       </ul>
     </div>
   </div>

--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -98,7 +98,7 @@
                   <path d="M6 7H16V8H6V7Z" fill="#0085CA"/>
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M4 2H20V22H4V2ZM5 3H19V21H5V3Z" fill="#0085CA"/>
                 </svg>
-                <a class="usa-link margin-left-1" href="/afd/{{ point.grid.wfo | normalize_wfo }}">Area Forecast Discussion</a>
+                <a class="usa-link margin-left-1" href="/afd/{{ point.grid.wfo | normalize_wfo }}">{{ "Area Forecast Discussion" | t }}</a>
               </div>
             </div>
           </div>
@@ -115,7 +115,7 @@
           </div>
         </div>
         <wx-daily-forecast class="wx-tab-container wx-focus-offset-205" id="daily" role="tabpanel" aria-labelledby="daily-tab-button" tabindex="0">
-            <h2 class="usa-sr-only">Daily forecast</h2>
+            <h2 class="usa-sr-only">{{ "Daily forecast" | t }}</h2>
             {% include '@new_weather_theme/point/forecast.html.twig' with { forecast: point.forecast } %}
             {{ drupal_block("weathergov_wfo_promo", { wfo: point.grid.wfo }) }}
         </wx-daily-forecast>

--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -39,7 +39,7 @@
     {% endif %}
 
     {% if point.error %}
-    {% set message = "Something went wrong loading this page. Please try again in a few minutes." | t %}
+    {% set message = "forecast.errors.point.01" | t %}
     <div class="grid-container padding-x-0 padding-y-2 grid-col-12 tablet-lg:grid-offset-2 tablet-lg:grid-col-8">
       {% include '@new_weather_theme/partials/uswds-alert.html.twig' with { 'level': "error", body: message } %}
     </div>
@@ -73,7 +73,7 @@
               </div>
               <div class="desktop:grid-col-8 display-flex flex-column">
                 {% if point.forecast.error or point.forecast.days | length == 0 %}
-                {% set message = "There was an error loading the forecast." | t %}
+                {% set message = "forecast.errors.loading.01" | t %}
                 {% include '@new_weather_theme/partials/uswds-alert.html.twig' with { 'level': "error", body: message } %}
                 {% else %}
                 {% include '@new_weather_theme/partials/today-summary-forecast.html.twig' with { forecast: point.forecast } %}
@@ -98,7 +98,7 @@
                   <path d="M6 7H16V8H6V7Z" fill="#0085CA"/>
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M4 2H20V22H4V2ZM5 3H19V21H5V3Z" fill="#0085CA"/>
                 </svg>
-                <a class="usa-link margin-left-1" href="/afd/{{ point.grid.wfo | normalize_wfo }}">{{ "Area Forecast Discussion" | t }}</a>
+                <a class="usa-link margin-left-1" href="/afd/{{ point.grid.wfo | normalize_wfo }}">{{ "forecast.link.area-forecast-discussion.01" | t }}</a>
               </div>
             </div>
           </div>
@@ -115,7 +115,7 @@
           </div>
         </div>
         <wx-daily-forecast class="wx-tab-container wx-focus-offset-205" id="daily" role="tabpanel" aria-labelledby="daily-tab-button" tabindex="0">
-            <h2 class="usa-sr-only">{{ "Daily forecast" | t }}</h2>
+            <h2 class="usa-sr-only">{{ "forecast.heading.daily-forecast.01" | t }}</h2>
             {% include '@new_weather_theme/point/forecast.html.twig' with { forecast: point.forecast } %}
             {{ drupal_block("weathergov_wfo_promo", { wfo: point.grid.wfo }) }}
         </wx-daily-forecast>

--- a/web/themes/new_weather_theme/templates/layout/page-metadata-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page-metadata-alerts.html.twig
@@ -28,8 +28,8 @@
         <thead>
           <tr>
             <th/>
-            <th>Alert name</th>
-            <th>Type</th>
+            <th>{{ "Alert name" | t }}</th>
+            <th>{{ "Type" | t }}</th>
           </tr>
         <tbody>
         {% for alert in alerts %}

--- a/web/themes/new_weather_theme/templates/layout/page-metadata-alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page-metadata-alerts.html.twig
@@ -28,8 +28,8 @@
         <thead>
           <tr>
             <th/>
-            <th>{{ "Alert name" | t }}</th>
-            <th>{{ "Type" | t }}</th>
+            <th>{{ "alerts.table-header.alert-name.01" | t }}</th>
+            <th>{{ "alerts.table-header.alert-type.01" | t }}</th>
           </tr>
         <tbody>
         {% for alert in alerts %}

--- a/web/themes/new_weather_theme/templates/partials/afd.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/afd.html.twig
@@ -28,30 +28,30 @@
                       <thead> 
                         <tr>
                           <td></td>
-                          <th colspan="4" scope="colgroup"> Temperatures </th>
-                          <th colspan="4" scope="colgroup"> Chance of precipitation </th>
+                          <th colspan="4" scope="colgroup">{{ "Temperatures" | t }}</th>
+                          <th colspan="4" scope="colgroup">{{"Chance of precipitation" | t }}</th>
                         </tr>
                         <tr>
-                          <th scope="col"> Location </th>
+                          <th scope="col">{{"Location" | t }}</th>
                           {# An unsophisticated check for which period the numbers correspond to#}
                           {% if (node.rows[0].numbers[0] - node.rows[0].numbers[1] > 0)  %}
-                          <th scope="col"> Today </th>
-                          <th scope="col"> Tonight </th>
-                          <th scope="col"> Tomorrow </th>
-                          <th scope="col"> Tomorrow night</th>
-                          <th scope="col"> Today </th>
-                          <th scope="col"> Tonight </th>
-                          <th scope="col"> Tomorrow </th>
-                          <th scope="col"> Tomorrow night</th>
+                          <th scope="col">{{ "Today" | t }}</th>
+                          <th scope="col">{{ "Tonight" | t }}</th>
+                          <th scope="col">{{ "Tomorrow" | t }}</th>
+                          <th scope="col">{{ "Tomorrow night" | t }}</th>
+                          <th scope="col">{{ "Today" | t }}</th>
+                          <th scope="col">{{ "Tonight" | t }}</th>
+                          <th scope="col">{{ "Tomorrow" | t }}</th>
+                          <th scope="col">{{ "Tomorrow night" | t }}</th>
                           {% else %}
-                          <th scope="col"> Tonight </th>
-                          <th scope="col"> Tomorrow </th>
-                          <th scope="col"> Tomorrow night</th>
-                          <th scope="col"> Next day</th>
-                          <th scope="col"> Tonight </th>
-                          <th scope="col"> Tomorrow </th>
-                          <th scope="col"> Tomorrow night</th>
-                          <th scope="col"> Next day</th>
+                          <th scope="col">{{ "Tonight" | t }}</th>
+                          <th scope="col">{{ "Tomorrow" | t }}</th>
+                          <th scope="col">{{ "Tomorrow night" | t }}</th>
+                          <th scope="col">{{ "Next day" | t }}</th>
+                          <th scope="col">{{ "Tonight" | t }}</th>
+                          <th scope="col">{{ "Tomorrow" | t }}</th>
+                          <th scope="col">{{ "Tomorrow night" | t }}</th>
+                          <th scope="col">{{ "Next day" | t }}</th>
                           {% endif %}
                         </tr>
                       </thead>

--- a/web/themes/new_weather_theme/templates/partials/afd.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/afd.html.twig
@@ -5,7 +5,7 @@
 <article class="afd-content desktop:padding-left-1" data-afd-id="{{afd.id}}">
     <div class="afd-preamble">
         <h2 class="usa-heading usa-sr-only">
-            {{ "Letterhead and timestamp" | t }}
+            {{ "afd.aria.letterhead.01" | t }}
         </h2>
         {% for key,val in preamble %}
             <span class="afd-preamble-{{key}} font-mono-sm text-pre-line">
@@ -28,30 +28,30 @@
                       <thead> 
                         <tr>
                           <td></td>
-                          <th colspan="4" scope="colgroup">{{ "Temperatures" | t }}</th>
-                          <th colspan="4" scope="colgroup">{{"Chance of precipitation" | t }}</th>
+                          <th colspan="4" scope="colgroup">{{ "afd.table-header.temperatures.01" | t }}</th>
+                          <th colspan="4" scope="colgroup">{{ "afd.table-header.chance-precip.01" | t }}</th>
                         </tr>
                         <tr>
-                          <th scope="col">{{"Location" | t }}</th>
+                          <th scope="col">{{"afd.table-header.location.01" | t }}</th>
                           {# An unsophisticated check for which period the numbers correspond to#}
                           {% if (node.rows[0].numbers[0] - node.rows[0].numbers[1] > 0)  %}
-                          <th scope="col">{{ "Today" | t }}</th>
-                          <th scope="col">{{ "Tonight" | t }}</th>
-                          <th scope="col">{{ "Tomorrow" | t }}</th>
-                          <th scope="col">{{ "Tomorrow night" | t }}</th>
-                          <th scope="col">{{ "Today" | t }}</th>
-                          <th scope="col">{{ "Tonight" | t }}</th>
-                          <th scope="col">{{ "Tomorrow" | t }}</th>
-                          <th scope="col">{{ "Tomorrow night" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.today.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tonight.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tomorrow.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tomorrow-night.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.today.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tonight.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tomorrow.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tomorrow-night.01" | t }}</th>
                           {% else %}
-                          <th scope="col">{{ "Tonight" | t }}</th>
-                          <th scope="col">{{ "Tomorrow" | t }}</th>
-                          <th scope="col">{{ "Tomorrow night" | t }}</th>
-                          <th scope="col">{{ "Next day" | t }}</th>
-                          <th scope="col">{{ "Tonight" | t }}</th>
-                          <th scope="col">{{ "Tomorrow" | t }}</th>
-                          <th scope="col">{{ "Tomorrow night" | t }}</th>
-                          <th scope="col">{{ "Next day" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tonight.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tomorrow.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tomorrow-night.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.next-day.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tonight.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tomorrow.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.tomorrow-night.01" | t }}</th>
+                          <th scope="col">{{ "afd.table-header.next-day.01" | t }}</th>
                           {% endif %}
                         </tr>
                       </thead>

--- a/web/themes/new_weather_theme/templates/partials/daily-forecast-list-item.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/daily-forecast-list-item.html.twig
@@ -94,7 +94,7 @@ only be a nighttime period.
                 </p>
                 {% if period.data.probabilityOfPrecipitation.hourlyMax and period.data.probabilityOfPrecipitation.hourlyMax > 1 %}
                 <p class="text-gray-50 font-body-xs margin-top-05 margin-bottom-0">
-                  {{period.data.probabilityOfPrecipitation.hourlyMax}}% {{ "daily-forecast.text.chance-precip.01" | t }}
+                  {{ "daily-forecast.text.chance-precip.02" | t({ "@percent": period.data.probabilityOfPrecipitation.hourlyMax }) }}
                 </p>
                 {% endif %}
               </div>
@@ -107,7 +107,7 @@ only be a nighttime period.
       {% if dayHours | length > 0 %}
       <div class="">
         {% include '@new_weather_theme/partials/forecast-details-toggle.html.twig' %}
-        <h4 class="font-heading-md text-normal text-primary-darker margin-top-0 margin-bottom-205">{{ "Hourly forecast" | t }}</h4>
+        <h4 class="font-heading-md text-normal text-primary-darker margin-top-0 margin-bottom-205">{{ "daily-forecast.heading.hourly-forecast.01" | t }}</h4>
         {% include '@new_weather_theme/partials/hourly-table.html.twig'
         with {
         for_day: periods[0].start | date('U') | format_date('custom', 'd'),

--- a/web/themes/new_weather_theme/templates/partials/daily-forecast-list-item.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/daily-forecast-list-item.html.twig
@@ -107,7 +107,7 @@ only be a nighttime period.
       {% if dayHours | length > 0 %}
       <div class="">
         {% include '@new_weather_theme/partials/forecast-details-toggle.html.twig' %}
-        <h4 class="font-heading-md text-normal text-primary-darker margin-top-0 margin-bottom-205">Hourly forecast</h4>
+        <h4 class="font-heading-md text-normal text-primary-darker margin-top-0 margin-bottom-205">{{ "Hourly forecast" | t }}</h4>
         {% include '@new_weather_theme/partials/hourly-table.html.twig'
         with {
         for_day: periods[0].start | date('U') | format_date('custom', 'd'),

--- a/web/themes/new_weather_theme/templates/partials/daily-forecast-quick-toggle.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/daily-forecast-quick-toggle.html.twig
@@ -32,17 +32,14 @@ the content
 
     <div class="wx-quick-toggle-condition flex-1">
       <span class="usa-sr-only">
-        {{ "Condition" | t }}
-        <span>
-          {{ day.periods[0].data.description }}
-        </span>
+        {{ "daily-forecast.aria.condition.01" | t({ "@description": day.periods[0].data.description }) }}
       </span>
       {% if day.alerts.metadata.count %}
       <span class="usa-sr-only">
         {% if day.alerts.metadata.count > 1 %}
-        {{ "Multiple weather alerts" | t }}
+          {{ "alerts.aria.multiple-alert.01" | t }}
         {% else %}
-        {{ "Weather alert" | t }}
+          {{ "alerts.aria.one-alert.01" | t }}
         {% endif %}
       </span>
       {% endif %}
@@ -60,37 +57,29 @@ the content
     <div class="wx-quick-toggle-item-high-low display-flex flex-1 text-primary-darker">
       {% if isNightPeriod %}
       <span class="usa-sr-only">
-        {{'High' | t}}
+        {{'daily-forecast.aria.high-not-applicable.01' | t}}
       </span>
-      <div class="wx-quick-high">
+      <div aria-hidden="true" class="wx-quick-high">
         <span class="wx-quick-temp display-block">
-          {{ "N/A" | t  }}
+          {{ "abbreviations.not-applicable.01" | t  }}
         </span>
       </div>
       {% else %}
       <span class="usa-sr-only">
-        {{'High' | t}}
+        {{ 'daily-forecast.aria.high-of.01' | t({ "@degrees": high }) }}
       </span>
-      <div class="wx-quick-high">
+      <div aria-hidden="true" class="wx-quick-high">
         <span class="wx-quick-temp display-block">
-          {{ high  }}
-          <span aria-hidden="true" class="wx-degree">
-            &deg;F
-          </span>
-          <span class="usa-sr-only">℉</span>
+          {{ high }}<span class="wx-degree">&deg;F</span>
         </span>
       </div>
       {% endif %}
       <div class="wx-quick-low width-auto">
         <span class="usa-sr-only">
-          {{'Low' | t }}
+          {{ 'daily-forecast.aria.low-of.01' | t({ "@degrees": low }) }}
         </span>
-        <span class="wx-quick-temp display-block">
-          {{ low }}
-          <span aria-hidden="true" class="wx-degree">
-            &deg;F
-          </span>
-          <span class="usa-sr-only">℉</span>
+        <span aria-hidden="true" class="wx-quick-temp display-block">
+          {{ low }}<span class="wx-degree">&deg;F</span>
         </span>
       </div>
     </div>
@@ -104,7 +93,7 @@ the content
 
   <div class="wx-quick-toggle-item-bottom wx-flex-basis-100 mobile-lg__wx-flex-basis-auto width-full flex-1 tablet:width-auto text-primary-darker">
     <span>
-      {{pop}}% {{"chance of precipitation" | t}}
+      {{ "daily-forecast.text.chance-precip.02" | t({ "@percent": pop }) }}
     </span>
   </div>
 

--- a/web/themes/new_weather_theme/templates/partials/daily-summary-list-item.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/daily-summary-list-item.html.twig
@@ -88,7 +88,7 @@ day
             </p>
             {% if period.data.probabilityOfPrecipitation.hourlyMax and period.data.probabilityOfPrecipitation.hourlyMax > 1 %}
             <p class="text-gray-50 font-body-xs margin-top-05 margin-bottom-0">
-            {{period.data.probabilityOfPrecipitation.hourlyMax}}% {{ "daily-forecast.text.chance-precip.01" | t }}
+            {{ "daily-forecast.text.chance-precip.02" | t({ "@percent": period.data.probabilityOfPrecipitation.hourlyMax }) }}
             </p>
             {% endif %}
           </div>

--- a/web/themes/new_weather_theme/templates/partials/forecast-details-toggle.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/forecast-details-toggle.html.twig
@@ -1,10 +1,10 @@
 <wx-tabs class="wx-forecast-details-toggle grid-row grid-col-12 tablet:grid-col-6 margin-y-205" data-selected="hourly-table_{{itemId}}">
     <div class="usa-button-group usa-button-group--segmented tablet-lg:grid-col-8" role="tablist">
         <button id="hourly-table-tab_{{itemId}}" type="button" class="usa-button flex-1" role="tab" aria-controls="hourly-table_{{itemId}}" aria-selected="true">
-            {{"daily-forecast.bale.details-toggle-table.01" | t}}
+            {{"daily-forecast.button.details-toggle-table.01" | t}}
         </button>
         <button id="hourly-charts-tab_{{itemId}}" type="button" class="usa-button flex-1" role="tab" aria-controls="hourly-charts_{{itemId}}" aria-selected="false">
-            {{"daily-forecast.label.details-toggle-charts.01" | t}}
+            {{"daily-forecast.button.details-toggle-charts.01" | t}}
         </button>
     </div>
 </wx-tabs>

--- a/web/themes/new_weather_theme/templates/partials/hourly-charts.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/hourly-charts.html.twig
@@ -10,7 +10,7 @@
 <wx-hourly-charts id="hourly-charts_{{itemId}}" role="tabpanel" data-tabpanel-selected="false" aria-labelledby="hourly-charts-tab_{{itemId}}" data-tabpanel-selected="false">
   <div class="wx-chart-wrapper">
     <h5 class="wx-mono-lg text-normal text-primary-dark margin-top-3 margin-bottom-05">
-      {{ "hourly-table.labels.temperature.01" | t }} <span class="usa-sr-only"> {{ "chart" | t }} </span>
+      {{ "hourly-charts.heading.temperature.01" | t }}
     </h5>
     <div class="position-sticky left-0 display-flex desktop:display-none flex-justify padding-top-2 padding-bottom-05">
       {% include "@new_weather_theme/partials/scroll-buttons.html.twig" %}
@@ -26,17 +26,17 @@
       <div class="width-3 border-bottom-2px border-primary-dark height-0 margin-right-1">
         <div class="bg-primary-dark margin-left-1 radius-pill width-1 height-1" style="margin-top: -3px;"></div>
       </div>
-      {{ "hourly-table.labels.temperature.01" | t }}
+      {{ "hourly-charts.legend.temperature.01" | t }}
       <div class="margin-left-3 width-3 border-bottom-2px border-top-0 border-left-0 border-right-0 border-dotted border-primary-light height-0 margin-right-1">
         <div class="bg-primary-light margin-left-1 radius-pill width-1 height-1" style="margin-top: -3px;"></div>
       </div>
-      {{  "forecast.current.feels-like.01" | t }}
+      {{  "hourly-charts.legend.feels-like.01" | t }}
     </div>
   </div>
 
   <div class="wx-chart-wrapper">
     <h5 class="wx-mono-lg text-normal text-primary-dark margin-top-4 margin-bottom-05">
-      {{ "daily-forecast.text.chance-precip.01" | t }} <span class="usa-sr-only"> {{ "chart" | t }} </span>
+      {{ "hourly-charts.heading.chance-precip.01" | t }}
     </h5>
     <div class="position-sticky left-0 display-flex desktop:display-none flex-justify padding-top-2 padding-bottom-05">
       {% include "@new_weather_theme/partials/scroll-buttons.html.twig" %}
@@ -51,7 +51,7 @@
 
   <div class="wx-chart-wrapper">
     <h5 class="wx-mono-lg text-normal text-primary-dark margin-top-2 margin-bottom-05">
-      {{ "observation-table.labels.wind.01" | t }}<span class="usa-sr-only"> {{ "chart" | t }} </span>
+      {{ "hourly-charts.heading.wind.01" | t }}
     </h5>
     <div class="position-sticky left-0 display-flex desktop:display-none flex-justify padding-top-2 padding-bottom-05">
       {% include "@new_weather_theme/partials/scroll-buttons.html.twig" %}
@@ -65,17 +65,17 @@
       <div class="width-3 border-bottom-2px border-secondary-darker height-0 margin-right-1">
         <div class="bg-primary-dark margin-left-1 radius-pill width-1 height-1" style="margin-top: -3px;"></div>
       </div>
-      {{ "hourly-table.labels.wind-speed.01" | t }}
+      {{ "hourly-charts.legend.wind-speed.01" | t }}
       <div class="margin-left-3 width-3 border-bottom-2px border-top-0 border-left-0 border-right-0 border-dotted border-secondary height-0 margin-right-1">
         <div class="bg-secondary margin-left-1 radius-pill width-1 height-1" style="margin-top: -3px;"></div>
       </div>
-      {{  "observation-table.labels.gusts.01" | t }}
+      {{  "hourly-charts.legend.gusts.01" | t }}
     </div>
   </div>
 
   <div class="wx-chart-wrapper">
     <h5 class="wx-mono-lg text-normal text-primary-dark margin-top-4 margin-bottom-05">
-      {{ "hourly-table.labels.humidity.01" | t }} <span class="usa-sr-only"> {{ "chart" | t }} </span>
+      {{ "hourly-charts.heading.humidity.01" | t }}
     </h5>
     <div class="position-sticky left-0 display-flex desktop:display-none flex-justify padding-top-2 padding-bottom-05">
       {% include "@new_weather_theme/partials/scroll-buttons.html.twig" %}
@@ -90,7 +90,7 @@
 
   <div class="wx-chart-wrapper margin-bottom-2">
     <h5 class="wx-mono-lg text-normal text-primary-dark margin-top-0 margin-bottom-105">
-      {{ "hourly-table.labels.dewpoint.01" | t }} <span class="usa-sr-only"> {{ "chart" | t }} </span>
+      {{ "hourly-charts.heading.dewpoint.01" | t }}
     </h5>
     <div class="position-sticky left-0 display-flex desktop:display-none flex-justify padding-top-2 padding-bottom-05">
       {% include "@new_weather_theme/partials/scroll-buttons.html.twig" %}

--- a/web/themes/new_weather_theme/templates/partials/hourly-table.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/hourly-table.html.twig
@@ -93,7 +93,7 @@
         </tr>
         <tr data-row-name="chance-precipitation" id="chance-precipitation_{{itemId}}">
           <th scope="row" class="position-sticky left-0 font-family-mono text-primary-dark bg-primary-lightest font-mono-xs text-uppercase z-400">
-            {{"daily-forecast.text.chance-precip.01" | t}}
+            {{ "hourly-table.table-header.chance-precip.01" | t }}
           </th>
           {% for period in hours %}
           <td>

--- a/web/themes/new_weather_theme/templates/partials/observation-table.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/observation-table.html.twig
@@ -16,7 +16,7 @@
                     {{ "observation-table.labels.gusts.01" | t }}
                 </th>
                 <td>
-                    {{ content.gusts.speed }} {{  "units.mph.01" | t }}
+                    {{ "units.mph.02" | t({ "@speed": content.gusts.speed }) }}
                 </td>
             </tr>
         {% endif %}

--- a/web/themes/new_weather_theme/templates/partials/precip-table.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/precip-table.html.twig
@@ -1,6 +1,6 @@
 <div class="grid-row wx-qpf-periods">
   <div class="grid-col-12">
-    <h5 class="wx-mono-lg text-normal text-primary-dark margin-top-2 margin-bottom-05">{{ "Precipitation amounts" |t }}</h5>
+    <h5 class="wx-mono-lg text-normal text-primary-dark margin-top-2 margin-bottom-05">{{ "precip-table.heading.amounts.01" |t }}</h5>
   </div>
 </div>
 
@@ -8,28 +8,28 @@
 {% set liquid = qpf.periods | map(p => p.liquid.in) | json_encode %}
 {% set snow = '[]' %}
 {% set ice = '[]' %}
-{% set liquidTitle = 'Rain' | t %}
+{% set liquidTitle = 'precip-table.table-header+legend.rain.01' | t %}
 
 {% if qpf.hasSnow %}
   {% set snow = qpf.periods | map(p => p.snow.in) | json_encode %}
-  {% set liquidTitle = 'Water' | t %}
+  {% set liquidTitle = 'precip-table.table-header+legend.water.01' | t %}
 {% endif %}
 {% if qpf.hasIce %}
   {% set ice = qpf.periods | map(p => p.ice.in) | json_encode %}
-  {% set liquidTitle = 'Water' | t %}
+  {% set liquidTitle = 'precip-table.table-header+legend.water.01' | t %}
 {% endif %}
 
 <div class="margin-bottom-205">
   <div class="display-flex flex-align-center font-mono-xs text-base">
     {% if qpf.hasSnow %}
     <div class="margin-x-1 margin-right-1 wx-bg-snow margin-left-1 width-2 height-2 border border-base-darker" style="margin-top: -3px;"></div>
-    {{ "Snow" | t }}
+    {{ "precip-table.table-header+legend.snow.01" | t }}
     <div class="margin-right-3"></div>
     {% endif %}
 
     {% if qpf.hasIce %}
     <div class="margin-x-1 margin-right-1 wx-bg-ice margin-left-1 width-2 height-2 border wx-border-cyan-80" style="margin-top: -3px;"></div>
-    {{ "Ice" | t }}
+    {{ "precip-table.table-header+legend.ice.01" | t }}
     <div class="margin-right-3"></div>
     {% endif %}
 
@@ -44,12 +44,12 @@
       <caption class="usa-sr-only">{{ "precip-table.aria.amounts.01" | t }}</caption>
       <thead>
         <tr>
-          <th scope="col">{{ "Time Period" | t }}</th>
+          <th scope="col">{{ "precip-table.table-header.time-period.01" | t }}</th>
           {% if qpf.hasSnow %}
-          <th scope="col">{{ "Snow" | t }}</th>
+          <th scope="col">{{ "precip-table.table-header+legend.snow.01" | t }}</th>
           {% endif %}
           {% if qpf.hasIce %}
-          <th scope="col">{{ "Ice" | t }}</th>
+          <th scope="col">{{ "precip-table.table-header+legend.ice.01" | t }}</th>
           {% endif %}
           {% if qpf.hasSnow or qpf.hasIce %}
           <th aria-hidden="true"></th>
@@ -63,15 +63,15 @@
           <tr>
             <td class="font-family-mono font-mono-xs text-base text-ls-neg-3">{{ hour.startHour }}&emsp13;–&emsp13;{{ hour.endHour }}</td>
             {% if qpf.hasSnow %}
-            <td class="text-align-left">{{ hour.snow.in }}{{ '"' | t }}</td>
+            <td class="text-align-left">{{ "units.inches.01" | t({ "@inches": hour.snow.in }) }}</td>
             {% endif %}
             {% if qpf.hasIce %}
-            <td class="text-align-left">{{ hour.ice.in }}{{ '"' | t }}</td>
+            <td class="text-align-left">{{ "units.inches.01" | t({ "@inches": hour.ice.in }) }}</td>
             {% endif %}
             {% if qpf.hasSnow or qpf.hasIce %}
             <td aria-hidden="true"></td>
             {% endif %}
-            <td class="text-align-left">{{ hour.liquid.in }}{{ '"' | t }}</td>
+            <td class="text-align-left">{{ "units.inches.01" | t({ "@inches": hour.liquid.in }) }}</td>
           </tr>
         {% endfor %}
       </tbody>
@@ -81,11 +81,7 @@
   {% if qpf.hasIce or qpf.hasSnow %}
     <div class="grid-col-12 tablet:grid-col-6 tablet:padding-left-1">
       <p class="bg-base-lightest padding-105">
-        {{
-          "\"Water\" refers to the amount of water that is present in the precipitation.
-          The precipitation may actually fall in solid form such as ice or snow, in
-          liquid form as rain, or a mix of both." | t
-        }}
+        {{ "precip-table.text.water-explainer.01" | t }}
       </p>
     </div>
   {% endif %}

--- a/web/themes/new_weather_theme/templates/partials/quick-forecast-link-item.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/quick-forecast-link-item.html.twig
@@ -38,9 +38,9 @@ the content
           {% if day.alerts.metadata.count %}
           <span class="usa-sr-only">
             {% if day.alerts.metadata.count > 1 %}
-              {{ "Multiple weather alerts" | t }}
+              {{ "alerts.aria.multiple-alert.01" | t }}
             {% else %}
-              {{ "Weather alert" | t }}
+              {{ "alerts.aria.one-alert.01" | t }}
             {% endif %}
           </span>
           {% endif %}
@@ -64,7 +64,7 @@ the content
                 {{"daily-forecast.labels.high.01" | t}}
               </span>
               <span class="wx-quick-temp">
-                {{ "abbreviations.not-applicable.01" | t  }}
+                {{ "abbreviations.not-applicable.01" | t }}
               </span>
             </div>
           {% else %}
@@ -106,7 +106,7 @@ the content
 
     <div class="wx-quick-forecast-item-bottom">
       <span>
-          {{pop}}% {{"daily-forecast.text.chance-precip.01" | t}}
+          {{"daily-forecast.text.chance-precip.02" | t({ "@percent": pop }) }}
       </span>
     </div>
 

--- a/web/themes/new_weather_theme/templates/partials/radar.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/radar.html.twig
@@ -11,7 +11,7 @@
 
       <div class="position-absolute top-0 right-0 height-full">
         <div class="position-sticky top-0" style="top: 55px;">
-          <button type="button" class="wx-radar-expand padding-0 margin-1">
+          <button type="button" tabindex="-1" class="wx-radar-expand padding-0 margin-1">
             <svg role="img" class="width-full height-full">
               <use xlink:href="{{ "/" ~ directory ~ "/assets/images/uswds/sprite.svg#zoom_out_map" }}"></use>
             </svg>
@@ -54,6 +54,7 @@
           <button
               class="usa-accordion__button"
               type="button"
+              tabindex="-1"
               aria-expanded="false"
               aria-controls="radar-legend">
             {{"radar.labels.legend.01" | t}}

--- a/web/themes/new_weather_theme/templates/partials/radar.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/radar.html.twig
@@ -1,22 +1,9 @@
 {{ attach_library("new_weather_theme/cmi-radar") }}
 
-<div class="margin-top-2" wx-outer-radar-container>
+<div aria-hidden="true" class="margin-top-2" wx-outer-radar-container>
   <h3 class="wx-visual-h2 text-normal text-primary-darker padding-x-2 tablet:padding-x-0 margin-top-3 margin-bottom-2">{{ "radar.labels.radar.01" | t }}</h3>
 
   <div class="grid-container padding-0 bg-white shadow-1">
-    <div class="usa-sr-only">
-      <p>
-        {{ "radar.aria.description.01" | t({"@place": place }) }}
-        <a href="" data-daily-tab-link>{{ "radar.labels.daily-tab.01" | t }}</a>.
-      </p>
-      <script type="text/javascript">
-       const link = document.querySelector("[data-daily-tab-link]");
-       link.addEventListener("click", e => {
-           e.preventDefault();
-           document.querySelector("wx-tabbed-nav").switchToTab("daily");
-       });
-      </script>
-    </div>
     <div class="grid-row wx-radar-container position-relative">
       <wx-radar class="grid-col-12" lat="{{ point.latitude }}" lon="{{ point.longitude }}">
         <div id="wx_radar_container" style="height: 300px; width:100%"></div>
@@ -25,9 +12,7 @@
       <div class="position-absolute top-0 right-0 height-full">
         <div class="position-sticky top-0" style="top: 55px;">
           <button type="button" class="wx-radar-expand padding-0 margin-1">
-            <div class="usa-sr-only wx-radar-expand__description">{{ "radar.aria.expand-map.01" | t }}</div>
-            <div class="usa-sr-only display-none wx-radar-expand__description">{{ "radar.aria.collapse-map.01" | t }}</div>
-            <svg role="img" aria-hidden="true" class="width-full height-full">
+            <svg role="img" class="width-full height-full">
               <use xlink:href="{{ "/" ~ directory ~ "/assets/images/uswds/sprite.svg#zoom_out_map" }}"></use>
             </svg>
           </button>
@@ -75,7 +60,6 @@
           </button>
         </h4>
         <table class="usa-accordion__content usa-table usa-table--borderless margin-top-0 wx-radar-legend" tabindex="0"  id="radar-legend">
-          <caption class="usa-sr-only">{{ "radar.aria.legend.01" | t }}</caption>
           <tr>
             <th class="font-family-mono text-primary-dark font-mono-xs z-400">
               {{ "units.dbz.01" | t }}

--- a/web/themes/new_weather_theme/templates/partials/satellite.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/satellite.html.twig
@@ -4,7 +4,7 @@
 
     <div class="padding-0 bg-white shadow-1">
       <div class="display-flex text-center">
-        <video controls loop class="display-block flex-1 width-full">
+        <video tabindex="-1" controls loop class="display-block flex-1 width-full">
           <source src="{{ point.satellite.mp4 }}" type="video/mp4" />
           {# Fallback to GIF, in case video is not supported #}
           <img src="{{ point.satellite.gif }}"  alt="">

--- a/web/themes/new_weather_theme/templates/partials/satellite.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/satellite.html.twig
@@ -1,18 +1,9 @@
 {% if point.satellite.gif is not null %}
-  <div class="margin-top-2" wx-outer-radar-container>
-    <h3 class="wx-visual-h2 text-normal text-primary-darker margin-top-3 margin-bottom-2 padding-left-2 tablet:padding-left-0">{{ "Satellite" | t }}</h3>
+  <div aria-hidden="true" class="margin-top-2" wx-outer-radar-container>
+    <h3 class="wx-visual-h2 text-normal text-primary-darker margin-top-3 margin-bottom-2 padding-left-2 tablet:padding-left-0">{{ "satellite.heading.satellite.01" | t }}</h3>
 
     <div class="padding-0 bg-white shadow-1">
-      <div class="usa-sr-only">
-        <p>
-          {{ "Listed below is an animated loop of the most recent
-            satellite imagery for @place."
-          | t({"@place": point.place.fullName })
-          }}
-        </p>
-      </div>
-
-      <div aria-hidden="true" class="display-flex text-center">
+      <div class="display-flex text-center">
         <video controls loop class="display-block flex-1 width-full">
           <source src="{{ point.satellite.mp4 }}" type="video/mp4" />
           {# Fallback to GIF, in case video is not supported #}

--- a/web/themes/new_weather_theme/templates/partials/today-summary-forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/today-summary-forecast.html.twig
@@ -4,7 +4,7 @@
 {% elseif forecast.days | length > 0 %}
   {% set today = forecast.days[0] %}
   <h3 class="wx-visual-h2 text-normal text-primary-darker padding-x-2 tablet:padding-x-0 desktop:margin-top-0 margin-top-3 margin-bottom-2">
-    {{ "Today's forecast" | t }}
+    {{ "forecast.heading.today-forecast.01" | t }}
   </h3>
   <div class="flex-1 height-full">
     <ol class="usa-list--unstyled height-full">

--- a/web/themes/new_weather_theme/templates/partials/wind.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/wind.html.twig
@@ -40,6 +40,8 @@
     <span class="usa-sr-only">{{ "wind.labels.speed-from-south.01" | t({ "@speed": speed.mph }) }}</span>
   {% elseif direction.cardinalLong == "southwest" %}
     <span class="usa-sr-only">{{ "wind.labels.speed-from-southwest.01" | t({ "@speed": speed.mph }) }}</span>
+  {% elseif direction.cardinalLong == "west" %}
+    <span class="usa-sr-only">{{ "wind.labels.speed-from-west.01" | t({ "@speed": speed.mph }) }}</span>
   {% elseif direction.cardinalLong == "northwest" %}
     <span class="usa-sr-only">{{ "wind.labels.speed-from-northwest.01" | t({ "@speed": speed.mph }) }}</span>
   {% endif %}

--- a/web/themes/new_weather_theme/templates/partials/wind.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/wind.html.twig
@@ -1,14 +1,9 @@
 {% if speed.mph is not same as (null) %}
-  {#
-  We will have a dedicated block for screen readers to mitigate an issue with
-  VoiceOver treating spans as distinct elements and forcing users to navigate
-  between them.
-  #}
-  <div class="display-flex flex-row flex-align-center" aria-hidden="true">
+  <div aria-hidden="true" class="display-flex flex-row flex-align-center">
     {% if speed.mph == 0 %}
       <span>{{ "wind.labels.calm.01" | t }}</span>
     {% else %}
-      <span>{{speed.mph}} {{ "units.mph.01" | t }}</span>
+      <span>{{ "units.mph.02" | t({ "@speed": speed.mph }) }}</span>
       <span class="padding-x-05">{{ direction.cardinalShort }}</span>
       <span class="display-flex flex-align-center margin-bottom-2px">
         {#
@@ -16,13 +11,16 @@
         is reported as a FROM direction, but our arrow points in the
         TO direction. So we just need to spin it 'round.
         #}
-        <svg role="img" aria-hidden="true" data-wind-direction class="width-2 height-2" style="transform: rotate({{ direction.degrees + 180 }}deg);">
+        <svg role="img" data-wind-direction class="width-2 height-2" style="transform: rotate({{ direction.degrees + 180 }}deg);">
           <use xlink:href="{{ "/" ~ directory ~ "/assets/images/spritesheet.svg#wx_wind_arrow" }}"></use>
         </svg>
       </span>
     {% endif %}
   </div>
   {#
+  We have a dedicated block for screen readers to mitigate an issue with
+  VoiceOver treating spans as distinct elements and forcing users to navigate
+  between them.
   By putting all of the content into a single span, we can get VoiceOver to read
   it in a more natural way.
   #}

--- a/web/themes/new_weather_theme/templates/point/alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/point/alerts.html.twig
@@ -1,5 +1,5 @@
 {{ attach_library("new_weather_theme/leaflet") }}
-<h2 class="usa-sr-only">Alerts</h2>
+<h2 class="usa-sr-only">{{ "Alerts" | t }}</h2>
 <div class="grid-container padding-x-2 desktop:padding-x-4"> 
   <div class="grid-row"> 
     <div class="grid-col-12">
@@ -123,7 +123,7 @@
                 >
                 <div id="wx_alert_map_{{ alert.id }}" class="height-full"></div>
                 <div class="wx_alert_map_legend margin-top-3 display-flex flex-align-center">
-                  <div class="wx_alert_map_legend_impact_area display-block width-3 height-3 border-2px margin-right-1"></div><span>Impacted Area</span>
+                  <div class="wx_alert_map_legend_impact_area display-block width-3 height-3 border-2px margin-right-1"></div><span>{{ "Impacted Area" | t }}</span>
                 </div>
               </wx-alert-map>
             </div>

--- a/web/themes/new_weather_theme/templates/point/alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/point/alerts.html.twig
@@ -1,5 +1,5 @@
 {{ attach_library("new_weather_theme/leaflet") }}
-<h2 class="usa-sr-only">{{ "Alerts" | t }}</h2>
+<h2 class="usa-sr-only">{{ "alerts.heading+aria.alerts.01" | t }}</h2>
 <div class="grid-container padding-x-2 desktop:padding-x-4"> 
   <div class="grid-row"> 
     <div class="grid-col-12">
@@ -18,8 +18,11 @@
         </h3>
         <div id="a{{alert.id}}" class="usa-accordion__content usa-prose">
           <p class="font-sans-md text-bold text-primary-darker margin-y-0" >
-            {{ "alerts.text.in-effect-from.01" | t }} {{ alert.timing.start }}
-            {% if alert.timing.end %} – {{ alert.timing.end }}{% endif %}
+          {% if alert.timing.end %}
+            {{ "alerts.text.in-effect-from-until.01" | t({ "@start": alert.timing.start, "@end": alert.timing.end }) }}
+          {% else %}
+            {{ "alerts.text.in-effect-from.01" | t({ "@start": alert.timing.start }) }}
+          {% endif %}
           </p>
           <p class="margin-y-05">
             {{ "alerts.text.issued-by.01" | t({ "@sender": alert.sender }) }}
@@ -123,7 +126,7 @@
                 >
                 <div id="wx_alert_map_{{ alert.id }}" class="height-full"></div>
                 <div class="wx_alert_map_legend margin-top-3 display-flex flex-align-center">
-                  <div class="wx_alert_map_legend_impact_area display-block width-3 height-3 border-2px margin-right-1"></div><span>{{ "Impacted Area" | t }}</span>
+                  <div class="wx_alert_map_legend_impact_area display-block width-3 height-3 border-2px margin-right-1"></div><span>{{ "alerts.legend.impacted-area.01" | t }}</span>
                 </div>
               </wx-alert-map>
             </div>

--- a/web/themes/new_weather_theme/templates/point/forecast.html.twig
+++ b/web/themes/new_weather_theme/templates/point/forecast.html.twig
@@ -15,20 +15,20 @@
         <div class="wx-quick-forecast-header-top margin-right-3 table:margin-right-0">
           <div class="flex-1">
             <span>
-              {{"Date" | t}}
+              {{"daily-forecast.table-header.date.01" | t}}
             </span>
           </div>
           <div class="flex-1 mobile-lg:display-flex mobile-lg:flex-justify-center">
             <span>
-              {{"Condition" | t}}
+              {{"daily-forecast.table-header.condition.01" | t}}
             </span>
           </div>
           <div class="flex-1 display-flex">
             <span class="flex-1">
-              {{"High" | t}}
+              {{"daily-forecast.table-header.high.01" | t}}
             </span>
             <span class="flex-1">
-              {{"Low" | t}}
+              {{"daily-forecast.table-header.low.01" | t}}
             </span>
           </div>
         </div>

--- a/web/themes/new_weather_theme/templates/point/observations.html.twig
+++ b/web/themes/new_weather_theme/templates/point/observations.html.twig
@@ -1,6 +1,6 @@
 {# Widgets and stuff. This is presented as a row of columns. #}
 <h3 class="wx-visual-h2 text-normal text-primary-darker padding-x-2 tablet:padding-x-0 margin-top-0 margin-bottom-2">
-  {{ "Current conditions" | t }}
+  {{ "forecast.heading.current-conditions.01" | t }}
 </h3>
 <div class="bg-white padding-2 shadow-1 grid-col-12 flex-1">
   <div class="wx-current-conditions grid-row grid-gap">
@@ -11,21 +11,17 @@
 
       {# Weather narrative is for screen readers only #}
       <div role="text" data-wx-current-conditions-narrative class="tablet:grid-col-12 usa-sr-only height-1px">
-        {{ 'forecast.current.weather-as-of.01' | t }}
-        <time datetime="{{ obs.timestamp.utc }}" data-wx-local-time>
-          {{ obs.timestamp.formatted }}
-        </time>.
-        {{ "forecast.current.weather-temp-description.01" |
-        t({
+        {{ 'forecast.aria.current-conditions-narrative.01' | t({
+            "@time": obs.timestamp.formatted,
             "@place": point.place.fullName,
             "@conditions": obs.description | lower,
             "@temperature": obs.data.temperature.degF,
         })
         }}
         {% if obs.data.feelsLike.degF != obs.data.temperature.degF %}
-          {{ "forecast.current.aria.feels-like.01" |
+          {{ "forecast.aria.current-conditions-feels-like.01" |
           t({
-              "@feelsLike": obs.data.feelsLike.degF
+              "@temperature": obs.data.feelsLike.degF
           })
           }}
         {% endif %}

--- a/web/themes/new_weather_theme/templates/wfo-info/node--wfo-info.html.twig
+++ b/web/themes/new_weather_theme/templates/wfo-info/node--wfo-info.html.twig
@@ -23,9 +23,9 @@
         <figure class="margin-0">
           <img src="/{{ directory }}/assets/images/wfos/{{ wfo.code }}.png" alt="">
           <figcaption class="font-sans-xs">
-            {{ "wfo-info.labels.coverage-area-map-caption.01" | t({ "@wfo": wfo.name })}}
+            {{ "wfo-info.caption.coverage-area-map.01" | t({ "@wfo": wfo.name })}}
             <p class="usa-sr-only">
-              {{ "This includes @counties" | t({ "@counties": counties }) }}
+              {{ "wfo-info.caption+aria.coverage-area-map.01" | t({ "@counties": counties }) }}
             </p>
           </figcaption>
         </figure>
@@ -39,30 +39,29 @@
     <div class="grid-row">
       <div class="grid-col-12 tablet:grid-col-6">
         <h2 class="font-sans-xl border-top-1px border-base-light text-normal text-primary-darker padding-top-105 margin-top-4">
-          {{ "wfo-info.labels.local-expertise.01" | t }}
+          {{ "wfo-info.heading.local-expertise.01" | t }}
         </h2>
         <p>
-          {{ "Decision support is description tk tk tk" | t }}
+          {{ "Decision support is description tk tk" | t }}
         </p>
         <ul class="margin-bottom-0 padding-left-2">
-          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Briefing" | t }}</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">{{ "County finder" | t }}</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">{{ "State page" | t }}</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Resource 1" | t }}</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Resource 2" | t }}</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Resource 3" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Briefing tk tk" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "County finder tk tk" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "State page tk tk" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Resource 1 tk tk" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Resource 2 tk tk" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Resource 3 tk tk" | t }}</a></li>
         </ul>
       </div>
 
       <div class="grid-col-12 tablet:grid-col-6">
         <h2 class="font-sans-xl border-top-1px border-base-light text-normal text-primary-darker padding-top-105 margin-top-4">
-          {{ "wfo-info.labels.forecast-discussion.01" | t }}
+          {{ "wfo-info.heading.forecast-discussion.01" | t }}
         </h2>
         <p>
-          {{ "The purpose of the area forecast discussion is to provide the
-          meteorological/scientific reasoning behind the forecast" | t }}
+          {{ "wfo-info.text.forecast-discussion.01" | t }}
         </p>
-        <a class="usa-link" href="/afd/{{ wfo.code }}">{{ "Current Area Forecast Discussion" | t }}</a>
+        <a class="usa-link" href="/afd/{{ wfo.code }}">{{ "wfo-info.link.area-forecast-discussion" | t }}</a>
       </div>
     </div>
 
@@ -80,7 +79,7 @@
 
     {% if hasContact %}
       <h2 class="font-sans-xl border-top-1px border-base-light text-normal text-primary-darker margin-bottom-0 padding-top-105 margin-top-4">
-        {{ "wfo-info.labels.contact-us.01" | t }}
+        {{ "wfo-info.heading.contact-us.01" | t }}
       </h2>
 
       <div class="grid-row margin-top-2">

--- a/web/themes/new_weather_theme/templates/wfo-info/node--wfo-info.html.twig
+++ b/web/themes/new_weather_theme/templates/wfo-info/node--wfo-info.html.twig
@@ -42,15 +42,15 @@
           {{ "wfo-info.labels.local-expertise.01" | t }}
         </h2>
         <p>
-          Decision support is description tk tk tk
+          {{ "Decision support is description tk tk tk" | t }}
         </p>
         <ul class="margin-bottom-0 padding-left-2">
-          <li class="padding-y-05"><a class="usa-link" href="#">Briefing</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">County finder</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">State page</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">Resource 1</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">Resource 2</a></li>
-          <li class="padding-y-05"><a class="usa-link" href="#">Resource 3</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Briefing" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "County finder" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "State page" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Resource 1" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Resource 2" | t }}</a></li>
+          <li class="padding-y-05"><a class="usa-link" href="#">{{ "Resource 3" | t }}</a></li>
         </ul>
       </div>
 
@@ -59,10 +59,10 @@
           {{ "wfo-info.labels.forecast-discussion.01" | t }}
         </h2>
         <p>
-          The purpose of the area forecast discussion is to provide the
-          meteorological/scientific reasoning behind the forecast
+          {{ "The purpose of the area forecast discussion is to provide the
+          meteorological/scientific reasoning behind the forecast" | t }}
         </p>
-        <a class="usa-link" href="/afd/{{ wfo.code }}">Current Area Forecast Discussion</a>
+        <a class="usa-link" href="/afd/{{ wfo.code }}">{{ "Current Area Forecast Discussion" | t }}</a>
       </div>
     </div>
 


### PR DESCRIPTION
## What does this PR do? 🛠️

* Makes a few fixes to the translation tests
* Adds 70+ additional strings to `en.po` -- they are also in [this spreadsheet](https://docs.google.com/spreadsheets/d/1xsCSnnQ9m4BIHCGbP6GGgMz95VKHQQvOvkbedyaLLm8/edit?pli=1&gid=0#gid=0) 🔒 to send for translation
* Consolidates a few strings for better translation
* Hides the Satellite and Radar from screen reader users, as discussed in our last a11y review call, and removes `sr-only` strings that aren't needed from that
* Marks "placeholder" strings with `tk tk` so that we'll know not to have them translated

Closes #2166 

## What does the reviewer need to know? 🤔

Best way to check this is to run `make update-translations` and go through the site to look for anything odd.

You can also run `make check-translations` to see what the tests think the state of translation is.
