### PR TITLE
Add missing day/vv and night/vv icon mapping

### DIFF
--- a/api-interop-layer/util/icon.legacyMapping.json
+++ b/api-interop-layer/util/icon.legacyMapping.json
@@ -176,6 +176,12 @@
   "night/tsra_sct": {
     "icon": "thunderstorm.svg"
   },
+  "day/vv": {
+    "icon": "cloudy_overcast.svg"
+  },
+  "night/vv": {
+    "icon": "cloudy_overcast.svg"
+  },
   "day/wind_bkn": {
     "icon": "new_windy_cloudy.svg"
   },

--- a/tests/api/data/testing/gridpoints/LWX/95,71/forecast.json
+++ b/tests/api/data/testing/gridpoints/LWX/95,71/forecast.json
@@ -48,7 +48,7 @@
         "relativeHumidity": { "unitCode": "wmoUnit:percent", "value": 35 },
         "windSpeed": "13 mph",
         "windDirection": "W",
-        "icon": "https://api.weather.gov/icons/land/day/vv?size=medium",
+        "icon": "https://api.weather.gov/icons/land/day/zzz_test_unmapped?size=medium",
         "shortForecast": "Haze",
         "detailedForecast": "Partly sunny, with a high near 53. West wind around 13 mph, with gusts as high as 21 mph."
       },

--- a/tests/api/data/testing/stations/KDCA/observations__limit=1.json
+++ b/tests/api/data/testing/stations/KDCA/observations__limit=1.json
@@ -35,7 +35,7 @@
         "timestamp": "date:now -2948 seconds",
         "rawMessage": "KDCA 191552Z 28008G19KT 250V320 10SM FEW055 BKN250 07/M07 A2993 RMK AO2 SLP136 T00721072 $",
         "textDescription": "Mostly Cloudy",
-        "icon": "https://api.weather.gov/icons/land/day/vv?size=medium",
+        "icon": "https://api.weather.gov/icons/land/day/zzz_test_unmapped?size=medium",
         "presentWeather": [],
         "temperature": {
           "unitCode": "wmoUnit:degC",


### PR DESCRIPTION
## Summary
- Adds icon mappings for the `day/vv` and `night/vv` API icon codes, which were previously unmapped and caused missing icons
- Maps both to `cloudy_overcast.svg`, matching the behavior of `ovc` (overcast) which the API reportedly now uses in place of `vv`
- The `vv` code represents vertical visibility / obscured sky conditions in meteorological notation
- Updates Playwright test data to use a synthetic unmapped icon code (`zzz_test_unmapped`) so the invalid-icon e2e tests continue to pass

Closes #1582

## Test plan
- [ ] Run the icon mapping unit test (`icon.legacyMapping.test.js`) to verify both new entries reference an existing SVG file
- [ ] Run the Playwright `invalid-icons.spec.js` e2e tests to confirm all 5 test cases still pass
- [ ] Verify that a forecast with `day/vv` or `night/vv` icon URLs now displays the overcast icon instead of a blank space