### PR TITLE
Fix: Prevent SSRF via absolute URL bypass in fetch wrapper

### DIFF
--- a/api-interop-layer/util/fetch.js
+++ b/api-interop-layer/util/fetch.js
@@ -5,8 +5,24 @@ const logger = createLogger("fetch wrapper");
 
 const BASE_URL = process.env.API_URL ?? "https://api.weather.gov";
 
+// Only allow paths that are simple relative references starting with a
+// forward slash. The old code used URL.canParse(path) and forwarded
+// fully-qualified URLs verbatim, which meant an attacker-controlled value
+// like "https://evil.com/data" would cause the server to reach out to
+// that host directly — a classic Server-Side Request Forgery opening.
+//
+// Blocking just "://" is not sufficient on its own, because the URL
+// constructor also resolves protocol-relative paths ("//evil.com/path")
+// against the base URL's scheme, resulting in a request to evil.com.
+// Similarly, "data:" or "javascript:" URIs pass the "://" check but
+// resolve to unexpected targets. Requiring a leading single "/" and
+// nothing else catches all of these edge cases in one shot.
 const internalFetch = async (path) => {
-  const url = URL.canParse(path) ? path : new URL(path, BASE_URL).toString();
+  if (!path.startsWith("/") || path.startsWith("//")) {
+    logger.error(`Blocked non-relative path: ${path}`);
+    return { error: true, message: "Only relative paths are permitted" };
+  }
+  const url = new URL(path, BASE_URL).toString();
   logger.verbose(`making request to ${url}`);
 
   return fetch(url).then(async (r) => {

--- a/api-interop-layer/util/fetch.test.js
+++ b/api-interop-layer/util/fetch.test.js
@@ -175,6 +175,53 @@ describe("fetch module", () => {
     );
   });
 
+  // Every path must start with exactly one "/" to be accepted. Anything
+  // else — absolute URLs, protocol-relative references, data URIs, bare
+  // hostnames — gets blocked before fetch is ever invoked.
+  it("rejects absolute URLs to prevent SSRF attacks", async () => {
+    response.json.resolves("success");
+    fetch.resolves(response);
+
+    const result = await fetchAPIJson("https://evil.com/steal-data", { wait });
+    expect(result).to.have.property("error", true);
+    expect(fetch.callCount).to.equal(0);
+  });
+
+  // Protocol-relative URLs like "//evil.com" would resolve against the
+  // base URL's scheme and send the request to evil.com instead of the
+  // configured API host. The double-slash must be caught explicitly.
+  it("rejects protocol-relative URLs (//evil.com)", async () => {
+    response.json.resolves("success");
+    fetch.resolves(response);
+
+    const result = await fetchAPIJson("//evil.com/data", { wait });
+    expect(result).to.have.property("error", true);
+    expect(fetch.callCount).to.equal(0);
+  });
+
+  // data: URIs don't contain "://" but Node's fetch still resolves them,
+  // so they need to be blocked as well. The leading-slash requirement
+  // handles this naturally.
+  it("rejects data: URIs", async () => {
+    response.json.resolves("success");
+    fetch.resolves(response);
+
+    const result = await fetchAPIJson("data:text/html,<h1>xss</h1>", { wait });
+    expect(result).to.have.property("error", true);
+    expect(fetch.callCount).to.equal(0);
+  });
+
+  // A bare hostname without a scheme could still be misinterpreted
+  // depending on the URL parser. Paths without a leading "/" are rejected.
+  it("rejects paths that don't start with a slash", async () => {
+    response.json.resolves("success");
+    fetch.resolves(response);
+
+    const result = await fetchAPIJson("evil.com/path", { wait });
+    expect(result).to.have.property("error", true);
+    expect(fetch.callCount).to.equal(0);
+  });
+
   it("specially handles syntax errors (ie, non-JSON data", async () => {
     const error = new SyntaxError();
     error.cause = { message: "not JSON probably" };


### PR DESCRIPTION
## Summary

The internal fetch wrapper in `util/fetch.js` previously used `URL.canParse(path)` to detect fully-qualified URLs and passed them through verbatim, bypassing the configured `BASE_URL`. This created a Server-Side Request Forgery (SSRF) vector: any caller providing an absolute URL (e.g., `https://evil.com/data`) as the path would cause the server to make an outbound HTTP request to that attacker-controlled host.

SSRF can be leveraged to probe internal network services, access cloud metadata endpoints (like `http://169.254.169.254` on AWS/GCP), or exfiltrate data to external servers.

The fix replaces the `URL.canParse()` check with a strict validation that requires paths to start with exactly one `/`. This blocks:

- **Absolute URLs** (`https://evil.com/...`) — scheme-based SSRF
- **Protocol-relative URLs** (`//evil.com/...`) — the URL constructor resolves these against the base URL's scheme, sending requests to the attacker's host
- **Data URIs** (`data:text/html,...`) — Node's `fetch()` resolves these successfully
- **Bare hostnames** (`evil.com/path`) — could be misinterpreted by URL parsers

All legitimate callers in the codebase use relative paths starting with `/` (e.g., `/alerts/active`, `/points/...`, `/products/...`), so no functional behavior changes.

## Test plan

- [x] All 13 fetch tests pass (9 existing + 4 new SSRF bypass tests)
- [x] New tests cover: absolute URLs, protocol-relative URLs, data URIs, bare hostnames
- [x] Verified all existing callers use `/`-prefixed relative paths