### PR TITLE
Hide timestamps and add construction icon

### DIFF
--- a/web/modules/weather_i18n/translations/en.po
+++ b/web/modules/weather_i18n/translations/en.po
@@ -544,8 +544,8 @@ msgstr "From the forecaster"
 msgid "weather-story.link.area-forecast-discussion.01"
 msgstr "Area Forecast Discussion"
 
-msgid "weather-story.text.created-by.01"
-msgstr "<strong class='text-base-dark'>Created: @date</strong> by the <a class='usa-link' href='@wfo_url'>@wfo_name WFO</a>"
+msgid "weather-story.text.created-by.02"
+msgstr "<strong class='text-base-dark'>Created by the <a class='usa-link' href='@wfo_url'>@wfo_name WFO</a></strong>"
 
 msgid "wind.labels.calm.01"
 msgstr "calm"

--- a/web/themes/new_weather_theme/templates/block/block--weathergov-weather-story-image.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--weathergov-weather-story-image.html.twig
@@ -3,13 +3,27 @@
   <div class="wx-weather-story-wrapper">
     {# Top section with text #}
     <div class="margin-bottom-2">
-      <h3 class="wx-visual-h2 text-normal text-primary-darker margin-top-3 margin-bottom-2">{{ "weather-story.heading.from-forecaster.01" | t }}</h3>
+      <h3 class="wx-visual-h2 text-normal text-primary-darker margin-top-3 margin-bottom-2">
+        {{ "weather-story.heading.from-forecaster.01" | t }}
+        <span class="display-flex flex-align-center bg-gold-10v text-black text-uppercase padding-y-05 padding-left-1 padding-right-105 font-sans-xs radius-md margin-left-1 margin-top-105 tablet:margin-top-0">
+          <svg
+              class="usa-icon height-205 width-205 margin-right-05 text-top margin-bottom-2px"
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+          >
+            <use
+              xlink:href="/{{ directory }}/assets/images/uswds/sprite.svg#construction_worker"
+            ></use>
+          </svg>
+          {{ "backend.banner.under-development.01" | t }}
+        </span>
+      </h3>
       <h4 class="wx-visual-h3 text-primary-dark margin-0 margin-bottom-2">{{ content.title }}</h4>
       <p class="margin-0 margin-bottom-2">
         {% set normalized_wfo = content.wfo_code | normalize_wfo %}
         {% set wfo_url = '/offices/' ~ normalized_wfo %}
-        {{ "weather-story.text.created-by.01" | t({
-          "@date": content.updated.formatted,
+        {{ "weather-story.text.created-by.02" | t({
           "@wfo_url": wfo_url,
           "@wfo_name": content.wfo_name
         })}}


### PR DESCRIPTION
## What does this PR do? 🛠️

To help reduce confusion until we can implement some fixes to old weather stories showing with incorrect dates:
* hide the timestamp
* add the "under development" icon

## Screenshots (if appropriate): 📸

![image](https://github.com/user-attachments/assets/f5aef0da-b513-427e-83b2-e0c3d7b35c0c)

Without a weather story:

![image](https://github.com/user-attachments/assets/61857096-c1a1-4188-a65f-7e3d70887353)
