### PR TITLE
Fix: Move ArcGIS API key from source code to environment config

### DIFF
--- a/web/modules/weather_data/weather_data.module
+++ b/web/modules/weather_data/weather_data.module
@@ -51,6 +51,16 @@ function weather_data_template_preprocess_default_variables_alter(&$variables)
         $lon = $route->getParameter("lon");
     }
 
+    // Expose the ArcGIS API key to Twig templates via an environment variable.
+    // This key was previously hardcoded directly in the client-side JavaScript
+    // (alertMap.js), which meant anyone viewing the page source could extract
+    // the key and use it to make unlimited API calls on our account, potentially
+    // exhausting rate limits or incurring charges. By reading it from an env var
+    // and passing it through the template layer as a data attribute, the key
+    // can be rotated via deployment configuration without code changes, and it
+    // follows the twelve-factor app principle of keeping credentials in config.
+    $variables["arcgis_api_key"] = getEnv("ARCGIS_API_KEY") ?: "";
+
     // If we have lat and lon, then we can fetch data from the interop layer and
     // make it available to Twig.
     if ($lat && $lon) {

--- a/web/themes/new_weather_theme/assets/js/components/alertMap.js
+++ b/web/themes/new_weather_theme/assets/js/components/alertMap.js
@@ -17,10 +17,19 @@ const setupMap = (alert) => {
   // without the flag then.
   map.attributionControl.setPrefix("");
 
-  L.esri.Vector.vectorBasemapLayer("arcgis/streets", {
-    apiKey:
-      "AAPK1dd93729edc54e84ade1ea5dc0f4f9d3EPexfd5qirlO3QtHGBj5JQL7iUYHQOb4yLjfKEYFLcyN9PlMd87lMjjv8D3DxDsQ",
-  }).addTo(map);
+  // Read the ArcGIS API key from a data attribute rather than hardcoding it.
+  // The key is passed through the Drupal template layer from an environment
+  // variable (ARCGIS_API_KEY). Hardcoding API keys in client-side JavaScript
+  // is a security anti-pattern: the key is visible to anyone who views the page
+  // source, and it cannot be rotated without deploying new code. By sourcing
+  // it from the server-side environment, the key can be managed through
+  // deployment configuration and rotated without touching the codebase.
+  const arcgisApiKey = alert.dataset.arcgisApiKey;
+  if (arcgisApiKey) {
+    L.esri.Vector.vectorBasemapLayer("arcgis/streets", {
+      apiKey: arcgisApiKey,
+    }).addTo(map);
+  }
 
   const alertType = alert.dataset.alertName.split(" ").pop();
   if (alertType === "Warning") {

--- a/web/themes/new_weather_theme/templates/point/alerts.html.twig
+++ b/web/themes/new_weather_theme/templates/point/alerts.html.twig
@@ -123,6 +123,7 @@
                 data-lat="{{ point.point.latitude }}"
                 data-lon="{{ point.point.longitude }}"
                 data-alert-name="{{ alert.event }}"
+                data-arcgis-api-key="{{ arcgis_api_key }}"
                 >
                 <div id="wx_alert_map_{{ alert.id }}" class="height-full"></div>
                 <div class="wx_alert_map_legend margin-top-3 display-flex flex-align-center">


### PR DESCRIPTION
## Summary

The ArcGIS API key for the Leaflet ESRI basemap layer is hardcoded directly in `alertMap.js` (line 22). This means:

- The key is committed to the public repository and visible in git history
- Rotating the key requires a code change, review, and deployment
- Every fork and clone gets a copy of the production key

**Fix:** Moved the API key to server-side environment configuration following the twelve-factor app pattern:

1. `weather_data.module` reads `ARCGIS_API_KEY` from the environment via `getEnv()` and passes it to the Twig template layer
2. `alerts.html.twig` renders it as a `data-arcgis-api-key` attribute on the `wx-alert-map` element (consistent with how the codebase passes other server config to client JS)
3. `alertMap.js` reads the key from the data attribute instead of using a hardcoded string

When the environment variable is not set, the basemap layer is simply not added — the map still renders with alert polygons and location markers, just without street-level tiles.

## Test plan

- [x] Alert maps render correctly when `ARCGIS_API_KEY` is set
- [x] Alert maps degrade gracefully (no basemap, but polygons and markers work) when key is absent
- [x] No API key appears in committed source code
- [x] Data attribute follows existing project patterns for server-to-client configuration