### PR TITLE
Add language selector and units toggle to site header

### DIFF
--- a/web/modules/weather_i18n/translations/en.po
+++ b/web/modules/weather_i18n/translations/en.po
@@ -253,6 +253,12 @@ msgstr "Weather information sections"
 msgid "forecast.link.area-forecast-discussion.01"
 msgstr "Area Forecast Discussion"
 
+msgid "language-selector.aria.select-language.01"
+msgstr "Select a language"
+
+msgid "language-selector.button.languages.01"
+msgstr "Languages"
+
 msgid "frontpage.heading.find-your-forecast.01"
 msgstr "Find your forecast"
 
@@ -450,6 +456,9 @@ msgstr "Satellite"
 
 msgid "theme.text.submitted-by.01"
 msgstr "Submitted by @author_name on @month/@day"
+
+msgid "units-toggle.aria.unit-system.01"
+msgstr "Unit system"
 
 msgid "units.dbz.01"
 msgstr "dBz"

--- a/web/modules/weather_i18n/translations/es.po
+++ b/web/modules/weather_i18n/translations/es.po
@@ -85,6 +85,12 @@ msgstr "Ciencia. Servicio. Administración"
 msgid "footer.text.usa-gov-site-alt.01"
 msgstr "Un sitio web oficial del gobierno de Estados Unidos"
 
+msgid "language-selector.aria.select-language.01"
+msgstr "Seleccionar idioma"
+
+msgid "language-selector.button.languages.01"
+msgstr "Idiomas"
+
 msgid "forecast.current.aria.feels-like.01"
 msgstr "Se siente como 77 ℉."
 
@@ -210,6 +216,9 @@ msgstr "Consejos para mantenerse seguro"
 
 msgid "theme.text.submitted-by.01"
 msgstr "Enviado por Colin Murphy el 25 de julio"
+
+msgid "units-toggle.aria.unit-system.01"
+msgstr "Sistema de unidades"
 
 msgid "units.dbz.01"
 msgstr "dBz"

--- a/web/modules/weather_i18n/translations/zh-hans.po
+++ b/web/modules/weather_i18n/translations/zh-hans.po
@@ -76,6 +76,12 @@ msgstr "科学。 服务。 管理"
 msgid "footer.text.usa-gov-site-alt.01"
 msgstr "美国政府官方网站"
 
+msgid "language-selector.aria.select-language.01"
+msgstr "选择语言"
+
+msgid "language-selector.button.languages.01"
+msgstr "语言"
+
 msgid "forecast.current.feels-like.01"
 msgstr "感觉像"
 
@@ -168,6 +174,9 @@ msgstr "保障安全的提示"
 
 msgid "theme.text.submitted-by.01"
 msgstr "@author_name于@month月@day日提交"
+
+msgid "units-toggle.aria.unit-system.01"
+msgstr "单位制"
 
 msgid "units.dbz.01"
 msgstr "dBz"

--- a/web/themes/new_weather_theme/assets/js/afd.page.js
+++ b/web/themes/new_weather_theme/assets/js/afd.page.js
@@ -1,1 +1,2 @@
 import("./components/combo-box.js");
+import("./components/LanguageSelector.js");

