### PR TITLE
Consolidate tab keyboard navigation into shared utility

### DIFF
--- a/web/themes/new_weather_theme/assets/js/components/DailyForecast.js
+++ b/web/themes/new_weather_theme/assets/js/components/DailyForecast.js
@@ -1,56 +1,64 @@
 /**
  * Daily Forecast Component
  * -------------------------
- * This component wraps the main elements of the
- * Daily Forecast tabpanel, specifically:
- * - the quick forecast nav / tab component
- * - the list containing daily forecasts
- * Its purpose is to manage setting the daily forecast into
- * "quick forecast tab mode" (on desktop) vs "quick toggle"
- * mode.
- * For a11y purposes, we need to add and remove aria attributes
- * and roles dynamically when breaking to and from desktop width.
- * This component also overrides click behavior on the quick
- * forecast nav links, forcing them to operate as tabs that
- * hide/show relevant forecast day list items.
+ * Wraps the daily forecast panel and the quick-forecast nav
+ * strip. At desktop widths the nav items become WCAG tabs that
+ * show/hide individual day panels; below desktop the component
+ * reverts to the default accordion-style layout managed by CSS.
+ *
+ * Keyboard navigation for the tab-mode view is handled by the
+ * shared tab-keyboard-nav utility, keeping the arrow-key /
+ * Home / End / Space logic in one place across all tab-like
+ * components on the site.
  */
