### PR TITLE
rename aria-labeledby to aria-labelledby

### DIFF
--- a/web/themes/new_weather_theme/assets/js/components/combo-box-location.js
+++ b/web/themes/new_weather_theme/assets/js/components/combo-box-location.js
@@ -181,7 +181,7 @@ export default class LocationComboBox extends ComboBox {
     // and possibly a heading list item for current search results as well.
     if (saved.length) {
       const list = document.createElement("ul");
-      list.setAttribute("aria-labeledby", `${this.id}--list`);
+      list.setAttribute("aria-labelledby", `${this.id}--list`);
       list.classList.add("wx-combo-box__list");
 
       list.append(makeSectionHeading("recent locations"));
@@ -192,7 +192,7 @@ export default class LocationComboBox extends ComboBox {
     // Now add search results, if any.
     if (data.suggestions.length) {
       const list = document.createElement("ul");
-      list.setAttribute("aria-labeledby", `${this.id}--list`);
+      list.setAttribute("aria-labelledby", `${this.id}--list`);
       list.classList.add("wx-combo-box__list");
 
       if (saved.length) {

--- a/web/themes/new_weather_theme/assets/js/components/combo-box.js
+++ b/web/themes/new_weather_theme/assets/js/components/combo-box.js
@@ -391,7 +391,7 @@ class ComboBox extends HTMLElement {
    */
   setListItems(items) {
     const list = document.createElement("ul");
-    list.setAttribute("aria-labeledby", `${this.id}--list`);
+    list.setAttribute("aria-labelledby", `${this.id}--list`);
     list.classList.add("wx-combo-box__list");
 
     const listItems = items.map((item, idx) => {


### PR DESCRIPTION
## What does this PR do? 🛠️
<!--- Describe what to expect after this change is implemented -->
This replaces instanced of `aria-labeledby` with `aria-labelledby` which is the prefered spelling and has the most cross-browser compatibility. While some browsers support `aria-labeledby`, more support `aria-labelledby`.

## What does the reviewer need to know? 🤔
<!--- Include any local deployment instructions, navigation instructions, etc -->
I'm making this change because the `aria-labeledby` (with a single `l` in the middle) is the alternate spelling to the correct `aria-labelledby` (with two `l`s in the middle). The two `l`s version is preferred over the single `l` version. Some browsers will only respect the version with two `l`s. 

I discovered this repository by performing a code search for uses of `aria-labeledby` and sending PRs to replace them. (I'm not a bot but someone who is working on fixing this issue). For more on this you could read https://github.com/w3c/aria/issues/2093.

## Screenshots (if appropriate): 📸

<!--- Make sure you add a subject matter expert to the Reviewers list -->
N/A