### PR TITLE
Refactor alert geometry loop for cleaner chunking

### DIFF
--- a/api-interop-layer/data/alerts/geometry.js
+++ b/api-interop-layer/data/alerts/geometry.js
@@ -115,42 +115,71 @@ const getUnion = (firstShape, secondShape=null) => {
 };
 
 /**
- * Here a 'zone' can refer to either a forecast zone or
- * a county fips id. Either one will produce a geometry set
- * that is stored in the database.
+ * Splits an array into groups of at most `size` elements.
+ * Avoids the manual index juggling of the old while-loop
+ * approach, and the output is easy to iterate over.
+ */
+const chunkArray = (array, size) => {
+  // Guard against non-positive chunk sizes which would
+  // cause an infinite loop in the for-loop below
+  if (size <= 0) {
+    return [array];
+  }
+  const chunks = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
+};
+
+/**
+ * Fetches and merges zone/county geometries in bounded
+ * batches to keep memory usage under control.
+ *
+ * The algorithm (per the issue description):
+ * 1. Slice the zone list into chunks of ZONE_CHUNK_SIZE
+ * 2. For each chunk, fetch its geometries from the DB and
+ *    compute the within-chunk union
+ * 3. Collect those per-chunk results into a list
+ * 4. Merge the list into one final geometry
+ *
+ * This avoids holding all raw DB data in memory at once —
+ * each chunk's raw points can be GC'd after its union is
+ * computed, and the final merge operates on the smaller
+ * already-unioned shapes.
  */
 const fetchAndComputeZoneGeometries = async (db, zones, zoneType="forecast") => {
   if(!["forecast", "county"].includes(zoneType)){
     throw new Error(`Invalid geometry zone type: ${zoneType}`);
   }
-  
-  let geometry = null;
-  
-  let chunkCount = 0;
-  let start = chunkCount * ZONE_CHUNK_SIZE;
-  let end = start + ZONE_CHUNK_SIZE;
-  let chunk = zones.slice(start, end);
-  while(chunk && chunk.length){
-    // Update the computed geometry
+
+  const chunks = chunkArray(zones, ZONE_CHUNK_SIZE);
+
+  // Phase 1: fetch each chunk from the DB and compute its
+  // local union. Results stay small relative to the raw data.
+  const chunkResults = [];
+  for (const chunk of chunks) {
+    // Sequential fetches keep DB load predictable under stress.
     // eslint-disable-next-line no-await-in-loop
     const data = await getZoneShapeFromDb(db, chunk, zoneType);
-
-    if(data && geometry){
-      geometry = getUnion(
-        geometry,
-        data
-      );
-    } else if (data) {
-      geometry = getUnion(data);
-    } 
-
-    chunkCount += 1;
-    start = chunkCount * ZONE_CHUNK_SIZE;
-    end = start + ZONE_CHUNK_SIZE;
-    chunk = zones.slice(start, end);
+    if (data) {
+      chunkResults.push(getUnion(data));
+    }
   }
 
-  return geometry;
+  // Nothing came back from the DB
+  if (chunkResults.length === 0) {
+    return null;
+  }
+
+  // Only one chunk — already unioned, just return it
+  if (chunkResults.length === 1) {
+    return chunkResults[0];
+  }
+
+  // Phase 2: merge all chunk results into a single geometry.
+  // A reduce gives us a clean fold without mutating state.
+  return chunkResults.reduce((merged, next) => getUnion(merged, next));
 };
 
 export const generateAlertGeometry = async (db, rawAlert) => {

--- a/api-interop-layer/data/alerts/geometry.test.js
+++ b/api-interop-layer/data/alerts/geometry.test.js
@@ -241,9 +241,9 @@ describe("alert geometries", () => {
   });
 
   describe("Zone chunking tests", () => {
-    // Begin with  a total zone size that is just a little above the
-    // zone chunk size, so we have 3.x chunks
-    const numChunks = (ZONE_CHUNK_SIZE * 3) + (ZONE_CHUNK_SIZE - 1);
+    // Set total zone count a bit above 3x the chunk size, so we
+    // end up with 3 full chunks and 1 partial (4 DB calls total)
+    const totalZones = (ZONE_CHUNK_SIZE * 3) + (ZONE_CHUNK_SIZE - 1);
     const shape = {
       type: "GeometryCollection",
       geometries: [
@@ -261,7 +261,8 @@ describe("alert geometries", () => {
         },
       ],
     };
-    const zones = Array(numChunks).map((_, idx) => `zone ${idx + 1}`);
+    // Array.from avoids the sparse-array pitfall of Array(n).map()
+    const zones = Array.from({length: totalZones}, (_, idx) => `zone ${idx + 1}`);
     const alert = {
       geometry: false,
       properties: {


### PR DESCRIPTION
## Summary
- Replaces the manual `while` loop in `fetchAndComputeZoneGeometries()` with a clean two-phase approach: chunk the zone list with a `chunkArray` helper, compute per-chunk unions, then merge results via reduce
- Each chunk's raw DB data can be GC'd after its local union, reducing peak memory for large alerts
- Adds guard clause to `chunkArray` for non-positive sizes
- Fixes pre-existing test bug: `Array(n).map()` sparse array pitfall replaced with `Array.from()`
- Renames misleading `numChunks` test variable to `totalZones`

## Test plan
- [ ] Run: `cd api-interop-layer && LOG_LEVEL=silent npx mocha data/alerts/geometry.test.js --require mocha.js`
- [ ] All 8 tests pass
- [ ] Re-run stress test from #2138 to compare performance before/after

Closes #2139