--- a/web/themes/new_weather_theme/assets/js/components/LanguageSelector.js
+++ b/web/themes/new_weather_theme/assets/js/components/LanguageSelector.js
@@ -1,0 +1,188 @@
+/**
+ * Language Selector + Units Toggle Component
+ * -------------------------------------------
+ * Enhances the server-rendered language dropdown and units
+ * toggle that live inside the site header.
+ *
+ * Language switching:
+ *   Drupal negotiates language via URL path prefixes
+ *   (/es/, /zh-hans/). This component reads the current
+ *   pathname, figures out which language is active, and
+ *   rewrites the <a> hrefs so each link points to the
+ *   correct translated version of the current page.
+ *
+ * Units toggle:
+ *   Stores the user's preferred unit system ("us" or "metric")
+ *   in localStorage. On init the saved preference is restored;
+ *   on toggle a custom event ("wx:units-changed") fires so
+ *   other components can react without polling.
+ */
+
+// Known language path prefixes, keyed by Drupal langcode.
+// English has no prefix (empty string), the other two carry
+// their standard Drupal path prefix values.
+const LANG_PREFIXES = {
+  en: "",
+  es: "/es",
+  "zh-hans": "/zh-hans",
+};
+
+// Ordered array for iteration — makes it easy to check each
+// prefix against the current path
+const LANG_CODES = Object.keys(LANG_PREFIXES);
+
+// localStorage key and the only two values we'll accept
+const UNITS_STORAGE_KEY = "wxgov_units";
+const ALLOWED_UNITS = ["us", "metric"];
+
+class LanguageSelector extends HTMLElement {
+  connectedCallback() {
+    this.setupLanguageLinks();
+    this.setupUnitsToggle();
+  }
+
+  /**
+   * Derives the active language from the current URL and
+   * updates every language link so it points to the equivalent
+   * page in the target language. Also visually marks the
+   * current language as active.
+   */
+  setupLanguageLinks() {
+    const currentLang = this.detectCurrentLanguage();
+    const basePath = this.stripLanguagePrefix(window.location.pathname, currentLang);
+
+    // Walk through each language link and compute its target URL
+    const langLinks = this.querySelectorAll("a[data-lang]");
+    langLinks.forEach((link) => {
+      const targetLang = link.getAttribute("data-lang");
+      const prefix = LANG_PREFIXES[targetLang] || "";
+
+      // Rebuild the full URL with the target language prefix,
+      // preserving any query string or hash fragment
+      const targetPath = prefix + (basePath || "/");
+      link.setAttribute(
+        "href",
+        targetPath + window.location.search + window.location.hash,
+      );
+
+      // Highlight the link for the language we're already viewing.
+      // The aria-current goes on the link itself for assistive tech,
+      // but the active class goes on the parent <li> so the CSS
+      // descendant selector (.usa-language__submenu-item--active a)
+      // can style the link correctly.
+      if (targetLang === currentLang) {
+        link.setAttribute("aria-current", "true");
+        if (link.parentElement) {
+          link.parentElement.classList.add("usa-language__submenu-item--active");
+        }
+      }
+    });
+  }
+
+  /**
+   * Checks the pathname against known language prefixes.
+   * Falls back to English when nothing matches.
+   */
+  detectCurrentLanguage() {
+    const path = window.location.pathname;
+
+    // Try non-English prefixes first (they have actual path segments)
+    for (const lang of LANG_CODES) {
+      const prefix = LANG_PREFIXES[lang];
+      if (prefix && (path.startsWith(`${prefix}/`) || path === prefix)) {
+        return lang;
+      }
+    }
+
+    // No prefix found — must be English
+    return "en";
+  }
+
+  /**
+   * Strips the language prefix from a pathname so we get the
+   * language-neutral base path. For example:
+   *   /es/point/37/-122  →  /point/37/-122
+   *   /point/37/-122     →  /point/37/-122
+   */
+  stripLanguagePrefix(pathname, lang) {
+    const prefix = LANG_PREFIXES[lang];
+    if (prefix && pathname.startsWith(prefix)) {
+      return pathname.substring(prefix.length) || "/";
+    }
+    return pathname;
+  }
+
+  /**
+   * Reads the saved unit preference from localStorage (with
+   * allowlist validation), applies it to the toggle buttons,
+   * and attaches click handlers for switching.
+   */
+  setupUnitsToggle() {
+    // Retrieve the stored preference, falling back to US if
+    // nothing is saved or the value is unexpected.
+    // localStorage can throw in private browsing or restricted
+    // environments, so we wrap access in try/catch.
+    let initialUnits = "us";
+    try {
+      const stored = localStorage.getItem(UNITS_STORAGE_KEY);
+      if (ALLOWED_UNITS.includes(stored)) {
+        initialUnits = stored;
+      }
+    } catch {
+      // Storage unavailable — stick with the default
+    }
+
+    // Apply the initial state to the buttons
+    this.applyUnitsState(initialUnits);
+
+    // Listen for clicks on either toggle button
+    const buttons = this.querySelectorAll(".wx-units-toggle__btn");
+    buttons.forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const units = btn.getAttribute("data-units");
+
+        // Guard: never store a value outside our allowlist
+        if (!ALLOWED_UNITS.includes(units)) return;
+
+        // Persist the choice when storage is available
+        try {
+          localStorage.setItem(UNITS_STORAGE_KEY, units);
+        } catch {
+          // Storage unavailable — toggling still works for the
+          // current session, just won't persist across reloads
+        }
+
+        this.applyUnitsState(units);
+
+        // Let the rest of the page know about the change
+        this.dispatchEvent(
+          new CustomEvent("wx:units-changed", {
+            detail: { units },
+            bubbles: true,
+          }),
+        );
+      });
+    });
+  }
+
+  /**
+   * Syncs the toggle buttons' visual state and aria-pressed
+   * attributes to reflect the given unit system.
+   */
+  applyUnitsState(activeUnits) {
+    const buttons = this.querySelectorAll(".wx-units-toggle__btn");
+    buttons.forEach((btn) => {
+      const isActive = btn.getAttribute("data-units") === activeUnits;
+      btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+
+      // Swap USWDS button styles to distinguish active vs inactive
+      if (isActive) {
+        btn.classList.remove("usa-button--outline");
+      } else {
+        btn.classList.add("usa-button--outline");
+      }
+    });
+  }
+}
+
+window.customElements.define("wx-language-selector", LanguageSelector);

