### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/api-proxy/proxy.js
+++ b/api-proxy/proxy.js
@@ -23,8 +23,7 @@ export default (req, res) => {
     .join("&");
 
   const proxyRequestSettings = {
-    // If there's a wx-host header, use that as our hostname
-    host: req.headers["wx-host"] ?? "api.weather.gov",
+    host: "api.weather.gov",
     port: 443,
     path: `${req.path}?${qs}`,
     method: "GET",


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `api-proxy/proxy.js:L27`

The proxy uses `req.headers["wx-host"]` directly as the outbound HTTPS hostname. An attacker can supply a crafted `wx-host` value to force server-side requests to arbitrary internal or external hosts, enabling SSRF against internal services/metadata endpoints.

## Solution

Do not trust client-provided host headers for upstream selection. Remove `wx-host` override entirely, or enforce a strict allowlist of permitted hostnames (e.g., only `api.weather.gov` and known dev hosts). Also log and reject invalid host overrides with a 4xx response.

## Changes

- `api-proxy/proxy.js` (modified)