### PR TITLE
Security: Open Redirect via Unvalidated wx-host Header in API Proxy

### DIFF
--- a/api-proxy/proxy.js
+++ b/api-proxy/proxy.js
@@ -21,9 +21,15 @@ export default (req, res) => {
   const qp = req.url.split('?');
   const qs = qp.length === 2 ? qp[1] : "";
 
+  const allowedHosts = ["api.weather.gov", "api.weather.gov."];
+  const wxHost = req.headers["wx-host"];
+  let host = "api.weather.gov";
+  if (wxHost && allowedHosts.includes(wxHost)) {
+    host = wxHost;
+  }
+
   const proxyRequestSettings = {
-    // If there's a wx-host header, use that as our hostname
-    host: req.headers["wx-host"] ?? "api.weather.gov",
+    host,
     port: 443,
     path: `${req.path}?${qs}`,
     method: "GET",


### PR DESCRIPTION
## Summary

Security: Open Redirect via Unvalidated wx-host Header in API Proxy

## Problem

**Severity**: `High` | **File**: `api-proxy/proxy.js:L24`

The `api-proxy/proxy.js` file uses the `wx-host` header from incoming requests to determine the target hostname for proxying requests. An attacker can set this header to any domain, causing the proxy to forward requests to arbitrary external servers. This could be used for server-side request forgery (SSRF), data exfiltration, or as an open redirect mechanism. The header is used directly without validation against an allowlist.

## Solution

Validate the `wx-host` header against a strict allowlist of permitted hostnames before using it in proxy requests. If the header value is not in the allowlist, fall back to the default `api.weather.gov` or reject the request.

## Changes

- `api-proxy/proxy.js` (modified)