--- a/web/themes/new_weather_theme/assets/js/front.page.js
+++ b/web/themes/new_weather_theme/assets/js/front.page.js
@@ -1,3 +1,4 @@
 import("./locationSearch.js");
 import("./components/combo-box.js");
 import("./components/combo-box-location.js");
+import("./components/LanguageSelector.js");

--- a/web/themes/new_weather_theme/assets/js/point.page.components.js
+++ b/web/themes/new_weather_theme/assets/js/point.page.components.js
@@ -15,3 +15,4 @@ import("./components/Tabs.js");
 import("./components/DailyForecast.js");
 import("./components/combo-box.js");
 import("./components/combo-box-location.js");
+import("./components/LanguageSelector.js");

--- a/web/themes/new_weather_theme/assets/sass/components/_language-selector.scss
+++ b/web/themes/new_weather_theme/assets/sass/components/_language-selector.scss
@@ -1,0 +1,49 @@
+/*
+ * Language Selector & Units Toggle
+ * ---------------------------------
+ * Sits in the site header alongside the NOAA branding.
+ * The language dropdown follows the USWDS "3+ languages"
+ * pattern; the units toggle is a segmented button pair
+ * for Fahrenheit vs Celsius.
+ */
+
+@use "uswds-core" as *;
+
+/* Wrapper for the language + units controls.
+   Positioned flush-right in the header grid row. */
+wx-language-selector {
+  display: flex;
+  align-items: center;
+  gap: units(1);
+}
+
+/* Override a bit of USWDS spacing so the language
+   dropdown doesn't push the header height too much */
+.usa-language-container {
+  margin: 0;
+}
+
+/* Highlight the currently active language inside the
+   dropdown so users can see which one they're on */
+.usa-language__submenu-item--active a {
+  background-color: color("primary-lighter");
+  font-weight: bold;
+}
+
+/* ── Units Toggle ──
+   A compact segmented pair of buttons. On small screens
+   the buttons shrink a bit to save horizontal space. */
+.wx-units-toggle {
+  margin: 0;
+  flex-shrink: 0;
+
+  .wx-units-toggle__btn {
+    @include u-font("sans", "2xs");
+    padding: units(0.5) units(1);
+    min-width: auto;
+    /* Remove the default min-height so the pair stays
+       compact inside the header */
+    min-height: auto;
+    line-height: 1.2;
+  }
+}

--- a/web/themes/new_weather_theme/assets/sass/styles.scss
+++ b/web/themes/new_weather_theme/assets/sass/styles.scss
@@ -34,3 +34,4 @@
 @use "components/accordion";
 @use "components/quick-forecast-toggle";
 @use "components/generic-tabs";
+@use "components/language-selector";

--- a/web/themes/new_weather_theme/templates/layout/page--point.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page--point.html.twig
@@ -11,7 +11,14 @@
   <header role="banner">
     <div class="grid-container">
       {% if page.header %}
-      <div class="grid-row">{{ page.header }}</div>
+      <div class="grid-row flex-justify flex-align-center">
+        <div class="grid-col">
+          {{ page.header }}
+        </div>
+        <div class="grid-col-auto">
+          {% include '@new_weather_theme/partials/language-selector.html.twig' %}
+        </div>
+      </div>
       {% endif %} {% if page.primary_menu %}
       <div class="grid-row">{{ page.primary_menu }}</div>
       {% endif %} {% if page.secondary_menu %}

--- a/web/themes/new_weather_theme/templates/layout/page.html.twig
+++ b/web/themes/new_weather_theme/templates/layout/page.html.twig
@@ -47,8 +47,13 @@
   <header role="banner">
     <div class="grid-container">
       {% if page.header %}
-        <div class="grid-row">
-          {{ page.header }}
+        <div class="grid-row flex-justify flex-align-center">
+          <div class="grid-col">
+            {{ page.header }}
+          </div>
+          <div class="grid-col-auto">
+            {% include '@new_weather_theme/partials/language-selector.html.twig' %}
+          </div>
         </div>
       {% endif %}
       {% if page.primary_menu %}

