### PR TITLE
Make forecast details toggle WCAG-compliant with roving tabindex

### DIFF
--- a/web/themes/new_weather_theme/assets/js/components/Tabs.js
+++ b/web/themes/new_weather_theme/assets/js/components/Tabs.js
@@ -1,28 +1,44 @@
 /**
  * Generic WCAG Tabs component
  * ------------------------------------------
- * This is a progressively enhanced component.
- * tab, tablist, and tabpanel elements are expected
- * to have the correct `role` attributes and other
- * aria references.
- * See
+ * A progressively enhanced custom element that expects
+ * tab, tablist, and tabpanel elements to already carry
+ * the correct `role` attributes and aria references in
+ * the server-rendered markup.
+ *
+ * What this adds on top of the static HTML:
+ * - Arrow key navigation with wraparound between tabs
+ * - Home/End support to jump to first or last tab
+ * - Space/Enter activation for the focused tab
+ * - Proper tabindex roving so only the active tab
+ *   sits in the keyboard Tab sequence
+ * - Tabpanel focus management for seamless keyboard flow
+ *
+ * Reference:
  * https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
  */
 class Tabs extends HTMLElement {
   constructor(){
     super();
 
-    // Bound methods
+    // Lock down `this` for methods used as event callbacks
     this.handleTabClick = this.handleTabClick.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   connectedCallback(){
+    // Wire up click handling on every tab
     Array.from(this.querySelectorAll('[role="tab"]'))
       .forEach(tabElement => {
         tabElement.addEventListener("click", this.handleTabClick);
       });
     this.addEventListener("keydown", this.handleKeyDown);
+
+    // Set up the roving tabindex right away. The WCAG tabs
+    // pattern dictates that only the currently selected tab
+    // should live in the natural Tab order — everything else
+    // becomes reachable solely through arrow keys.
+    this.initializeTabindexState();
   }
 
   disconnectedCallback(){
@@ -34,18 +50,71 @@ class Tabs extends HTMLElement {
   }
 
   /**
-   * The click handler should update the tab's
-   * aria-selected attribute, and also update the
-   * data-tabpanel-selected attribute on its corresponding
-   * tabpanel.
-   * Any hiding/showing of tabpanel content should be
-   * handled by implementor's CSS
+   * Walks through every tab and panel to establish the
+   * starting tabindex layout. The selected tab receives
+   * tabindex="0" (reachable via Tab key), while the rest
+   * get tabindex="-1" (arrow-key only).
+   *
+   * Panels follow the same logic — the visible one becomes
+   * focusable so users can Tab straight from the active tab
+   * into its content.
+   */
+  initializeTabindexState(){
+    this.tabs.forEach(tabElement => {
+      const isSelected = tabElement.getAttribute("aria-selected") === "true";
+      tabElement.setAttribute("tabindex", isSelected ? "0" : "-1");
+    });
+
+    // Panels need the same treatment: the one on display
+    // should accept focus, the hidden ones should not
+    this.tabpanels.forEach(panelElement => {
+      if(panelElement){
+        const isActive = panelElement.getAttribute("data-tabpanel-selected") === "true";
+        panelElement.setAttribute("tabindex", isActive ? "0" : "-1");
+      }
+    });
+  }
+
+  /**
+   * Synchronizes the roving tabindex whenever a new tab is
+   * chosen. Pulls every tab out of the Tab order first, then
+   * puts just the newly selected one back in. Panels get the
+   * same shuffle.
+   */
+  updateTabindexState(selectedTab, selectedPanel){
+    // Yank all tabs out of the natural Tab sequence
+    this.tabs.forEach(tabElement => {
+      tabElement.setAttribute("tabindex", "-1");
+    });
+    // ...and restore just the one that was clicked/activated
+    selectedTab.setAttribute("tabindex", "0");
+
+    // Same idea for panels — hide the old, reveal the new
+    this.tabpanels.forEach(panelElement => {
+      if(panelElement){
+        panelElement.setAttribute("tabindex", "-1");
+      }
+    });
+    if(selectedPanel){
+      selectedPanel.setAttribute("tabindex", "0");
+    }
+  }
+
+  /**
+   * Handles a click (or programmatic .click()) on a tab.
+   * Flips aria-selected across all tabs, toggles the
+   * data-tabpanel-selected attribute on the panels, and
+   * refreshes the roving tabindex to match the new state.
+   *
+   * Actual show/hide of panel content is left to the
+   * implementor's CSS — this component only manages state.
    */
   handleTabClick(event){
     const tab = event.target.closest('[role="tab"]');
     const panelId = tab.getAttribute("aria-controls");
     const panel = document.getElementById(panelId);
     if(panel){
+      // Clear selection across every tab and panel
       this.tabs.forEach(tabElement => {
         tabElement.setAttribute("aria-selected", false);
       });
@@ -55,12 +124,17 @@ class Tabs extends HTMLElement {
       });
       panel.setAttribute("data-tabpanel-selected", true);
       this.setAttribute("data-selected", panelId);
+
+      // Keep the roving tabindex in sync with the visual state
+      this.updateTabindexState(tab, panel);
     }
   }
 
   /**
-   * Binds key handling events as specified in
-   * the WCAG recommendations
+   * Keyboard handler following the WCAG manual activation
+   * pattern. Arrow keys shift focus between tabs (wrapping
+   * at the edges), Home/End jump to the extremes, and
+   * Space or Enter fires the tab's click to activate it.
    */
   handleKeyDown(event){
     const currentFocus = this.querySelector('[role="tab"]:focus,[role="tab"]:focus-within');
@@ -68,6 +142,7 @@ class Tabs extends HTMLElement {
     const lastItemInFocus = currentFocus.matches('[role="tab"]:last-child:focus, [role="tab"]:last-child:focus-within');
     let handled = false;
     if(event.key === "ArrowLeft"){
+      // Wrap around to the end if we're already on the first tab
       if(firstItemInFocus){
         this.focusTab(this.querySelector('[role="tab"]:last-child'));
       } else {
@@ -75,6 +150,7 @@ class Tabs extends HTMLElement {
       }
       handled = true;
     } else if(event.key === "ArrowRight"){
+      // Wrap around to the start when past the last tab
       if(lastItemInFocus){
         this.focusTab(this.querySelector('[role="tab"]:first-child'));
       } else {
@@ -82,6 +158,7 @@ class Tabs extends HTMLElement {
       }
       handled = true;
     } else if(event.key === "Space" || event.key === "Enter"){
+      // Trigger the tab just like a mouse click would
       currentFocus.click();
       handled = true;
     } else if(event.key === "Home") {
@@ -98,12 +175,13 @@ class Tabs extends HTMLElement {
     }
   }
 
+  /**
+   * Tries to move keyboard focus to the given element.
+   * Not every element with role="tab" is inherently
+   * focusable (it might be a <div>), so we also check
+   * for a focusable child like a button or anchor.
+   */
   focusTab(anElement){
-    // It is not required that the element with the role tab
-    // be a focusable element. In such cases, we need to
-    // check its children for elements that can receive focus.
-    // We do this in the simplest possible way, limiting ourselves
-    // to a, button, or any element with a tabindex
     const matchString = "a, button, [tabindex]";
     if(anElement.matches(matchString)){
       anElement.focus();
@@ -115,10 +193,12 @@ class Tabs extends HTMLElement {
     }
   }
 
+  // Convenience getter — collects all tab elements inside this component
   get tabs(){
     return Array.from(this.querySelectorAll('[role="tab"]'));
   }
 
+  // Resolves each tab's aria-controls to its corresponding panel element
   get tabpanels(){
     return this.tabs.map(tabElement => {
       const panelId = tabElement.getAttribute("aria-controls");

--- a/web/themes/new_weather_theme/tests/components/generic-tabs-tests.js
+++ b/web/themes/new_weather_theme/tests/components/generic-tabs-tests.js
@@ -1,6 +1,9 @@
 /* eslint no-unused-expressions: off */
 import { expect } from "chai";
 
+// Test fixture matching the structure used in production.
+// Each panel carries data-tabpanel-selected so the component
+// can manage tabindex on initialization.
 const EXAMPLE = `
 <wx-tabs role="tablist">
     <button role="tab" aria-selected="true" aria-controls="tab1" id="button1">
@@ -13,13 +16,13 @@ const EXAMPLE = `
         Tab 3
     </button>
 </wx-tabs>
-<div id="tab1" ""role="tabpanel" aria-labelledby="button1">
+<div id="tab1" role="tabpanel" data-tabpanel-selected="true" aria-labelledby="button1">
     Tab 1 content
 </div>
-<div id="tab2" role="tabpanel" aria-labelledby="button2">
+<div id="tab2" role="tabpanel" data-tabpanel-selected="false" aria-labelledby="button2">
     Tab 2 content
 </div>
-<div id="tab3" role="tabpanel" aria-labelledby="button3">
+<div id="tab3" role="tabpanel" data-tabpanel-selected="false" aria-labelledby="button3">
     Tab 3 content
 </div>
 `;
@@ -94,17 +97,17 @@ describe("Tab web component basic tests", () => {
 
     // First instance, highlights second element
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:nth-child(2)'));
+    expect(document.activeElement.matches('[role="tab"]:nth-child(2)')).to.be.true;
 
     // Second instance, focuses last element
     evt = new window.KeyboardEvent("keydown", {key: "ArrowRight"});
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:last-child'));
+    expect(document.activeElement.matches('[role="tab"]:last-child')).to.be.true;
 
     // Third time should loop around to the beginning of the tabs
     evt = new window.KeyboardEvent("keydown", {key: "ArrowRight"});
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:first-child'));
+    expect(document.activeElement.matches('[role="tab"]:first-child')).to.be.true;
   });
 
   it("left arrow navigation works", () => {
@@ -113,43 +116,43 @@ describe("Tab web component basic tests", () => {
 
     // First instance, loops around to focus on the last tab
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:last-child'));
+    expect(document.activeElement.matches('[role="tab"]:last-child')).to.be.true;
 
     // Second instance, loops around to the second tab
     evt = new window.KeyboardEvent("keydown", {key: "ArrowLeft"});
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:nth-child(2)'));
+    expect(document.activeElement.matches('[role="tab"]:nth-child(2)')).to.be.true;
 
     // Third time, comes back to focus on first element
     evt = new window.KeyboardEvent("keydown", {key: "ArrowLeft"});
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:first-child'));
+    expect(document.activeElement.matches('[role="tab"]:first-child')).to.be.true;
   });
 
   it("Home key focuses on the first tab", () => {
     const tablist = document.querySelector("wx-tabs");
     const evt = new window.KeyboardEvent("keydown", {key: "Home"});
 
-    // Start by focusing the second tab
-    tablist.tabs[0].focus();
-    expect(document.activeElement.matches('[role="tab"]:nth-child(2)'));
+    // Start by focusing the second tab so Home has somewhere to go
+    tablist.tabs[1].focus();
+    expect(document.activeElement.matches('[role="tab"]:nth-child(2)')).to.be.true;
 
     // Now push the Home key to focus first item
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:first-child'));
+    expect(document.activeElement.matches('[role="tab"]:first-child')).to.be.true;
   });
 
-  it("End key focuses on the first tab", () => {
+  it("End key focuses on the last tab", () => {
     const tablist = document.querySelector("wx-tabs");
     const evt = new window.KeyboardEvent("keydown", {key: "End"});
 
-    // Start by focusing the second tab
-    tablist.tabs[0].focus();
-    expect(document.activeElement.matches('[role="tab"]:nth-child(2)'));
+    // Start by focusing the second tab so End has somewhere to go
+    tablist.tabs[1].focus();
+    expect(document.activeElement.matches('[role="tab"]:nth-child(2)')).to.be.true;
 
     // Now push the End key to focus last item
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:last-child'));
+    expect(document.activeElement.matches('[role="tab"]:last-child')).to.be.true;
   });
 
   it("Selecting a tab updates the corresponding tabpanel data selection attribute", () => {
@@ -168,5 +171,45 @@ describe("Tab web component basic tests", () => {
     const actual = tablist.getAttribute("data-selected");
 
     expect(actual).to.eql(expected);
-  })
+  });
+
+  // --- Tabindex management (WCAG roving tabindex) ---
+
+  it("on init, the selected tab has tabindex 0 and others have tabindex -1", () => {
+    const tablist = document.querySelector("wx-tabs");
+    const tabindexValues = tablist.tabs.map(t => t.getAttribute("tabindex"));
+
+    // Only the first tab (aria-selected="true") should be in the Tab order
+    expect(tabindexValues).to.eql(["0", "-1", "-1"]);
+  });
+
+  it("on init, the active tabpanel has tabindex 0 and others have tabindex -1", () => {
+    const tablist = document.querySelector("wx-tabs");
+    const panelTabindexValues = tablist.tabpanels.map(p => p.getAttribute("tabindex"));
+
+    // The first panel (data-tabpanel-selected="true") should be focusable
+    expect(panelTabindexValues).to.eql(["0", "-1", "-1"]);
+  });
+
+  it("clicking a different tab moves tabindex 0 to that tab", () => {
+    const tablist = document.querySelector("wx-tabs");
+
+    // Switch to the third tab
+    tablist.tabs[2].click();
+    const tabindexValues = tablist.tabs.map(t => t.getAttribute("tabindex"));
+
+    // Now only the third tab should carry tabindex="0"
+    expect(tabindexValues).to.eql(["-1", "-1", "0"]);
+  });
+
+  it("clicking a different tab moves tabindex 0 to the corresponding panel", () => {
+    const tablist = document.querySelector("wx-tabs");
+
+    // Switch to the second tab
+    tablist.tabs[1].click();
+    const panelTabindexValues = tablist.tabpanels.map(p => p.getAttribute("tabindex"));
+
+    // Second panel should now be the focusable one
+    expect(panelTabindexValues).to.eql(["-1", "0", "-1"]);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds WCAG roving tabindex pattern to the `wx-tabs` component so only the active tab is in the Tab order (`tabindex="0"`), while inactive tabs get `tabindex="-1"`
- Updates tabindex on both tabs and panels when selection changes
- Fixes pre-existing test bugs: 10 no-op Chai assertions (missing `.to.be.true`), Home/End tests focusing wrong tab, End test description

## Test plan
- [ ] Verify keyboard nav: Tab lands only on the active tab, arrow keys move between tabs, Tab from active tab moves into the panel
- [ ] Run component tests: `cd web/themes/new_weather_theme && npx mocha --require ./tests/components/preload.js tests/components/generic-tabs-tests.js`
- [ ] All 16 tests pass

Closes #1944