### PR TITLE
Fix expired weather stories

### DIFF
--- a/web/modules/weather_data/src/Service/WeatherEntityService.php
+++ b/web/modules/weather_data/src/Service/WeatherEntityService.php
@@ -101,8 +101,10 @@ class WeatherEntityService
             ->accessCheck(false)
             ->condition("status", 1)
             ->condition("type", $nodeType)
+            ->condition("field_starttime", time(), '<=')
+            ->condition("field_endtime", time(), '>=')
             ->condition("field_office", '%' . $wfo, 'LIKE')
-            ->sort("changed", "DESC")
+            ->sort("field_order", "ASC")
             // Only get the first one.
             ->range(0, 1)
             ->execute();


### PR DESCRIPTION
## What does this PR do? 🛠️

This PR tries to limit stories selected for display to those where the current server time is within the UTC start/end times given by the weather story XML.

## What does the reviewer need to know? 🤔

James, I faked some timestamps to test this on local, but I would love if we could copy a bunch of actual stories from beta. Do you already have a script that can do that?