### PR TITLE
Fixup links from the wa-wa map dev tool

### DIFF
--- a/wa-wa/main.js
+++ b/wa-wa/main.js
@@ -47,8 +47,8 @@ map.on("click", (e) => {
 
   leaflet
     .popup(latlng, {
-      content: `<a href="https://beta.weather.gov/point/${lat}/${lng}">Open on beta</a><br><a href="https://weathergov-staging.app.cloud.gov/point/${lat}/${lng}">Open on staging</a>
-      <br><a href="http://localhost:8080/point/${lat}/${lng}">Open in local dev</a>`,
+      content: `<a href="https://beta.weather.gov/forecast/point/${lat}/${lng}">Open on beta</a><br><a href="https://weathergov-staging.app.cloud.gov/forecast/point/${lat}/${lng}">Open on staging</a>
+      <br><a href="http://localhost:8080/forecast/point/${lat}/${lng}">Open in local dev</a>`,
     })
     .openOn(map);
 });


### PR DESCRIPTION
The URLs on beta changed from `/points/[lat]/[lon]` to `/forecast/points/[lat]/[lon]`. This PR updates the dev tool version of the wawa map accordingly.