### PR TITLE
gitlab ci: generalize build and add documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - test
   - deploy
 
-build-utility-image:
+.build-image:
   image: docker:27
   stage: build
   services:
@@ -15,12 +15,24 @@ build-utility-image:
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_TLS_CERTDIR: ""
-    PROJECT_REGISTRY: "$CI_REGISTRY/nws/systems/dis/weather.gov-2.0"
   script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker compose build utility-node
-    - docker image tag weathergov-utility-node:latest $PROJECT_REGISTRY/weathergov-utility:latest
-    - docker push $PROJECT_REGISTRY/weathergov-utility:latest
+    - docker compose build $IMAGE_NAME
+    - IMAGE_ID=$(docker images | grep $DERIVED_IMAGE_NAME | awk '{print $3}')
+    - docker image tag $IMAGE_ID $CI_REGISTRY_IMAGE/weathergov-$IMAGE_NAME:latest
+    - docker push $CI_REGISTRY_IMAGE/weathergov-$IMAGE_NAME:latest
+
+build-utility-node-image:
+  extends: .build-image
+  variables:
+    DERIVED_IMAGE_NAME: utility-node
+    IMAGE_NAME: utility-node
+
+build-drupal-image:
+  extends: .build-image
+  variables:
+    DERIVED_IMAGE_NAME: 18f-zscaler-drupal
+    IMAGE_NAME: drupal
 
 # NB: GitLab clones into CI_BUILDS_DIR which defaults to
 # /builds/gitlab-licensed/NWS/Systems/DIS/Weather.gov-2.0/ whereas in our Docker
@@ -28,7 +40,7 @@ build-utility-image:
 # CI_BUILDS_DIR so we can "npm run" as needed.
 js-lint:
   stage: test
-  image: $CI_REGISTRY_IMAGE/weathergov-utility:latest
+  image: $CI_REGISTRY_IMAGE/weathergov-utility-node:latest
   script:
     - ln -s /app/node_modules/ .
     - ln -s /app/api-interop-layer/node_modules api-interop-layer/
@@ -41,7 +53,7 @@ js-lint:
 
 style-lint:
   stage: test
-  image: $CI_REGISTRY_IMAGE/weathergov-utility:latest
+  image: $CI_REGISTRY_IMAGE/weathergov-utility-node:latest
   script:
     - ln -s /app/node_modules/ .
     - npm run --silent style-lint-report 2> stylelint.xml
@@ -62,7 +74,7 @@ php-lint:
 
 js-component-tests:
   stage: test
-  image: $CI_REGISTRY_IMAGE/weathergov-utility:latest
+  image: $CI_REGISTRY_IMAGE/weathergov-utility-node:latest
   script:
     - ln -s /app/node_modules/ .
     - npm run --silent js-component-tests-report
@@ -73,7 +85,7 @@ js-component-tests:
 
 js-interop-layer-tests:
   stage: test
-  image: $CI_REGISTRY_IMAGE/weathergov-utility:latest
+  image: $CI_REGISTRY_IMAGE/weathergov-utility-node:latest
   script:
     - ln -s /app/api-interop-layer/node_modules api-interop-layer/
     - cd api-interop-layer/ && npm run --silent test-report

--- a/Makefile
+++ b/Makefile
@@ -204,5 +204,5 @@ container_repository = "registry.gitlab-licensed.vlab.noaa.gov/nws/systems/dis/w
 ### Tag the weather.gov utility image to push up to our Gitlab container repository
 push-weathergov-utility-image:
 	docker compose build utility-node
-	docker image tag weathergov-utility-node ${container_repository}/weathergov-utility:latest
-	docker push ${container_repository}/weathergov-utility:latest
+	docker image tag weathergov-utility-node ${container_repository}/weathergov-utility-node:latest
+	docker push ${container_repository}/weathergov-utility-node:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       DB_PORT: 3306
       API_URL: http://api-proxy:8081
       API_INTEROP_NAME: ${API_INTEROP_NAME:-local}
-      NEWRELIC_LICENSE: $NEWRELIC_LICENSE
+      NEWRELIC_LICENSE: ${NEWRELIC_LICENSE:-}
     networks:
       - weather.gov
     links:

