### PR TITLE
Fix: Parameterize all SQL queries in API interop layer

### DIFF
--- a/api-interop-layer/data/alerts/cache.js
+++ b/api-interop-layer/data/alerts/cache.js
@@ -67,15 +67,17 @@ PRIMARY KEY(id)
    * Remove rows from the cache table by hash.
    * If the argument is a list, we assume a list of hashes.
    */
+  // Previously the single-hash path spliced the value straight into the
+  // query string while the multi-hash path already used placeholders.
+  // Unified both to always go through parameterized IN (?) — no reason
+  // to treat one hash differently from many, and the old shortcut left
+  // the door open if upstream ever fed us a weird hash string.
   async removeByHashes(aHashList){
     if(!aHashList.length){
       return [];
     }
-    let whereClause = `hash='${aHashList[0]}';`;
-    if(aHashList.length > 1){
-      const marks = aHashList.map(() => "?").join(", ");
-      whereClause = `hash IN (${marks});`;
-    }
+    const marks = aHashList.map(() => "?").join(", ");
+    const whereClause = `hash IN (${marks});`;
     const sql = `DELETE FROM ${this.tableName} WHERE ${whereClause}`;
     return this.db.query(sql, aHashList);
   }

--- a/api-interop-layer/data/alerts/cache.test.js
+++ b/api-interop-layer/data/alerts/cache.test.js
@@ -78,6 +78,20 @@ describe("AlertsCache tests", () => {
     expect(result).to.be.true;
   });
 
+  // Regression guard: the old code had a separate branch for single-hash
+  // deletes that skipped parameterization. Make sure we don't slide back.
+  it("#removeByHashes (single hash uses parameterized query)", async () => {
+    const toRemove = ["only-one"];
+    const query = `DELETE FROM ${alertsCache.tableName} WHERE hash IN (?);`;
+    global.test.database.query
+      .withArgs(query, toRemove)
+      .resolves(true);
+
+    const result = await alertsCache.removeByHashes(toRemove);
+
+    expect(result).to.be.true;
+  });
+
   it("#add (with land alert kind)", async () => {
     const hash = "ten";
     const alert = { some: "json-object"};

--- a/api-interop-layer/data/obs/index.js
+++ b/api-interop-layer/data/obs/index.js
@@ -130,12 +130,18 @@ export default async ({
 
     convertProperties(data);
 
+    // The station geometry blob comes straight from the NWS observation
+    // endpoint — it's external data we don't control. Pushing it through
+    // a placeholder instead of splicing it into the query string keeps
+    // the door shut even if that upstream response is ever malformed or
+    // tampered with. Same reasoning for the lat/lon coordinates here.
+    const geometryJson = JSON.stringify(station.geometry);
     const [[{ distance }]] = await db.query(`
       SELECT ST_DISTANCE_SPHERE(
-        ST_GEOMFROMGEOJSON('${JSON.stringify(station.geometry)}'),
-        ST_SRID(ST_GEOMFROMTEXT('POINT(${longitude} ${latitude})'), 4326)
+        ST_GEOMFROMGEOJSON(?),
+        ST_SRID(ST_GEOMFROMTEXT(CONCAT('POINT(', ?, ' ', ?, ')')), 4326)
       ) as distance
-    `);
+    `, [geometryJson, longitude, latitude]);
 
     sendNewRelicMetric({
       name: "wx.observation",

--- a/api-interop-layer/data/points.js
+++ b/api-interop-layer/data/points.js
@@ -23,13 +23,18 @@ export default async (latitude, longitude) => {
   );
 
   const db = await openDatabase();
+  // Defense-in-depth: even though Fastify validates lat/lon as numbers,
+  // we still bind them through positional placeholders. If a future route
+  // change loosens the schema or a middleware bug lets through a raw
+  // string, we don't want it landing inside an ST_GEOMFROMTEXT call.
   const placePromise = db
     .query(
       `SELECT
        name,state,stateName,county,timezone,stateFIPS,countyFIPS
        FROM weathergov_geo_places
-       ORDER BY ST_DISTANCE(point,ST_GEOMFROMTEXT('POINT(${longitude} ${latitude})'))
+       ORDER BY ST_DISTANCE(point,ST_GEOMFROMTEXT(CONCAT('POINT(', ?, ' ', ?, ')')))
        LIMIT 1`,
+      [longitude, latitude],
     )
     .then((row) => {
       if (Array.isArray(row) && row.length > 0) {


### PR DESCRIPTION
## Summary

The API interop layer constructs several SQL queries by interpolating values directly into template literal strings. While the mysql2 driver's `query()` method supports parameterized placeholders (`?`), three call sites bypass this protection entirely by embedding values inline:

- **`data/points.js`** — Latitude and longitude are spliced into an `ST_GEOMFROMTEXT('POINT(...)')` call via `${longitude}` / `${latitude}`. Although Fastify validates these as numbers upstream, a defense-in-depth approach requires the database layer to independently protect itself.

- **`data/obs/index.js`** — The station geometry JSON (sourced from the external NWS API) and lat/lon coordinates are interpolated directly into `ST_GEOMFROMGEOJSON('${...}')` and `ST_GEOMFROMTEXT('POINT(${...})')`. Since the geometry data originates from an external service, a compromise or malformed response could inject arbitrary SQL.

- **`data/alerts/cache.js`** — The `removeByHashes()` method had an inconsistent parameterization strategy: the multi-hash path correctly used `IN (?, ?, ...)` with a params array, but the single-hash path used `hash='${aHashList[0]}'`, bypassing parameterization entirely.

All three are converted to use positional `?` placeholders. For the spatial functions, the approach uses `ST_GEOMFROMTEXT(CONCAT('POINT(', ?, ' ', ?, ')'))` to keep the WKT construction within SQL while binding the coordinate values safely.

## Test plan

- [x] `data/alerts/cache.test.js` — 9 passing (includes new single-hash parameterized query test)
- [x] `data/obs/index.test.js` — 13 passing, no regressions
- [x] Verified `CONCAT`-based WKT construction produces identical results to inline interpolation