--- a/web/themes/new_weather_theme/templates/partials/language-selector.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/language-selector.html.twig
@@ -1,0 +1,86 @@
+{#
+/**
+ * Language and units selector partial.
+ *
+ * Placed in the site header, this provides two controls:
+ *
+ * 1. A USWDS-pattern language dropdown that lets users switch
+ *    between English, Spanish, and Simplified Chinese. Drupal
+ *    handles language negotiation via URL path prefixes
+ *    (/es/, /zh-hans/), so each link just swaps the prefix on
+ *    the current page URL.
+ *
+ * 2. A units toggle (°F / °C) persisted in localStorage so the
+ *    preference carries across page loads. Other components can
+ *    react to changes via the "wx:units-changed" custom event.
+ *
+ * The <wx-language-selector> web component handles the dynamic
+ * bits: computing the correct language URLs on the client side
+ * and wiring up the units toggle state.
+ */
+#}
+<wx-language-selector class="display-flex flex-align-center flex-gap-1">
+
+  {# ── USWDS Language Selector (3+ languages pattern) ──
+     The dropdown accordion behavior is handled by the built-in
+     USWDS JavaScript. Language names are always shown in their
+     native script so speakers can recognize them regardless of
+     the page's current language. #}
+  <div class="usa-language-container">
+    <ul class="usa-language__primary usa-accordion">
+      <li class="usa-language__primary-item">
+        <button
+          type="button"
+          class="usa-accordion__button usa-language__link"
+          aria-expanded="false"
+          aria-controls="wx-language-options"
+          aria-label="{{ 'language-selector.aria.select-language.01' | t }}"
+        >
+          {{ "language-selector.button.languages.01" | t }}
+        </button>
+        <ul id="wx-language-options" class="usa-accordion__content usa-language__submenu" hidden>
+          <li class="usa-language__submenu-item">
+            <a href="/" data-lang="en" title="English">
+              <span lang="en" xml:lang="en"><strong>English</strong></span>
+            </a>
+          </li>
+          <li class="usa-language__submenu-item">
+            <a href="/es/" data-lang="es" title="Español | Spanish">
+              <span lang="es" xml:lang="es"><strong>Español</strong></span>
+            </a>
+          </li>
+          <li class="usa-language__submenu-item">
+            <a href="/zh-hans/" data-lang="zh-hans" title="中文 | Chinese (Simplified)">
+              <span lang="zh-Hans" xml:lang="zh-Hans"><strong>中文</strong></span>
+            </a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+
+  {# ── Units Toggle ──
+     A paired button group for Fahrenheit vs. Celsius. The
+     pressed state is tracked via aria-pressed and a data
+     attribute on the wrapper, while the actual preference is
+     stored in localStorage by the web component. #}
+  <div
+    class="wx-units-toggle usa-button-group usa-button-group--segmented"
+    role="group"
+    aria-label="{{ 'units-toggle.aria.unit-system.01' | t }}"
+  >
+    <button
+      type="button"
+      class="usa-button wx-units-toggle__btn"
+      data-units="us"
+      aria-pressed="true"
+    >°F</button>
+    <button
+      type="button"
+      class="usa-button usa-button--outline wx-units-toggle__btn"
+      data-units="metric"
+      aria-pressed="false"
+    >°C</button>
+  </div>
+
+</wx-language-selector>


### PR DESCRIPTION
## Summary
- Adds a USWDS language selector dropdown (English/Español/中文) and a Fahrenheit/Celsius units toggle to the site header
- Language switching computes correct URL path prefixes for Drupal's path-based language negotiation
- Units toggle persists preference in localStorage with allowlist validation and try/catch for restricted environments
- Dispatches `wx:units-changed` custom event so other components can react to unit preference changes
- Includes the selector in both `page.html.twig` and `page--point.html.twig` headers
- Adds 3 translation keys to all 3 .po files (en, es, zh-hans)

## Test plan
- [ ] Verify language dropdown opens/closes via USWDS accordion behavior
- [ ] Verify language links point to correct `/es/...` and `/zh-hans/...` paths for the current page
- [ ] Verify units toggle persists across page reloads (check localStorage)
- [ ] Verify selector appears on both the front page and forecast (point) page
- [ ] Run translation tests: `node tests/translations/main.js` (new keys should not appear in errors)
- [ ] Test in private browsing mode (localStorage unavailable) — toggle should still work for the session

Closes #1985