--- a/docs/dev/gitlab-ci.md
+++ b/docs/dev/gitlab-ci.md
@@ -1,0 +1,24 @@
+# Gitlab CI Configuration
+
+## General approach
+
+With Gitlab, we have an opportunity to re-use our existing Docker infrastructure for CI, especially in conjunction with the [Gitlab container registry](https://vlab.noaa.gov/gitlab-licensed/NWS/Systems/DIS/Weather.gov-2.0/container_registry). This simplifies our Gitlab CI configuration since we can build and test in CI exactly the same way as we do locally. (This approach differs from Github Actions because Actions sometimes uses alternative approaches to install the required environment, such as installing `php` via `shivammathur/setup-php@v2`.) Some changes to keep in mind:
+
+- We want Gitlab CI to create the Docker images for us. Generally, pushing direct images to the Gitlab container repository is discouraged, as we want to ensure images were generated from a known and fixed commit for reproducibility and security reasons.
+- We may want to default to pulling from the Gitlab container repository instead of building locally (this will save time.) Of course, you can always build locally.
+- NWS Vlab is still building out requisite Gitlab CI runner functionality (see limitations below), and in particular may need help tweaking Gitlab CI runner concurrency settings.
+
+### Current Limitations as of December 2024
+
+- We only have one instance-level Gitlab CI runner (Kubernetes) shared across the organization. Fortunately, this runner is configured for concurrent pipeline jobs and is reasonably performant.
+- [Distributed caches](https://docs.gitlab.com/runner/configuration/autoscale.html#distributed-runners-caching) for Gitlab runners is not enabled. (This feature will be implemented eventually but is not a high priority.)
+- Docker-in-Docker requires TLS to be disabled. (This may change in the near future.)
+- Gitlab container security scanning is present but functionality is minimal. (Amazon ECR may be an alternative in the future.)
+
+## Versioning
+
+Still a work in progress. Currently images are manually created. The plan is roughly:
+
+- Every push to `main` will generate new images and tag them as `latest`.
+- If the Dockerfile or its dependencies (such as `package-lock.json`) are changed in a commit, then CI will build a new image and tag it with the git sha1 hash. (TBD: how to pull in that version for that pipeline)
+- Some images, such as Playwright, will be periodically refreshed using Gitlab's [pipeline schedules](https://vlab.noaa.gov/gitlab-licensed/NWS/Systems/DIS/Weather.gov-2.0/-/pipeline_schedules).

--- a/docs/dev/gitlab-ci.md
+++ b/docs/dev/gitlab-ci.md
@@ -5,7 +5,7 @@
 With Gitlab, we have an opportunity to re-use our existing Docker infrastructure for CI, especially in conjunction with the [Gitlab container registry](https://vlab.noaa.gov/gitlab-licensed/NWS/Systems/DIS/Weather.gov-2.0/container_registry). This simplifies our Gitlab CI configuration since we can build and test in CI exactly the same way as we do locally. (This approach differs from Github Actions because Actions sometimes uses alternative approaches to install the required environment, such as installing `php` via `shivammathur/setup-php@v2`.) Some changes to keep in mind:
 
 - We want Gitlab CI to create the Docker images for us. Generally, pushing direct images to the Gitlab container repository is discouraged, as we want to ensure images were generated from a known and fixed commit for reproducibility and security reasons.
-- We may want to default to pulling from the Gitlab container repository instead of building locally (this will save time.) Of course, you can always build locally.
+- We may want to default to pulling from the Gitlab container repository instead of building the Docker images locally (this will save time.) Of course, you can always build the Docker images locally.
 - NWS Vlab is still building out requisite Gitlab CI runner functionality (see limitations below), and in particular may need help tweaking Gitlab CI runner concurrency settings.
 
 ### Current Limitations as of December 2024


### PR DESCRIPTION
## What does this PR do? 🛠️

Does what it says on the tin: generalize build (does not work for `database` yet) and documents Gitlab CI as it is right now ([rendered](https://github.com/weather-gov/weather.gov/blob/fd5bf0118f2688fcc532768d481f59f0f1a6df8b/docs/dev/gitlab-ci.md)). 

## What does the reviewer need to know? 🤔

- There is no good way to name an image -- it is derived from the docker compose yaml. So I add a derived variable but we might be able to clean this up later.
- A dot before the gitlab pipeline means "do not execute directly" -- here, we use `.build-image` as a template to be extended. 