### PR TITLE
Fix: Validate query parameters in AFD redirect URLs

### DIFF
--- a/web/modules/weather_routes/src/Controller/AFDController.php
+++ b/web/modules/weather_routes/src/Controller/AFDController.php
@@ -46,6 +46,34 @@ final class AFDController extends ControllerBase
         );
     }
 
+    /**
+     * Validate that a WFO code or product ID contains only safe characters.
+     *
+     * Query parameters used in RedirectResponse URLs must be validated to
+     * prevent open redirect and header injection attacks. Without validation,
+     * an attacker could craft a URL like:
+     *
+     *   /afd?wfo=../../evil.com&id=foo
+     *
+     * ...which would redirect to /afd/../../evil.com/foo. While Symfony's
+     * RedirectResponse mitigates most header injection vectors, unvalidated
+     * path segments can still cause unexpected routing behavior, be used in
+     * phishing (the URL starts with the trusted domain), or interact with
+     * reverse proxies and CDNs in unexpected ways.
+     *
+     * WFO codes are always 3-letter uppercase identifiers (e.g., "OKX").
+     * Product IDs are UUID-like alphanumeric strings with hyphens.
+     */
+    private function isValidWfoCode($code): bool
+    {
+        return $code !== null && preg_match('/^[A-Za-z]{3}$/', $code) === 1;
+    }
+
+    private function isValidProductId($id): bool
+    {
+        return $id !== null && preg_match('/^[A-Za-z0-9\-]{8,64}$/', $id) === 1;
+    }
+
     public function afdDefault()
     {
         try {
@@ -59,6 +87,19 @@ final class AFDController extends ControllerBase
             // id, this means we really just want to update the WFO
             if ($current == $id) {
                 $id = null;
+            }
+
+            // Validate query parameters before using them in redirect URLs.
+            // Without this check, arbitrary strings from query parameters would
+            // be concatenated directly into RedirectResponse paths. An attacker
+            // could craft URLs that redirect to unexpected paths or inject path
+            // traversal sequences. These parameters come from the user's browser
+            // and must never be trusted without format validation.
+            if ($id && !$this->isValidProductId($id)) {
+                throw new NotFoundHttpException();
+            }
+            if ($wfo_code && !$this->isValidWfoCode($wfo_code)) {
+                throw new NotFoundHttpException();
             }
 
             if ($id && $wfo_code) {
@@ -124,9 +165,15 @@ final class AFDController extends ControllerBase
     {
         // If a querystring parameter of an AFD id was passed in,
         // we are requesting that specific ID.
-        // Simple redirect in that case
+        // Simple redirect in that case.
+        // Validate the id parameter before using it in a redirect — same
+        // rationale as in afdDefault(): unvalidated query params in redirect
+        // URLs can enable path traversal and phishing attacks.
         $id = $this->request->getCurrentRequest()->query->get("id");
         if ($id) {
+            if (!$this->isValidProductId($id)) {
+                throw new NotFoundHttpException();
+            }
             return new RedirectResponse("/afd/" . $wfo_code . "/" . $id);
         }
 


### PR DESCRIPTION
## Summary

The AFD controller (`AFDController.php`) reads `wfo` and `id` query parameters from the request and uses them directly in `RedirectResponse` URL construction without validation. For example:

```php
return new RedirectResponse("/afd/" . $wfo_code . "/" . $id);
```

Without validation, an attacker could craft URLs like `/afd?wfo=../../evil.com&id=foo` that redirect to unexpected paths. While Symfony's `RedirectResponse` mitigates most header injection vectors, unvalidated path segments can still be used in phishing (the URL starts with the trusted weather.gov domain) or interact with reverse proxies and CDNs in unexpected ways.

**Fix:** Added two private validation methods:

- `isValidWfoCode($code)` — validates against `^[A-Za-z]{3}$` (consistent with Drupal route constraints in `weather_routes.routing.yml`)
- `isValidProductId($id)` — validates against `^[A-Za-z0-9\-]{8,64}$` (matches NWS UUID format)

Both use explicit `=== 1` comparison with `preg_match()` for strict typing. Validation is applied in `afdDefault()` and `byOffice()` before any redirect URL is constructed. Invalid values trigger a 404 response.

## Test plan

- [x] Valid WFO codes (e.g., "OKX", "LAX") pass validation and redirect correctly
- [x] Valid product IDs (UUID format) pass validation
- [x] Path traversal attempts (`../../evil.com`) are rejected with 404
- [x] Special characters in query params are rejected
- [x] Route-level regex constraints (`wfo_code: '^[A-Za-z]{3}$'`) remain the primary defense for path parameters