### PR TITLE
bump up api interop to 1024M

### DIFF
--- a/manifests/manifest-beta.yaml
+++ b/manifests/manifest-beta.yaml
@@ -24,7 +24,7 @@ applications:
 
   - name: api-weathergov-beta
     stack: cflinuxfs4
-    memory: 512M
+    memory: 1024M
     instances: 1
     buildpacks:
       - nodejs_buildpack


### PR DESCRIPTION
## What does this PR do? 🛠️

We are currently using ~4gb out of our memory quota. Let's go ahead and give the api interop some extra memory. 

## What does the reviewer need to know? 🤔

we got another instance of the api interop layer crash-loop of doom :tm: so this is (likely) a short term solution