### PR TITLE
Fix wind chart arrows not displaying on initial load

### DIFF
--- a/web/themes/new_weather_theme/assets/js/charts/hourly-wind.js
+++ b/web/themes/new_weather_theme/assets/js/charts/hourly-wind.js
@@ -9,12 +9,25 @@ const chartContainers = Array.from(
 );
 
 /**
- * Source image for the arrow icon
+ * Dimensions for the wind direction arrow icon.
+ * Each arrow is a 16x16 SVG rendered onto the chart canvas.
  */
 const IMG_WIDTH = 16;
 const IMG_HEIGHT = 16;
 const IMG_HEIGHT_OFFSET = IMG_HEIGHT / 2;
 const IMG_WIDTH_OFFSET = IMG_WIDTH / 2;
+
+/**
+ * Generate a data URI for a wind direction arrow SVG.
+ * The arrow points in the direction the wind is blowing TO,
+ * which is 180 degrees opposite from the meteorological convention
+ * of reporting where wind blows FROM.
+ *
+ * @param {string} label - Unused, kept for API compatibility
+ * @param {number} degrees - Wind direction in degrees (where wind blows FROM)
+ * @param {string} color - Fill color for the arrow, defaults to dark gray
+ * @returns {string} A data URI string containing the SVG markup
+ */
 const createArrowSVG = (label, degrees, color = "#3D4551") => {
   // We rotate the degrees by 180,
   // since the supplied angle represents where
@@ -28,6 +41,58 @@ const createArrowSVG = (label, degrees, color = "#3D4551") => {
     `<path fill-rule="evenodd" clip-rule="evenodd" d="M2.96808 6.46448L4.38229 7.88059L7.625 4.63354L7.625 9.97052H9.625L9.625 4.63372L12.8676 7.88065L14.2818 6.46454L10.0391 2.21618L10.0391 2.21616L8.62493 0.800049L2.96808 6.46448ZM9.625 11.9705H7.625V14.9584H9.625V11.9705Z" fill="${encodedColor}"/>` +
     "</svg>"
   );
+};
+
+/**
+ * Pre-load an arrow Image object and ensure it is fully decoded
+ * before returning. This prevents the race condition where
+ * ctx.drawImage() is called before the browser has finished
+ * parsing the SVG data URI.
+ *
+ * @param {number} degrees - Wind direction in degrees
+ * @param {string} color - Fill color for the arrow
+ * @returns {Promise<Image>} A promise that resolves to a fully decoded Image
+ */
+const preloadArrowImage = (degrees, color) => {
+  // Skip null/undefined degree values — the API can return null
+  // for wind direction when data is unavailable
+  if (degrees == null) {
+    return Promise.resolve(null);
+  }
+  const img = new Image();
+  img.src = createArrowSVG("", degrees, color);
+  // img.decode() returns a promise that resolves once the image
+  // data has been fully parsed and is ready for canvas rendering.
+  // If decoding fails, we return null so the arrow is simply
+  // skipped rather than crashing the entire chart.
+  return img.decode().then(() => img).catch(() => null);
+};
+
+/**
+ * Build a cache of pre-loaded arrow images for all wind directions
+ * used by a given chart container. Each unique degree value gets
+ * its own cached Image object, keyed by the degree number.
+ *
+ * @param {HTMLElement} container - The chart container DOM element
+ *   with wind direction data stored in data attributes
+ * @returns {Promise<Map<number, Image>>} A map from degree values
+ *   to fully decoded Image objects
+ */
+const buildArrowImageCache = async (container) => {
+  const directions = JSON.parse(container.dataset.windDirections);
+
+  // Collect unique degree values so we only create one Image per direction
+  const uniqueDegrees = [...new Set(directions.map((d) => d.degrees))];
+
+  // Load all unique arrow images in parallel for efficiency
+  const entries = await Promise.all(
+    uniqueDegrees.map(async (degrees) => {
+      const img = await preloadArrowImage(degrees, styles.colors.secondaryDarker);
+      return [degrees, img];
+    }),
+  );
+
+  return new Map(entries);
 };
 
 /**
@@ -54,36 +119,45 @@ const getCombinedWindInfo = (element) => {
 };
 
 /**
- * Draw the wind direction arrows and cardinal direction
- * text for the given chart on the x-axis.
- * Designed to be used in an `afterDraw` plugin function,
- * which occurs after the rest of the chart has already
- * been rendered
+ * Create the afterDraw plugin function with access to
+ * the pre-loaded arrow image cache. This closure pattern
+ * ensures the cached images are available when Chart.js
+ * calls the plugin hook.
+ *
+ * @param {Map<number, Image>} arrowCache - Map of degree values
+ *   to pre-decoded Image objects
+ * @returns {Function} A Chart.js afterDraw plugin function
  */
