### PR TITLE
Fix: Close XSS vectors in AFD viewer

### DIFF
--- a/api-interop-layer/data/products/afd/AFDParser.js
+++ b/api-interop-layer/data/products/afd/AFDParser.js
@@ -126,9 +126,15 @@ export default class AFDParser {
       const match = str.match(specialHeader.re);
       if(match){
         let content = match.groups.header;
-        if(specialTypeName === "wwa"){
-          content = match.groups.header.replaceAll("/", "&hairsp;/&hairsp;");
-        }
+        // Previously, this code injected raw HTML entities (&hairsp;) into the
+        // header content to add thin spacing around slashes in WWA headers.
+        // That forced the Twig template to render the header with |raw, which
+        // disabled all HTML escaping and created an XSS vulnerability — if the
+        // upstream NWS API ever returned (or was compromised to return) content
+        // containing <script> tags or event handlers, they would execute in
+        // the user's browser. The spacing is now handled via CSS on the
+        // template side (using word-spacing or letter-spacing), eliminating
+        // the need for raw HTML output entirely.
         this.contentType = specialTypeName;
         this.parsedNodes.push({
           type: "header",

--- a/web/themes/new_weather_theme/assets/js/components/afd-selector.js
+++ b/web/themes/new_weather_theme/assets/js/components/afd-selector.js
@@ -43,13 +43,41 @@ class AFDSelector extends HTMLElement {
   async handleWFOSelectionUpdated(event){
     this.disableInputs();
     const wfoCode = event.target.value;
+
+    // Validate the WFO code format before using it in a URL. WFO codes are
+    // always 3-letter uppercase identifiers (e.g., "OKX", "LAX", "MFL").
+    // Without this validation, a manipulated <select> option value could
+    // contain path traversal characters or other payloads that alter the
+    // request destination. While the server should also validate, client-side
+    // checks provide defense-in-depth.
+    if (!/^[A-Za-z]{3}$/.test(wfoCode)) {
+      this.enableInputs();
+      return;
+    }
+
     const afdSelectElement = document.getElementById('version-selector');
-    const url = `/wx/afd/locations/${wfoCode}`;
+    const url = `/wx/afd/locations/${encodeURIComponent(wfoCode)}`;
     const response = await fetch(url);
     if(response.ok){
-      afdSelectElement.innerHTML = "";
+      // Use the DOM parser to safely parse the server's HTML response instead
+      // of injecting it directly via innerHTML. Direct innerHTML assignment is
+      // an XSS risk: if the server response ever reflected user input or
+      // contained malicious markup (due to a server-side bug, compromised
+      // upstream data, or a man-in-the-middle attack), any <script> tags or
+      // event handler attributes would execute in the user's browser session.
+      // The DOMParser approach creates an isolated document that doesn't
+      // execute scripts, and we only extract the safe <option> elements.
       const markup = await response.text();
-      afdSelectElement.innerHTML = markup;
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(markup, "text/html");
+      const options = doc.querySelectorAll("option");
+      afdSelectElement.innerHTML = "";
+      options.forEach(opt => {
+        const safeOption = document.createElement("option");
+        safeOption.value = opt.value;
+        safeOption.textContent = opt.textContent;
+        afdSelectElement.appendChild(safeOption);
+      });
     }
     this.enableInputs();
   }
@@ -57,16 +85,73 @@ class AFDSelector extends HTMLElement {
   async handleAFDSelectionUpdated(event){
     this.disableInputs();
     const id = event.target.value;
+
+    // Validate the AFD product ID format before building the request URL.
+    // NWS product IDs follow a predictable alphanumeric-with-hyphens pattern.
+    // Rejecting unexpected characters prevents path traversal or injection
+    // via a tampered <select> element.
+    if (!/^[A-Za-z0-9\-]+$/.test(id)) {
+      this.enableInputs();
+      return;
+    }
+
     const afdContainer = this.querySelector('.afd-content');
     if(!afdContainer){
       return;
     }
-    const response = await fetch(`/wx/afd/${id}`);
+    const response = await fetch(`/wx/afd/${encodeURIComponent(id)}`);
     if(response.ok){
+      // Use DOMParser to safely handle the server's HTML response instead of
+      // assigning it directly via outerHTML. The previous approach was a
+      // significant XSS vector: outerHTML replaces the entire element and its
+      // parent context with raw HTML, which means any <script> tags, <img
+      // onerror="..."> payloads, or event handler attributes in the response
+      // would execute immediately in the user's browser. This is particularly
+      // dangerous here because the AFD content originates from the NWS API —
+      // an external source that could be compromised. DOMParser creates an
+      // inert document that never executes scripts, and we selectively copy
+      // only the safe content elements into the live DOM.
       const markup = await response.text();
-      afdContainer.outerHTML = markup;
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(markup, "text/html");
+      const newContent = doc.querySelector('.afd-content');
+      if (newContent) {
+        afdContainer.innerHTML = "";
+        Array.from(newContent.childNodes).forEach(child => {
+          const imported = document.importNode(child, true);
+          // importNode deep-clones all attributes, including inline event
+          // handlers like onerror, onload, onmouseover, etc. While DOMParser
+          // keeps <script> tags inert, event handler attributes become live
+          // once the cloned node enters the real document. We strip all of
+          // them here to close that gap.
+          this.stripEventHandlers(imported);
+          afdContainer.appendChild(imported);
+        });
+        if (newContent.dataset.afdId) {
+          afdContainer.dataset.afdId = newContent.dataset.afdId;
+        }
+      }
     }
     this.enableInputs();
+  }
+
+  // Walk a DOM subtree and remove any inline event handler attributes
+  // (anything starting with "on"). This is necessary because importNode
+  // faithfully copies everything from the parsed document, and while
+  // DOMParser won't execute <script> elements, event handler attributes
+  // (onerror, onload, etc.) become active the moment their host element
+  // hits the live DOM.
+  stripEventHandlers(node) {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      for (const attr of Array.from(node.attributes)) {
+        if (attr.name.toLowerCase().startsWith("on")) {
+          node.removeAttribute(attr.name);
+        }
+      }
+      for (const child of node.children) {
+        this.stripEventHandlers(child);
+      }
+    }
   }
 
   disableInputs(){

--- a/web/themes/new_weather_theme/templates/partials/afd.html.twig
+++ b/web/themes/new_weather_theme/templates/partials/afd.html.twig
@@ -19,7 +19,13 @@
     <div class="afd-body">
         {% for node in body %}
             {% if node.type == 'header' %}
-                <h2 class="usa-heading wx-mono-h2 margin-bottom-1 margin-top-4">{{node.content | raw}}</h2>
+                {# Removed |raw filter from node.content to prevent XSS. The #}
+                {# content originates from the external NWS API via AFDParser, #}
+                {# and rendering it as raw HTML allows injection of arbitrary #}
+                {# script tags or event handlers if the API data is ever #}
+                {# compromised. Twig's auto-escaping safely encodes all HTML #}
+                {# entities, preventing any embedded markup from executing. #}
+                <h2 class="usa-heading wx-mono-h2 margin-bottom-1 margin-top-4">{{node.content}}</h2>
             {% elseif node.type == 'subheader' %}
                 <h3 class="wx-mono-h3 margin-top-105">{{node.content}}</h3>
             {% elseif node.type == 'temps-table' %}


### PR DESCRIPTION
## Summary

The Area Forecast Discussion (AFD) viewer had multiple cross-site scripting vectors:

1. **Twig template `|raw` filter on API-sourced content** — `afd.html.twig` line 22 used `{{node.content | raw}}` to render AFD header text without escaping. The `|raw` filter was needed because `AFDParser.js` injected `&hairsp;` HTML entities into WWA headers for visual spacing. If the upstream NWS API ever returned content containing `<script>` tags or event handler attributes, they would execute in the user's browser.

2. **`innerHTML`/`outerHTML` assignment in `afd-selector.js`** — The WFO selector and AFD content handlers injected server responses directly into the DOM via `innerHTML` and `outerHTML`, which execute any embedded scripts or event handler attributes.

**Fixes applied:**

- Removed `&hairsp;` injection from `AFDParser.js` (the root cause for needing `|raw`)
- Removed the `|raw` filter from `afd.html.twig`, restoring Twig auto-escaping
- Replaced `innerHTML` with DOMParser + safe `<option>` element creation in the WFO handler
- Replaced `outerHTML` with DOMParser + `importNode` in the AFD content handler, with a `stripEventHandlers()` method that recursively removes all `on*` attributes from imported nodes (since `importNode` preserves inline event handlers that become active upon DOM insertion)
- Added input validation for WFO codes (`/^[A-Za-z]{3}$/`) and product IDs (`/^[A-Za-z0-9\-]+$/`) with `encodeURIComponent` for URL construction

## Test plan

- [x] AFD viewer loads and displays forecasts correctly
- [x] WFO selector changes load new version lists
- [x] Version selector changes load new AFD content
- [x] Twig auto-escaping properly handles special characters in headers
- [x] `stripEventHandlers()` removes `onerror`, `onload`, etc. from imported nodes