### PR TITLE
change filepath setting to remove warning, not used

### DIFF
--- a/web/config/sync/filefield_paths.settings.yml
+++ b/web/config/sync/filefield_paths.settings.yml
@@ -1,3 +1,3 @@
 _core:
   default_config_hash: Kt7Ug8VUG1kQuaf77ad_5XIKSr-66nzuWUTIEVmhKl8
-temp_location: 'public://filefield_paths'
+temp_location: 'temporary://filefield_paths'


### PR DESCRIPTION
Chatted with James about this. It's not being used, but it's giving us an error I'd like to get rid of.