-const drawWindInfoLabels = (chart) => {
+const createDrawWindInfoLabels = (arrowCache) => (chart) => {
   const ctx = chart.ctx;
   const xAxis = chart.scales.x;
   const yAxis = chart.scales.y;
   const container = chart.canvas.closest(".wx-hourly-wind-chart-container");
   const windInfo = getCombinedWindInfo(container);
+
   xAxis.ticks.forEach((val, idx) => {
     const x = xAxis.getPixelForTick(idx);
     const dataIndex = val.value;
+    const degrees = windInfo[dataIndex].direction.degrees;
 
-    // Draw the arrow with rotation
+    // Look up the pre-loaded image from the cache instead of
+    // creating a new Image() each time, which avoids the race
+    // condition where drawImage runs before the SVG is decoded.
+    // The image may be null if the degree value was null (missing
+    // API data) or if decoding failed — skip drawing in that case.
+    const img = arrowCache.get(degrees);
+    if (!img) {
+      return;
+    }
+
+    // Draw the arrow with rotation (rotation is baked into the SVG)
     const drawX = x;
     const drawY = yAxis.bottom + 40;
-    const img = new Image();
-    img.src = createArrowSVG(
-      "",
-      windInfo[dataIndex].direction.degrees,
-      styles.colors.secondaryDarker,
-    );
     ctx.save();
     ctx.drawImage(img, drawX - IMG_WIDTH_OFFSET, drawY - IMG_HEIGHT_OFFSET);
     ctx.restore();
 
-    // Draw the cardinal direction text
+    // Draw the cardinal direction text below the arrow
     const text = windInfo[dataIndex].direction.cardinalShort;
     ctx.save();
     const textMeasure = ctx.measureText(text);
@@ -97,111 +171,128 @@ const drawWindInfoLabels = (chart) => {
   });
 };
 
+/**
+ * Initialize each wind chart container. We pre-load all arrow
+ * images first, then create the chart with the cached images
+ * available to the afterDraw plugin. This ensures arrows render
+ * correctly on the very first draw, not just after user interaction.
+ */
 for (const container of chartContainers) {
   const times = JSON.parse(container.dataset.times);
   const speeds = JSON.parse(container.dataset.windSpeeds);
   const gusts = JSON.parse(container.dataset.windGusts);
 
-  const config = {
-    type: "line",
-    plugins: [
-      {
-        afterDraw: drawWindInfoLabels,
-      },
-    ],
-
-    options: {
-      animation: false,
-      responsive: true,
-      maintainAspectRatio: false,
-      interaction: {
-        intersect: false,
-        mode: "index",
-      },
-      plugins: {
-        legend: {
-          display: false,
-        },
-        tooltip: {
-          events: ['click', 'mousemove', 'mouseout'],
-        },
-      },
-      layout: {
-        padding: {
-          top: 24,
-          bottom: 50,
-        },
-      },
-      scales: {
-        x: {
-          ticks: {
-            autoSkip: true,
-            maxRotation: 0,
-            color: styles.colors.base,
-          },
-          grid: {
-            color: times.map((v) => {
-              if (v === "12 AM") {
-                return "black";
-              }
-
-              const even = Number.parseInt(v, 10) % 2 === 0;
-              if (even) {
-                return styles.colors.baseLighter;
-              }
-              return styles.colors.baseLightest;
-            }),
-          },
-        },
-        y: {
-          min: 0,
-          max: Math.max(
-            Math.round(Math.max(...speeds) / 10) * 10 + 10,
-            Math.round(Math.max(...gusts) / 10) * 10 + 10,
-          ),
-          ticks: {
-            autoSkip: true,
-            color: styles.colors.base,
-            maxTicksLimit: 6,
-            callback: (v) => `${v} mph`,
-          },
-        },
-      },
-    },
-
-    data: {
-      labels: times,
-      datasets: [
+  // Pre-load all arrow images before creating the chart so they
+  // are fully decoded and ready for canvas rendering on first draw.
+  // If pre-loading fails entirely, fall back to an empty cache so
+  // the chart still renders (arrows will just be missing, matching
+  // the previous behavior before this fix).
+  buildArrowImageCache(container)
+  .catch(() => new Map())
+  .then((arrowCache) => {
+    const config = {
+      type: "line",
+      plugins: [
         {
-          label: "Speed",
-          data: speeds,
-          datalabels: {
-            align: ({ dataIndex }) =>
-              speeds[dataIndex] >= gusts[dataIndex] ? "top" : "bottom",
-            color: styles.colors.primaryDark,
-          },
-          backgroundColor: styles.colors.secondaryDarker,
-          borderColor: styles.colors.secondaryDarker,
-          borderWidth: 1.5,
-        },
-        {
-          label: "Gusts",
-          data: gusts,
-          datalabels: {
-            align: ({ dataIndex }) =>
-              speeds[dataIndex] >= gusts[dataIndex] ? "bottom" : "top",
-            color: styles.colors.primary,
-            display: ({ dataIndex }) => speeds[dataIndex] !== gusts[dataIndex],
-          },
-          borderDash: [4],
-          backgroundColor: styles.colors.secondary,
-          borderColor: styles.colors.secondary,
-          borderWidth: 1.5,
+          // Use the factory function to inject the pre-loaded
+          // image cache into the afterDraw plugin
+          afterDraw: createDrawWindInfoLabels(arrowCache),
         },
       ],
-    },
-  };
 
-  drawChart(container, config);
-  setupScrollButtons(container);
+      options: {
+        animation: false,
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: {
+          intersect: false,
+          mode: "index",
+        },
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            events: ['click', 'mousemove', 'mouseout'],
+          },
+        },
+        layout: {
+          padding: {
+            top: 24,
+            bottom: 50,
+          },
+        },
+        scales: {
+          x: {
+            ticks: {
+              autoSkip: true,
+              maxRotation: 0,
+              color: styles.colors.base,
+            },
+            grid: {
+              color: times.map((v) => {
+                if (v === "12 AM") {
+                  return "black";
+                }
+
+                const even = Number.parseInt(v, 10) % 2 === 0;
+                if (even) {
+                  return styles.colors.baseLighter;
+                }
+                return styles.colors.baseLightest;
+              }),
+            },
+          },
+          y: {
+            min: 0,
+            max: Math.max(
+              Math.round(Math.max(...speeds) / 10) * 10 + 10,
+              Math.round(Math.max(...gusts) / 10) * 10 + 10,
+            ),
+            ticks: {
+              autoSkip: true,
+              color: styles.colors.base,
+              maxTicksLimit: 6,
+              callback: (v) => `${v} mph`,
+            },
+          },
+        },
+      },
+
+      data: {
+        labels: times,
+        datasets: [
+          {
+            label: "Speed",
+            data: speeds,
+            datalabels: {
+              align: ({ dataIndex }) =>
+                speeds[dataIndex] >= gusts[dataIndex] ? "top" : "bottom",
+              color: styles.colors.primaryDark,
+            },
+            backgroundColor: styles.colors.secondaryDarker,
+            borderColor: styles.colors.secondaryDarker,
+            borderWidth: 1.5,
+          },
+          {
+            label: "Gusts",
+            data: gusts,
+            datalabels: {
+              align: ({ dataIndex }) =>
+                speeds[dataIndex] >= gusts[dataIndex] ? "bottom" : "top",
+              color: styles.colors.primary,
+              display: ({ dataIndex }) => speeds[dataIndex] !== gusts[dataIndex],
+            },
+            borderDash: [4],
+            backgroundColor: styles.colors.secondary,
+            borderColor: styles.colors.secondary,
+            borderWidth: 1.5,
+          },
+        ],
+      },
+    };
+
+    drawChart(container, config);
+    setupScrollButtons(container);
+  });
 }


### PR DESCRIPTION
## Summary
- Fixes a race condition where wind direction arrows on the hourly wind chart only appeared after mouseover, not on initial page load
- Root cause: `ctx.drawImage()` was called on `Image` objects whose SVG data URIs hadn't been decoded yet
- Pre-loads and caches all arrow images via `img.decode()` before creating the chart, so they are ready when the Chart.js `afterDraw` hook first fires
- Includes error handling for null wind directions from the API, failed image decoding, and a graceful fallback if preloading fails entirely

Closes #2086

## Test plan
- [ ] Navigate to a location's hourly forecast and verify wind direction arrows appear immediately on the chart without needing to hover
- [ ] Test in Chrome, Firefox, and Safari
- [ ] Verify arrows still update correctly when scrolling through the chart
- [ ] Verify tooltip interaction still works on the wind chart
- [ ] Test with a location that has calm/variable winds (null wind direction) to confirm graceful handling