### PR TITLE
Remove construction worker badge from site branding

### DIFF
--- a/web/modules/weather_i18n/translations/en.po
+++ b/web/modules/weather_i18n/translations/en.po
@@ -109,9 +109,6 @@ msgstr "Including these cities"
 msgid "alerts.text.issued-by.01"
 msgstr "Issued by @sender"
 
-msgid "backend.banner.under-development.01"
-msgstr "Under development"
-
 msgid "backend.login.cancel-text.01"
 msgstr "Cancel Text"
 

--- a/web/themes/new_weather_theme/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/new_weather_theme/templates/block/block--system-branding-block.html.twig
@@ -28,20 +28,7 @@
     <span class="site-slogan display-block font-sans-2xs desktop:font-sans-xs text-base-dark padding-left-05">
       {{ site_slogan  }}
     </span>
-    {% endif %} 
+    {% endif %}
   </div>
-  <span class="display-flex flex-align-center bg-gold-10v text-black text-uppercase padding-y-05 padding-left-1 padding-right-105 font-sans-xs radius-md margin-left-1 margin-top-105 tablet:margin-top-0">
-    <svg
-        class="usa-icon height-205 width-205 margin-right-05 text-top margin-bottom-2px"
-        aria-hidden="true"
-        focusable="false"
-        role="img"
-    >
-      <use
-        xlink:href="/{{ directory }}/assets/images/uswds/sprite.svg#construction_worker"
-      ></use>
-    </svg>
-    {{ "backend.banner.under-development.01" | t }}
-  </span>
 </a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Removes the "Under development" construction worker badge from the branding block to reduce header height, especially on mobile
- Cleans up the stale `backend.banner.under-development.01` translation key from en.po (was the only .po file containing it)
- The separate beta banner region continues to communicate development status

## Test plan
- [ ] Verify the site header no longer shows the construction worker badge
- [ ] Verify the beta banner region still displays
- [ ] Run translation tests: `node tests/translations/main.js` (removed key should not cause new errors)
- [ ] Check mobile header height is reduced

Closes #2104