### PR TITLE
fix WFO canonical mapping

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherEntityService.php
+++ b/web/modules/weather_data/src/Service/WeatherEntityService.php
@@ -94,8 +94,6 @@ class WeatherEntityService
 
     public function getLatestWeatherStoryImageFromWFO($wfo, $nodeType)
     {
-        // we get canonical four letters from the DSS builder. omit the first character.
-        $truncatedWFO = substr($wfo, 1);
         // get the latest weather story upload that matches the grid WFO.
         $nodeID = $this->entityTypeManager
             ->getStorage("node")
@@ -103,7 +101,7 @@ class WeatherEntityService
             ->accessCheck(false)
             ->condition("status", 1)
             ->condition("type", $nodeType)
-            ->condition("field_office", $truncatedWFO)
+            ->condition("field_office", '%' . $wfo, 'LIKE')
             ->sort("changed", "DESC")
             // Only get the first one.
             ->range(0, 1)


### PR DESCRIPTION
## What does this PR do? 🛠️

Quick fix-- don't truncate the WFO but rather query the WFO ending. e.g., searching for WFO with `IWX` will match these with `SIWX`. 

## Screenshots (if appropriate): 📸

![image](https://github.com/user-attachments/assets/3573b997-7cd5-4877-ab9e-27bbaaf3630d)
