### PR TITLE
add opt out for weather stories

### DIFF
--- a/web/config/sync/core.entity_form_display.taxonomy_term.weather_forecast_offices.default.yml
+++ b/web/config/sync/core.entity_form_display.taxonomy_term.weather_forecast_offices.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.weather_forecast_offices.field_weather_story_opt_out
     - field.field.taxonomy_term.weather_forecast_offices.field_wfo_code
     - taxonomy.vocabulary.weather_forecast_offices
 id: taxonomy_term.weather_forecast_offices.default
@@ -10,6 +11,13 @@ targetEntityType: taxonomy_term
 bundle: weather_forecast_offices
 mode: default
 content:
+  field_weather_story_opt_out:
+    type: boolean_checkbox
+    weight: 26
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_wfo_code:
     type: string_textfield
     weight: 3

--- a/web/config/sync/core.entity_view_display.taxonomy_term.weather_forecast_offices.default.yml
+++ b/web/config/sync/core.entity_view_display.taxonomy_term.weather_forecast_offices.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.weather_forecast_offices.field_weather_story_opt_out
     - field.field.taxonomy_term.weather_forecast_offices.field_wfo_code
     - taxonomy.vocabulary.weather_forecast_offices
   module:
@@ -18,6 +19,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_weather_story_opt_out:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 2
     region: content
   field_wfo_code:
     type: string

--- a/web/config/sync/field.field.taxonomy_term.weather_forecast_offices.field_weather_story_opt_out.yml
+++ b/web/config/sync/field.field.taxonomy_term.weather_forecast_offices.field_weather_story_opt_out.yml
@@ -1,0 +1,23 @@
+uuid: 7eeed965-8e2c-4195-8bbd-0d169018347e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_weather_story_opt_out
+    - taxonomy.vocabulary.weather_forecast_offices
+id: taxonomy_term.weather_forecast_offices.field_weather_story_opt_out
+field_name: field_weather_story_opt_out
+entity_type: taxonomy_term
+bundle: weather_forecast_offices
+label: weather_story_opt_out
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Select to opt out of weather stories'
+  off_label: 'Opted into weather stories by default'
+field_type: boolean

--- a/web/config/sync/field.storage.taxonomy_term.field_weather_story_opt_out.yml
+++ b/web/config/sync/field.storage.taxonomy_term.field_weather_story_opt_out.yml
@@ -1,0 +1,18 @@
+uuid: c84a451b-c210-4374-a479-4ba4866160e8
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_weather_story_opt_out
+field_name: field_weather_story_opt_out
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/weather_blocks/src/Plugin/Block/Test/WeatherStoryImageBlock.php.test
+++ b/web/modules/weather_blocks/src/Plugin/Block/Test/WeatherStoryImageBlock.php.test
@@ -21,6 +21,11 @@ final class WeatherStoryImageBlockTest extends Base
             $this->entityService
                 ->method("getLatestWeatherStoryImageFromWFO")
                 ->willReturn([]);
+
+            $this->entityService
+                ->method("getWFOTaxonomyOptOut")
+                ->willReturn(0);
+
             return;
         }
 
@@ -82,6 +87,10 @@ final class WeatherStoryImageBlockTest extends Base
         $this->entityService
             ->method("getLatestWeatherStoryImageFromWFO")
             ->willReturn($story);
