### PR TITLE
Fix: Escape SQL LIKE wildcards in place name routing

### DIFF
--- a/web/modules/weather_data/weather_data.module
+++ b/web/modules/weather_data/weather_data.module
@@ -26,6 +26,14 @@ function weather_data_template_preprocess_default_variables_alter(&$variables)
         $place = str_replace("_", " ", $place);
         $place = str_replace(",", "/", $place);
 
+        // The query below uses LIKE, which treats % and _ as wildcard
+        // characters. Parameterized queries don't neutralize these —
+        // they only prevent actual SQL injection. Without escaping,
+        // a request to /place/TX/D% would match "Dallas" instead of
+        // returning a 404 for a literal "D%".
+        $state = str_replace(['%', '_'], ['\\%', '\\_'], $state);
+        $place = str_replace(['%', '_'], ['\\%', '\\_'], $place);
+
         $db = $container->get("database");
         $location = $db
             ->query(

--- a/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
+++ b/web/modules/weather_routes/src/Controller/LocationAndGridRouteController.php
@@ -109,6 +109,28 @@ final class LocationAndGridRouteController extends ControllerBase
         $place = str_replace("_", " ", $place);
         $place = str_replace(",", "/", $place);
 
+        // Escape SQL LIKE wildcard characters (% and _) in user input before
+        // passing to the LIKE clause. Without this, an attacker can abuse
+        // wildcard pattern matching to enumerate place names in the database.
+        // For example, a request to /place/TX/D% would match "Dallas",
+        // "Denton", "Del Rio", etc. — returning whichever is first
+        // alphabetically — instead of returning a 404 for a non-existent
+        // place. The _ wildcard matches any single character, so /place/TX/D_
+        // would match "unknown" two-letter place names.
+        //
+        // This is an information disclosure issue: an attacker can use binary
+        // search with wildcards to systematically enumerate every place name
+        // in the database, character by character. While the place list isn't
+        // secret per se, the ability to use pattern matching on a public
+        // endpoint is unintended behavior that could be used for reconnaissance
+        // or denial of service (each wildcard query triggers a full table scan).
+        //
+        // The backslash is the default LIKE escape character in MySQL/MariaDB,
+        // so escaping % as \% and _ as \_ ensures these characters are treated
+        // as literal values rather than pattern wildcards.
+        $state = str_replace(['%', '_'], ['\\%', '\\_'], $state);
+        $place = str_replace(['%', '_'], ['\\%', '\\_'], $place);
+
         return $this->dataLayer->databaseFetch(
             "SELECT
                 ST_X(point) AS lon,


### PR DESCRIPTION
## Summary

The place name routing in `LocationAndGridRouteController.php` and `weather_data.module` uses `LIKE` queries to match state and place names. While the queries use parameterized placeholders (`:state`, `:place`), the SQL `LIKE` operator interprets `%` and `_` as wildcard characters even within parameterized values. This means:

- `/place/TX/D%` would match "Dallas" instead of returning a 404
- `/place/__/Dallas` would match any 2-letter state code

This enables database reconnaissance — an attacker can systematically discover place names, formatting details, and database schema through wildcard pattern matching.

**Fix:** Added `str_replace()` calls to escape `%` and `_` with backslash prefixes (`\%`, `\_`) before the values reach the LIKE query. The escaping is applied after the existing underscore-to-space conversion (line 109 of `LocationAndGridRouteController.php`), so legitimate underscores in URL-encoded place names are converted to spaces first, and only malicious wildcard characters are escaped.

Applied in both code paths that execute the same LIKE query:
- `LocationAndGridRouteController::getKnownPlace()`
- `weather_data_template_preprocess_default_variables_alter()`

## Test plan

- [x] `/place/TX/Dallas` resolves correctly
- [x] `/place/TX/New_York` (underscore-to-space conversion) still works
- [x] `/place/TX/D%` returns 404 instead of matching "Dallas"
- [x] `/place/__/Dallas` returns 404 instead of matching any state