### PR TITLE
dss builder: bugfix to accommodate 4 char WFO ids

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherEntityService.php
+++ b/web/modules/weather_data/src/Service/WeatherEntityService.php
@@ -94,6 +94,8 @@ class WeatherEntityService
 
     public function getLatestWeatherStoryImageFromWFO($wfo, $nodeType)
     {
+        // we get canonical four letters from the DSS builder. omit the first character.
+        $truncatedWFO = substr($wfo, 1);
         // get the latest weather story upload that matches the grid WFO.
         $nodeID = $this->entityTypeManager
             ->getStorage("node")
@@ -101,7 +103,7 @@ class WeatherEntityService
             ->accessCheck(false)
             ->condition("status", 1)
             ->condition("type", $nodeType)
-            ->condition("field_office", $wfo)
+            ->condition("field_office", $truncatedWFO)
             ->sort("changed", "DESC")
             // Only get the first one.
             ->range(0, 1)


### PR DESCRIPTION
## What does this PR do? 🛠️

We discovered today that WFO ids are canonically four characters.

> Not all of them start with a "K," e.g. Guam (PGUM). I can't imagine any conflict ever in reality, but the full, proper call signs are four characters.

This fixes for DSS builder weather story image matching by throwing away the first character.