+
+        $this->entityService
+            ->method("getWFOTaxonomyOptOut")
+            ->willReturn(0);
     }
 
     /**

--- a/web/modules/weather_blocks/src/Plugin/Block/WeatherStoryImageBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/WeatherStoryImageBlock.php
@@ -13,21 +13,6 @@ namespace Drupal\weather_blocks\Plugin\Block;
  */
 class WeatherStoryImageBlock extends WeatherBlockBase
 {
-    public function getWFOTaxonomyOptOut($wfoCode)
-    {
-        $wfo_results = \Drupal::entityTypeManager()
-            ->getStorage("taxonomy_term")
-            ->loadByProperties([
-                "vid" => "weather_forecast_offices",
-                "field_wfo_code" => strtoupper($wfoCode),
-            ]);
-        $wfo_results = array_values($wfo_results); // Indices can be totally random numbers!
-        if (count($wfo_results) == 0) {
-            throw new NotFoundHttpException();
-        }
-        return $wfo_results[0]->get('field_weather_story_opt_out')->getValue();
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -39,13 +24,13 @@ class WeatherStoryImageBlock extends WeatherBlockBase
         }
 
         if ($wfo) {
-            $weatherStoryOptOut = $this->getWFOTaxonomyOptOut($wfo);
+            $weatherStoryOptOut = $this->entityTypeService->getWFOTaxonomyOptOut($wfo);
             $story = $this->entityTypeService->getLatestWeatherStoryImageFromWFO(
                 $wfo,
                 "wfo_weather_story_upload",
             );
 
-            if ($story && $weatherStoryOptOut[0]['value'] == 0) {
+            if ($story && $weatherStoryOptOut == 0) {
                 // because the weather story description is comes via a xml
                 // CDATA tag, we need to strip tags and surrounding whitespace.
                 $description = $story->get("field_description")->value;

--- a/web/modules/weather_blocks/src/Plugin/Block/WeatherStoryImageBlock.php
+++ b/web/modules/weather_blocks/src/Plugin/Block/WeatherStoryImageBlock.php
@@ -13,6 +13,21 @@ namespace Drupal\weather_blocks\Plugin\Block;
  */
 class WeatherStoryImageBlock extends WeatherBlockBase
 {
+    public function getWFOTaxonomyOptOut($wfoCode)
+    {
+        $wfo_results = \Drupal::entityTypeManager()
+            ->getStorage("taxonomy_term")
+            ->loadByProperties([
+                "vid" => "weather_forecast_offices",
+                "field_wfo_code" => strtoupper($wfoCode),
+            ]);
+        $wfo_results = array_values($wfo_results); // Indices can be totally random numbers!
+        if (count($wfo_results) == 0) {
+            throw new NotFoundHttpException();
+        }
+        return $wfo_results[0]->get('field_weather_story_opt_out')->getValue();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -24,14 +39,13 @@ class WeatherStoryImageBlock extends WeatherBlockBase
         }
 
         if ($wfo) {
+            $weatherStoryOptOut = $this->getWFOTaxonomyOptOut($wfo);
             $story = $this->entityTypeService->getLatestWeatherStoryImageFromWFO(
                 $wfo,
                 "wfo_weather_story_upload",
             );
 
-            // If we actually have a story, now we can go about pulling data
-            // from it to pass along to the template.
-            if ($story) {
+            if ($story && $weatherStoryOptOut[0]['value'] == 0) {
                 // because the weather story description is comes via a xml
                 // CDATA tag, we need to strip tags and surrounding whitespace.
                 $description = $story->get("field_description")->value;

--- a/web/modules/weather_data/src/Service/WeatherEntityService.php
+++ b/web/modules/weather_data/src/Service/WeatherEntityService.php
@@ -81,6 +81,21 @@ class WeatherEntityService
         );
     }
 
+    public function getWFOTaxonomyOptOut($wfoCode)
+    {
+        $wfo_results = \Drupal::entityTypeManager()
+            ->getStorage("taxonomy_term")
+            ->loadByProperties([
+                "vid" => "weather_forecast_offices",
+                "field_wfo_code" => strtoupper($wfoCode),
+            ]);
+        $wfo_results = array_values($wfo_results); // Indices can be totally random numbers!
+        if (count($wfo_results) == 0) {
+            throw new NotFoundHttpException();
+        }
+        return $wfo_results[0]->get('field_weather_story_opt_out')->getValue()[0]['value'];
+    }
+
     public function getLatestNodeFromWFO($wfo, $nodeType)
     {
         // Get the ID for the WFO taxonomy term that matches our grid WFO.


### PR DESCRIPTION
## What does this PR do? 🛠️
We want to be able to give admins in the CMS the ability to opt certain WFOs out of having weather stories show up. This PR adds a bool field to the weather field office taxonomy, sets the default to true, and allows admins to check a box if they want to opt an office out.

## What does the reviewer need to know? 🤔
Before merging, I'll test in staging where we have some stories and create documentation for our admins. 