+import { attachTabKeyboardNav } from "./tab-keyboard-nav.js";
+
 class DailyForecast extends HTMLElement {
   constructor(){
     super();
 
-    // Bound methods
+    // Bound callbacks for click and media-change events
     this.tabClickHandler = this.tabClickHandler.bind(this);
     this.setupMediaEvents = this.setupMediaEvents.bind(this);
     this.setupTabMode = this.setupTabMode.bind(this);
     this.undoTabMode = this.undoTabMode.bind(this);
     this.handleDesktopMediaChange = this.handleDesktopMediaChange.bind(this);
-    this.handleKeys = this.handleKeys.bind(this);
   }
 
   connectedCallback(){
     this.setupMediaEvents();
 
-    this.addEventListener("keydown", this.handleKeys);
+    // Attach keyboard navigation for the quick-forecast items.
+    // Space should activate the focused item (matching the
+    // original behavior that used event.code). Returns a
+    // teardown function for cleanup on disconnect.
+    this._cleanupKeyNav = attachTabKeyboardNav(
+      this,
+      ".wx-quick-forecast-item",
+      { activateOnSpace: true },
+    );
   }
 
   disconnectedCallback(){
+    // Clean up click handlers on the quick-forecast nav items
     Array.from(
       this.querySelectorAll(".wx-quick-forecast-item")
     ).forEach(item => {
       item.removeEventListener("click", this.tabClickHandler);
     });
 
-    this.removeEventListener("keydown", this.handleKeys);
+    // Tear down keyboard navigation
+    if(this._cleanupKeyNav){
+      this._cleanupKeyNav();
+    }
   }
 
   /**
-   * In order to respond to the change in desktop
-   * breakpoint / media query, we need to pull out
-   * preset CSS Custom Property values and then
-   * set up matchMedia listeners.
-   * This method does so, and also calls the handler
-   * immediately, so as to setup the component for
-   * the given media (desktop or everything else)
+   * Reads the desktop breakpoint from a CSS custom property
+   * and sets up a matchMedia listener so we can toggle between
+   * tab mode (desktop) and accordion mode (narrower viewports).
+   * Fires the handler once immediately to pick up the current
+   * screen size.
    */
   setupMediaEvents(){
     const computedStyle = getComputedStyle(this);
@@ -61,16 +69,14 @@ class DailyForecast extends HTMLElement {
   }
 
   /**
-   * "tab mode" corresponds to the desktop width
-   * view, where the quick forecast nav component
-   * is displayed and acts as a tablist, also transforming
-   * each daily forecast list item into a corresponding
-   * tabpanel.
-   * This is primarily accomplished by setting role and
-   * aria attributes as needed on the appropriate elements.
+   * Activates tab mode for the desktop layout. Assigns ARIA
+   * roles and references so the quick-forecast strip operates
+   * as a proper tablist, with each day's forecast acting as
+   * the corresponding tabpanel.
    */
   setupTabMode(){
-    // Set up the tabpanel role for the forecast items
+    // Tag each forecast day wrapper with the tabpanel role
+    // and collect their ids for aria-controls references
     const panelRefs = [];
     this.forecastList = this.querySelector(".wx-forecast-list");
     Array.from(this.forecastList.querySelectorAll(".wx-daily-forecast-list-item-inner"))
@@ -78,9 +84,9 @@ class DailyForecast extends HTMLElement {
         item.setAttribute("role", "tabpanel");
         panelRefs.push(item.id);
       });
-    
-    // Set up the tablist and tab roles for the
-    // quick forecast and its nav items
+
+    // Promote the quick-forecast strip to a tablist and
+    // mark each nav item as a tab with the right controls ref
     this.quickForecastEl = this.querySelector(".wx-quick-forecast");
     this.quickForecastEl.setAttribute("role", "tablist");
     Array.from(
@@ -92,29 +98,25 @@ class DailyForecast extends HTMLElement {
       correspondingPanel.setAttribute("aria-labelledby", item.id);
     });
 
-    // Bind even handlers for click on tabs
+    // Bind click handlers so tapping a nav item reveals its panel
     Array.from(
       this.querySelectorAll(".wx-quick-forecast-item")
     ).forEach(item => {
       item.addEventListener("click", this.tabClickHandler);
     });
 
-    // Click the first item in the list to select it
+    // Select the first day by default
     this.querySelector(".wx-quick-forecast-item:first-child").click();
   }
 
   /**
-   * "non-tab mode" corresponds to anything below desktop
-   * width, where the quick forecast is hidden.
-   * The daily forecast items will be displayed as accordion toggled
-   * content, all of which is handled by CSS.
-   * We need to remove the role and aria attributes added by
-   * tab mode, in order to keep a11y properties correct
-   * (for example, daily list items shouldn't have tabpanel roles anymore).
-   * This method cleans up those attributes as needed.
+   * Tears down tab mode when the viewport drops below the
+   * desktop breakpoint. Removes all the ARIA roles and
+   * references that only make sense in tab context, so the
+   * accordion fallback is semantically clean.
    */
   undoTabMode(){
-    // Remove all tabpanel roles/aria
+    // Strip tabpanel roles and labelledby from forecast items
     Array.from(
       this.querySelectorAll(".wx-daily-forecast-list-item, .wx-daily-forecast-list-item-inner")
     ).forEach(item => {
@@ -122,7 +124,7 @@ class DailyForecast extends HTMLElement {
       item.removeAttribute("aria-labelledby");
     });
 
-    // Remove all tab roles/aria
+    // Strip tab roles and controls from nav items
     Array.from(
       this.querySelectorAll(".wx-quick-forecast-item")
     ).forEach(item => {
@@ -132,9 +134,9 @@ class DailyForecast extends HTMLElement {
   }
 
   /**
-   * When the media query for USWDS "desktop" has changed,
-   * this handler will be called.
-   * It will toggle tab/non-tab mode as needed.
+   * Called whenever the desktop media query changes state.
+   * Switches between tab mode and non-tab mode and stamps
+   * an attribute on the component for CSS hooks.
    */
   handleDesktopMediaChange(){
     this.setAttribute("wx-media-desktop", this.desktopQuery.matches);
@@ -146,64 +148,27 @@ class DailyForecast extends HTMLElement {
   }
 
   /**
-   * Click handler for quick-forecast nav link elements.
-   * Overrides the normal (in page linking) behavior, and
-   * operates as a tab, toggling attributes as needed to
-   * show/hide appropriate tabpanels
+   * Click handler for the quick-forecast nav items in tab mode.
+   * Overrides the default anchor behavior and toggles
+   * aria-selected / data-tabpanel-active attributes to reveal
+   * the corresponding day panel.
    */
   tabClickHandler(event){
     event.preventDefault();
     if(event.target.getAttribute("aria-selected") !== "true"){
+      // Clear selection on every nav item first
       Array.from(this.querySelectorAll(".wx-quick-forecast-item"))
         .forEach(item => item.setAttribute("aria-selected", "false"));
       event.target.setAttribute("aria-selected", "true");
 
-      // Update panel data attributes, used for showing/hiding
-      // the tabs
+      // Toggle the active panel attribute used by CSS to
+      // control which forecast day is visible
       Array.from(
         this.forecastList.querySelectorAll(".wx-daily-forecast-list-item-inner")
       ).forEach(item => item.setAttribute("data-tabpanel-active", "false"));
       const correspondingPanelId = event.target.getAttribute("aria-controls");
       const correspondingPanel = document.getElementById(correspondingPanelId);
       correspondingPanel.setAttribute("data-tabpanel-active", "true");
-    }
-  }
-
-  /**
-   * Handle the additional key events required by the
-   * WCAG tabs pattern
-   */
-  handleKeys(event){
-    if(event.code === "Space"){
-      // Space selects the item
-      event.target.click();
-      event.preventDefault();
-    } else if(event.code === "ArrowRight"){
-      // Move to the next element in the nav list.
-      // If we are already on the last one, loop back to
-      // the first one.
-      if(event.target.matches(":last-child")){
-        this.querySelector(".wx-quick-forecast-item:first-child").focus();
-      } else {
-        event.target.nextElementSibling.focus();
-      }
-    } else if(event.code === "ArrowLeft"){
-      // Move to the previous element in the nav list.
-      // If we are already on the first element, loop
-      // around to the last one.
-      if(event.target.matches(":first-child")){
-        this.querySelector(".wx-quick-forecast-item:last-child").focus();
-      } else {
-        event.target.previousElementSibling.focus();
-      }
-    } else if(event.code === "Home"){
-      // Move focus to the first nav item
-      this.querySelector(".wx-quick-forecast-item:first-child").focus();
-      event.preventDefault();
-    } else if(event.code === "End"){
-      // Move focus to the last nav item
-      this.querySelector(".wx-quick-forecast-item:last-child").focus();
-      event.preventDefault();
     }
   }
 }

--- a/web/themes/new_weather_theme/assets/js/components/TabbedNavigator.js
+++ b/web/themes/new_weather_theme/assets/js/components/TabbedNavigator.js
@@ -1,8 +1,21 @@
+/**
+ * Tabbed Navigator Component
+ * ------------------------------------------
+ * Manages the multi-tab layout on location pages, handling
+ * tab switching, hash-based deep linking, accordion expansion,
+ * and scroll offset compensation for the sticky button bar.
+ *
+ * Keyboard navigation (arrow keys, Home/End) is handled by
+ * the shared tab-keyboard-nav utility rather than inline here.
+ */
+import { attachTabKeyboardNav } from "./tab-keyboard-nav.js";
+
 class TabbedNavigator extends HTMLElement {
   constructor() {
     super();
 
-    // Bind this context to methods that need it
+    // Bind methods that rely on `this` context when called
+    // as event callbacks
     this.handleAlertAnchorClick = this.handleAlertAnchorClick.bind(this);
     this.handleTabButtonClick = this.handleTabButtonClick.bind(this);
     this.switchToTab = this.switchToTab.bind(this);
@@ -10,7 +23,8 @@ class TabbedNavigator extends HTMLElement {
   }
 
   connectedCallback() {
-    // If no tabs are selected by default, then select the first one
+    // When no tab has the selected attribute on load,
+    // default to activating whichever button comes first
     const selected = Array.from(
       this.querySelectorAll(".tab-button[data-selected]"),
     );
@@ -18,10 +32,8 @@ class TabbedNavigator extends HTMLElement {
       this.switchToTab(this.querySelector("button").dataset.tabName);
     }
 
-    // The initial page load might contain a hash fragment
-    // referring either to content within a given tab
-    // (such as an alert) or a tab itself. We should handle
-    // these two cases.
+    // If the initial URL includes a hash fragment pointing to
+    // a tab or content inside one, navigate there immediately
     this.navigateWithInitialHash();
 
     // Intercept click events on Alert links at the
@@ -32,29 +44,41 @@ class TabbedNavigator extends HTMLElement {
       },
     );
 
-    // Intercept click events on Alert spans in
-    // any hourly detail tables
+    // Same treatment for alert links embedded in hourly
+    // detail tables
     Array.from(this.querySelectorAll(".wx-alert-link a")).forEach(
       (alertSpan) => {
         alertSpan.addEventListener("click", this.handleAlertAnchorClick);
       }
     );
 
-    // Add needed event listeners
+    // Attach click handlers to every tab button
     Array.from(this.querySelectorAll("button.tab-button")).forEach((button) => {
       button.addEventListener("click", this.handleTabButtonClick);
-      button.addEventListener("keydown", this.handleTabListKeydown);
     });
+
+    // Keyboard navigation is provided by the shared utility —
+    // it gives back a cleanup function we store for disconnect
+    this._cleanupKeyNav = attachTabKeyboardNav(this, ".tab-button");
   }
 
   disconnectedCallback() {
-    // Remove any event listeners
+    // Tear down keyboard navigation
+    if(this._cleanupKeyNav){
+      this._cleanupKeyNav();
+    }
+
+    // Remove click listeners from the tab buttons
     Array.from(this.querySelectorAll("button.tab-button")).forEach((button) => {
       button.removeEventListener("click", this.handleTabButtonClick);
-      button.removeEventListener("keydown", this.handleTabListKeydown);
     });
   }
 
+  /**
+   * Checks the current URL hash on first load and, if it
+   * points to a known tab or an element inside one, switches
+   * to that tab (and opens its accordion if applicable).
+   */
   navigateWithInitialHash() {
     const hash = new URL(window.location).hash;
     if (!hash || hash === "") {
@@ -62,6 +86,7 @@ class TabbedNavigator extends HTMLElement {
     }
 
     try {
+      // First check: is the hash the name of a tab itself?
       const matchedTabButton = this.querySelector(
         `[data-tab-name="${hash.replace("#", "")}"]`,
       );
@@ -71,6 +96,8 @@ class TabbedNavigator extends HTMLElement {
         return;
       }
 
+      // Second check: is the hash an element nested inside
+      // one of the tab containers?
       const childElement = this.querySelector(
         `${hash},wx-tab-container, .wx-tab-container ${hash}`,
       );
@@ -85,14 +112,19 @@ class TabbedNavigator extends HTMLElement {
         }
       }
     } catch (e) {
-      // Guard against hashes that are not valid DOM identifiers. We can't
-      // prevent users from typing random stuff in the address bar, but we
-      // prevent our scripts from crashing if they do.
+      // Guard against hashes that are not valid DOM identifiers.
+      // Users can type arbitrary text into the address bar, and
+      // we shouldn't let that crash our scripts.
     }
   }
 
+  /**
+   * Activates the tab identified by tabId while deactivating
+   * all others. Also fires a custom event so external code
+   * can react to the switch.
+   */
   switchToTab(tabId) {
-    // First, deactivate all tabs
+    // Start by clearing every tab and container
     Array.from(this.querySelectorAll(".tab-button, .wx-tab-container")).forEach(
       (element) => {
         element.removeAttribute("data-selected");
@@ -103,18 +135,17 @@ class TabbedNavigator extends HTMLElement {
       },
     );
 
-    // Active the tab button
+    // Mark the target tab button as active
     const tabButton = this.querySelector(`[data-tab-name="${tabId}"]`);
     tabButton.setAttribute("data-selected", "");
     tabButton.setAttribute("aria-expanded", "true");
     tabButton.removeAttribute("tabindex");
 
-    // Activate the corresponding container
+    // Reveal the matching content container
     const tabContainer = this.querySelector(`#${tabId}`);
     tabContainer.setAttribute("data-selected", "");
 
-    // Trigger a custom event for use externally
-    // when tabs switch
+    // Broadcast the switch so other components can respond
     const event = new CustomEvent("wx:tab-switched", {
       detail: {
         tabId,
@@ -126,39 +157,36 @@ class TabbedNavigator extends HTMLElement {
 
   handleTabButtonClick(event) {
     this.switchToTab(event.target.dataset.tabName);
-    // Since this was an actual click, update the hash
-    // of the site to the tab button's id
+    // Persist the active tab in the URL hash so bookmarks
+    // and browser history reflect the current state
     window.history.replaceState(null, null, `#${event.target.dataset.tabName}`);
   }
 
+  /**
+   * Intercepts clicks on alert anchor links and, when the
+   * target lives inside one of our tab containers, switches
+   * to that tab and scrolls the relevant accordion into view.
+   */
   handleAlertAnchorClick(event) {
     const hash = new URL(event.currentTarget.href).hash;
     const accordionEl = this.querySelector(`${hash}.usa-accordion`);
 
     if (accordionEl) {
-      // If we get here, then the element referred
-      // to by the href is a child of this tabbed
-      // navigator.
-      // We need to toggle to the correct tab pane
-      // to properly display and scroll to the element.
+      // The linked element is an accordion inside a tab —
+      // switch to its parent tab and expand it
       const tabContainer = accordionEl.closest(".wx-tab-container");
       this.switchToTab(tabContainer.id);
       this.toggleAccordion(accordionEl, true);
 
-      // Because we use a sticky position on
-      // the tab button area, the normal browser
-      // scrolling will not display the proper position
-      // to the user. Instead, we have to roll our
-      // own scrolling method
+      // The sticky tab-button bar throws off native anchor
+      // scrolling, so we compute the offset manually
       this.scrollToAccordion(accordionEl);
       event.preventDefault();
       window.history.replaceState(null, null, hash);
     } else {
-      // If we're not looking at one of the tab container's inner accordions,
-      // check if we're looking for a tab.
+      // Not an accordion — could still be a direct tab reference
       const tabContainer = this.querySelector(`${hash}.wx-tab-container`);
       if (tabContainer) {
-        // If we are, switch to that tab.
         this.switchToTab(tabContainer.id);
         event.preventDefault();
         this.scrollTo(0, 0);
@@ -167,6 +195,11 @@ class TabbedNavigator extends HTMLElement {
     }
   }
 
+  /**
+   * Expands or collapses a USWDS accordion element by
+   * toggling its button's aria-expanded and the content's
+   * hidden attribute.
+   */
   toggleAccordion(accordionElement, on = true) {
     const button = accordionElement.querySelector(
       "button.usa-accordion__button",
@@ -178,49 +211,15 @@ class TabbedNavigator extends HTMLElement {
       content.removeAttribute("hidden");
     } else {
       button.setAttribute("aria-expanded", "false");
-      content.addAttribute("hidden", "");
+      content.setAttribute("hidden", "");
     }
   }
 
-  handleTabListKeydown(event) {
-    // Per W3C guidelines, arrow keys and other navigation
-    // keys should be used (instead of tab) to navigate the
-    // focus of tab buttons.
-    // See (https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-manual/)
-    const currentElement = event.target;
-    const isFirst = currentElement.matches(":first-child");
-    const isLast = currentElement.matches(":last-child");
-    if (event.key === "ArrowRight") {
-      if (isLast) {
-        event.target.parentElement
-          .querySelector(".tab-button:first-child")
-          .focus();
-      } else {
-        currentElement.nextElementSibling.focus();
-      }
-      event.preventDefault();
-    } else if (event.key === "ArrowLeft") {
-      if (isFirst) {
-        event.target.parentElement
-          .querySelector(".tab-button:last-child")
-          .focus();
-      } else {
-        currentElement.previousElementSibling.focus();
-      }
-      event.preventDefault();
-    } else if (event.key === "Home") {
-      event.target.parentElement
-        .querySelector(".tab-button:first-child")
-        .focus();
-      event.preventDefault();
-    } else if (event.key === "End") {
-      event.target.parentElement
-        .querySelector(".tab-button:last-child")
-        .focus();
-      event.preventDefault();
-    }
-  }
-
+  /**
+   * Scrolls so that the given accordion is visible, accounting
+   * for the height of the sticky tab-button bar that would
+   * otherwise obscure the top of the content.
+   */
   scrollToAccordion(accordionElement) {
     const accordionTop = accordionElement.getBoundingClientRect().top;
     const buttonArea = this.querySelector(".tab-buttons");

--- a/web/themes/new_weather_theme/assets/js/components/Tabs.js
+++ b/web/themes/new_weather_theme/assets/js/components/Tabs.js
@@ -1,32 +1,49 @@
 /**
  * Generic WCAG Tabs component
  * ------------------------------------------
- * This is a progressively enhanced component.
- * tab, tablist, and tabpanel elements are expected
- * to have the correct `role` attributes and other
- * aria references.
- * See
- * https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+ * Progressively enhanced tab interface that expects the
+ * underlying markup to include proper `role`, `aria-selected`,
+ * and `aria-controls` attributes on tab and panel elements.
+ *
+ * Keyboard navigation (ArrowLeft/Right, Home, End, Space,
+ * Enter) is delegated to the shared tab-keyboard-nav utility
+ * so the same logic doesn't get duplicated across components.
+ *
+ * See https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
  */
+import { attachTabKeyboardNav } from "./tab-keyboard-nav.js";
+
 class Tabs extends HTMLElement {
   constructor(){
     super();
 
-    // Bound methods
+    // Keep a bound reference so we can cleanly remove it later
     this.handleTabClick = this.handleTabClick.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   connectedCallback(){
+    // Wire up click handlers on every declared tab
     Array.from(this.querySelectorAll('[role="tab"]'))
       .forEach(tabElement => {
         tabElement.addEventListener("click", this.handleTabClick);
       });
-    this.addEventListener("keydown", this.handleKeyDown);
+
+    // Keyboard navigation comes from the shared utility —
+    // it returns a teardown function we'll invoke on disconnect
+    this._cleanupKeyNav = attachTabKeyboardNav(
+      this,
+      '[role="tab"]',
+      { activateOnSpace: true, activateOnEnter: true },
+    );
   }
 
   disconnectedCallback(){
-    this.removeEventListener("keydown", this.handleKeyDown);
+    // Tear down keyboard navigation first
+    if(this._cleanupKeyNav){
+      this._cleanupKeyNav();
+    }
+
+    // Then remove click listeners from individual tabs
     Array.from(this.querySelectorAll('[role="tab"]'))
     .forEach(tabElement => {
       tabElement.removeEventListener("click", this.handleTabClick);
@@ -34,84 +51,31 @@ class Tabs extends HTMLElement {
   }
 
   /**
-   * The click handler should update the tab's
-   * aria-selected attribute, and also update the
-   * data-tabpanel-selected attribute on its corresponding
-   * tabpanel.
-   * Any hiding/showing of tabpanel content should be
-   * handled by implementor's CSS
+   * When a tab is clicked, flip the aria-selected flags across
+   * the whole set and toggle the matching tabpanel's visibility
+   * attribute. Actual show/hide styling is left to the
+   * implementor's CSS.
    */
   handleTabClick(event){
     const tab = event.target.closest('[role="tab"]');
     const panelId = tab.getAttribute("aria-controls");
     const panel = document.getElementById(panelId);
     if(panel){
+      // Deselect every tab, then mark the clicked one active
       this.tabs.forEach(tabElement => {
         tabElement.setAttribute("aria-selected", false);
       });
       tab.setAttribute("aria-selected", true);
+
+      // Mirror the selection state on tabpanels
       this.tabpanels.forEach(tabpanelElement => {
         tabpanelElement.setAttribute("data-tabpanel-selected", false);
       });
       panel.setAttribute("data-tabpanel-selected", true);
+
+      // Stash the active panel id on the component itself so
+      // external code can read which tab is current
       this.setAttribute("data-selected", panelId);
-    }
-  }
-
-  /**
-   * Binds key handling events as specified in
-   * the WCAG recommendations
-   */
-  handleKeyDown(event){
-    const currentFocus = this.querySelector('[role="tab"]:focus,[role="tab"]:focus-within');
-    const firstItemInFocus = currentFocus.matches('[role="tab"]:first-child:focus, [role="tab"]:first-child:focus-within');
-    const lastItemInFocus = currentFocus.matches('[role="tab"]:last-child:focus, [role="tab"]:last-child:focus-within');
-    let handled = false;
-    if(event.key === "ArrowLeft"){
-      if(firstItemInFocus){
-        this.focusTab(this.querySelector('[role="tab"]:last-child'));
-      } else {
-        this.focusTab(currentFocus.previousElementSibling);
-      }
-      handled = true;
-    } else if(event.key === "ArrowRight"){
-      if(lastItemInFocus){
-        this.focusTab(this.querySelector('[role="tab"]:first-child'));
-      } else {
-        this.focusTab(currentFocus.nextElementSibling);
-      }
-      handled = true;
-    } else if(event.key === "Space" || event.key === "Enter"){
-      currentFocus.click();
-      handled = true;
-    } else if(event.key === "Home") {
-      this.focusTab(this.querySelector('[role="tab"]:first-child'));
-      handled = true;
-    } else if(event.key === "End"){
-      this.focusTab(this.querySelector('[role="tab"]:last-child'));
-      handled = true;
-    }
-
-    if(handled){
-      event.stopPropagation();
-      event.preventDefault();
-    }
-  }
-
-  focusTab(anElement){
-    // It is not required that the element with the role tab
-    // be a focusable element. In such cases, we need to
-    // check its children for elements that can receive focus.
-    // We do this in the simplest possible way, limiting ourselves
-    // to a, button, or any element with a tabindex
-    const matchString = "a, button, [tabindex]";
-    if(anElement.matches(matchString)){
-      anElement.focus();
-    } else {
-      const childFocusElement = anElement.querySelector(matchString);
-      if(childFocusElement){
-        childFocusElement.focus();
-      }
     }
   }
 

--- a/web/themes/new_weather_theme/assets/js/components/tab-keyboard-nav.js
+++ b/web/themes/new_weather_theme/assets/js/components/tab-keyboard-nav.js
@@ -1,0 +1,119 @@
+/**
+ * Shared WCAG tab keyboard navigation utility.
+ *
+ * Centralizes the arrow-key, Home, End, and optional activation
+ * key handling mandated by the WCAG tabs pattern. Decoupled from
+ * any specific custom element or DOM layout so each consumer can
+ * supply its own container and tab selector.
+ *
+ * Three weather.gov components use this:
+ *   - wx-tabs (generic WCAG tabs)
+ *   - wx-tabbed-nav (location page navigator)
+ *   - wx-daily-forecast (quick forecast day picker)
+ *
+ * Reference: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+ */
+
+/**
+ * Shifts focus to the supplied element — or, when that element
+ * isn't natively focusable (a wrapper <div> carrying a tab role,
+ * for instance), drills into its first focusable descendant.
+ */
+const focusElement = (el) => {
+  const focusable = "a, button, [tabindex]";
+  if (el.matches(focusable)) {
+    el.focus();
+  } else {
+    const child = el.querySelector(focusable);
+    if (child) {
+      child.focus();
+    }
+  }
+};
+
+/**
+ * Wires up WCAG-compliant keyboard navigation on a group of
+ * tab-like elements living inside a container.
+ *
+ * Navigation uses index-based lookup in the collected tab list
+ * rather than DOM sibling traversal — this way, the tabs don't
+ * need to be adjacent siblings in the markup.
+ *
+ * @param {HTMLElement} container - The element that will
+ *   receive the keydown listener (usually the web component root)
+ * @param {string} tabSelector - CSS selector matching the
+ *   individual tab elements (e.g. '[role="tab"]', '.tab-button')
+ * @param {Object} [options]
+ * @param {boolean} [options.activateOnSpace=false]
+ *   When true, pressing Space fires a click on the focused tab
+ * @param {boolean} [options.activateOnEnter=false]
+ *   When true, pressing Enter fires a click on the focused tab
+ *
+ * @returns {Function} A teardown callback that removes the
+ *   keydown listener — intended for disconnectedCallback cleanup.
+ */
+export const attachTabKeyboardNav = (container, tabSelector, options = {}) => {
+  const { activateOnSpace = false, activateOnEnter = false } = options;
+
+  const handler = (event) => {
+    // Identify the tab that currently holds focus (or contains
+    // a focused descendant, via :focus-within)
+    const focused = container.querySelector(
+      `${tabSelector}:focus, ${tabSelector}:focus-within`,
+    );
+    if (!focused) return;
+
+    // Gather every tab matching our selector and figure out
+    // where the focused one sits in the sequence. Index-based
+    // navigation is more reliable than previousElementSibling
+    // when tabs aren't necessarily direct DOM siblings.
+    const allTabs = Array.from(container.querySelectorAll(tabSelector));
+    const currentIndex = allTabs.indexOf(focused);
+    if (currentIndex < 0) return;
+
+    let handled = false;
+
+    if (event.key === "ArrowLeft") {
+      // Step backward through the tab list, wrapping from
+      // the first position back around to the last
+      const prev = currentIndex === 0
+        ? allTabs.length - 1
+        : currentIndex - 1;
+      focusElement(allTabs[prev]);
+      handled = true;
+    } else if (event.key === "ArrowRight") {
+      // Advance forward, looping from the final tab back
+      // to the beginning of the list
+      const next = currentIndex === allTabs.length - 1
+        ? 0
+        : currentIndex + 1;
+      focusElement(allTabs[next]);
+      handled = true;
+    } else if (event.key === "Home") {
+      // Jump straight to the opening tab
+      focusElement(allTabs[0]);
+      handled = true;
+    } else if (event.key === "End") {
+      // Jump straight to the closing tab
+      focusElement(allTabs[allTabs.length - 1]);
+      handled = true;
+    } else if (
+      (activateOnSpace && (event.key === " " || event.key === "Space" || event.code === "Space")) ||
+      (activateOnEnter && event.key === "Enter")
+    ) {
+      // Simulate a click so the tab's own activation logic runs
+      focused.click();
+      handled = true;
+    }
+
+    if (handled) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+  };
+
+  container.addEventListener("keydown", handler);
+
+  // Return a cleanup function for easy teardown
+  return () => container.removeEventListener("keydown", handler);
+};

--- a/web/themes/new_weather_theme/tests/components/generic-tabs-tests.js
+++ b/web/themes/new_weather_theme/tests/components/generic-tabs-tests.js
@@ -13,7 +13,7 @@ const EXAMPLE = `
         Tab 3
     </button>
 </wx-tabs>
-<div id="tab1" ""role="tabpanel" aria-labelledby="button1">
+<div id="tab1" role="tabpanel" aria-labelledby="button1">
     Tab 1 content
 </div>
 <div id="tab2" role="tabpanel" aria-labelledby="button2">
@@ -77,6 +77,19 @@ describe("Tab web component basic tests", () => {
     expect(secondTab.getAttribute("aria-selected")).to.eql("true");
   });
 
+  it("pressing real browser space key (key=' ') on the second tab will select it", () => {
+    // Real browsers send { key: " " } (a literal space character) for
+    // the spacebar, not { key: "Space" }. This test verifies the shared
+    // keyboard utility handles that correctly.
+    const tablist = document.querySelector("wx-tabs");
+    const secondTab = tablist.querySelector('[role="tab"]:nth-child(2)');
+    secondTab.focus();
+    const evt = new window.KeyboardEvent("keydown", { key: " " });
+    tablist.dispatchEvent(evt);
+
+    expect(secondTab.getAttribute("aria-selected")).to.eql("true");
+  });
+
   it("sets the correct aria-selected values on all tabs (when clicking 3rd)", () => {
     document.body.querySelector('[role="tab"]:nth-child(3)').click();
     const actualFirst = document.body.querySelector('[role="tab"]:nth-child(1)');
@@ -94,17 +107,17 @@ describe("Tab web component basic tests", () => {
 
     // First instance, highlights second element
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:nth-child(2)'));
+    expect(document.activeElement.matches('[role="tab"]:nth-child(2)')).to.be.true;
 
     // Second instance, focuses last element
     evt = new window.KeyboardEvent("keydown", {key: "ArrowRight"});
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:last-child'));
+    expect(document.activeElement.matches('[role="tab"]:last-child')).to.be.true;
 
     // Third time should loop around to the beginning of the tabs
     evt = new window.KeyboardEvent("keydown", {key: "ArrowRight"});
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:first-child'));
+    expect(document.activeElement.matches('[role="tab"]:first-child')).to.be.true;
   });
 
   it("left arrow navigation works", () => {
@@ -113,43 +126,43 @@ describe("Tab web component basic tests", () => {
 
     // First instance, loops around to focus on the last tab
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:last-child'));
+    expect(document.activeElement.matches('[role="tab"]:last-child')).to.be.true;
 
     // Second instance, loops around to the second tab
     evt = new window.KeyboardEvent("keydown", {key: "ArrowLeft"});
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:nth-child(2)'));
+    expect(document.activeElement.matches('[role="tab"]:nth-child(2)')).to.be.true;
 
     // Third time, comes back to focus on first element
     evt = new window.KeyboardEvent("keydown", {key: "ArrowLeft"});
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:first-child'));
+    expect(document.activeElement.matches('[role="tab"]:first-child')).to.be.true;
   });
 
   it("Home key focuses on the first tab", () => {
     const tablist = document.querySelector("wx-tabs");
     const evt = new window.KeyboardEvent("keydown", {key: "Home"});
 
-    // Start by focusing the second tab
-    tablist.tabs[0].focus();
-    expect(document.activeElement.matches('[role="tab"]:nth-child(2)'));
+    // Start by focusing the second tab so Home has somewhere to go
+    tablist.tabs[1].focus();
+    expect(document.activeElement.matches('[role="tab"]:nth-child(2)')).to.be.true;
 
     // Now push the Home key to focus first item
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:first-child'));
+    expect(document.activeElement.matches('[role="tab"]:first-child')).to.be.true;
   });
 
-  it("End key focuses on the first tab", () => {
+  it("End key focuses on the last tab", () => {
     const tablist = document.querySelector("wx-tabs");
     const evt = new window.KeyboardEvent("keydown", {key: "End"});
 
-    // Start by focusing the second tab
-    tablist.tabs[0].focus();
-    expect(document.activeElement.matches('[role="tab"]:nth-child(2)'));
+    // Start by focusing the second tab so End has somewhere to go
+    tablist.tabs[1].focus();
+    expect(document.activeElement.matches('[role="tab"]:nth-child(2)')).to.be.true;
 
     // Now push the End key to focus last item
     tablist.dispatchEvent(evt);
-    expect(document.activeElement.matches('[role="tab"]:last-child'));
+    expect(document.activeElement.matches('[role="tab"]:last-child')).to.be.true;
   });
 
   it("Selecting a tab updates the corresponding tabpanel data selection attribute", () => {


### PR DESCRIPTION
## Summary
- Extracts duplicated WCAG tab keyboard navigation from `Tabs.js`, `TabbedNavigator.js`, and `DailyForecast.js` into a shared `tab-keyboard-nav.js` utility
- Uses index-based navigation (more robust than sibling traversal) with configurable tab selector and optional Space/Enter activation
- Fixes `addAttribute` bug in TabbedNavigator (should be `setAttribute`) that would crash on accordion collapse
- Fixes pre-existing test defects: stray `""` in fixture, 10 no-op assertions, wrong Home/End test setup, wrong End description
- Adds test for real browser space key (`{ key: " " }` vs `{ key: "Space" }`)

## Test plan
- [ ] Run component tests: `cd web/themes/new_weather_theme && npx mocha --require ./tests/components/preload.js tests/components/generic-tabs-tests.js`
- [ ] All 13 tests pass
- [ ] Verify keyboard nav works in all three tab contexts (forecast details, tabbed navigator, daily forecast)
- [ ] Verify arrow keys wrap around, Home/End jump to first/last, Space/Enter activate

Closes #2152